### PR TITLE
Capture tool overhaul: picker, panels, auto face, flexible saves

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -81,27 +81,70 @@ Outputs:
 
 ---
 
+
+
 ### 3) Capture “face shots” for annotation
 
 ```bash
 python -m src.capture_isc_face \
   --calib calib_color.yaml \
   --width 640 --height 480 --fps 30
+# Optional UI sizing
+#   --panel_w 560         # centre info panel width
+#   --recent_w 480        # right "Last saved" panel width
+# Optional saving layout / manifest
+#   --layout {flat,by_object,by_object_side,split_type}   # default: by_object_side
+#   --manifest boards/shots/manifest.csv                  # append one row per save
 ```
 
-Workflow:
+**Workflow (no terminal prompts while preview runs):**
 
-* Enter object name (`connection_plate_white_sideA`, etc.)
-* Select face index
-* Live preview; **ENTER** to save
+* Press **`o`** to open the **in-window object picker**; navigate with **↑/↓/W/S/K/J**, **Enter** to select, **Esc** to cancel.
+* You may also start with `--object_name`:
 
-Outputs:
+  * Base only: `--object_name connection_plate_white` → **side auto-deduced** from live detections via `boards/tag_registry.yaml`.
+  * Full face: `--object_name connection_plate_white_sideA` → fixed side.
+* **ENTER** saves a shot. If expected tags are missing, **double-press ENTER within 3 s** to force.
+
+**Keys**
+
+* **ENTER** – save (double-press to force if validation fails)
+* **o** – object picker (in-window)
+* **a** – toggle **auto side/face** (works when an object base is chosen)
+* **f** – cycle faces **when auto is OFF**
+* **g** – toggle gallery/“Last saved” panels
+* **h** – help overlay
+* **q / Esc** – quit
+
+**Panels & window**
+
+* Left: 640×480 live feed with detections (unchanged resolution).
+* Centre: **Info** (object/side, seen vs expected IDs, validation, recent thumbnails, instructions).
+* Right: **Last saved** annotated image (blank when off).
+* The top-level window is **resizable**; use `--panel_w` / `--recent_w` to make side panels roomier.
+
+**Outputs (default layout: `by_object_side`)**
 
 ```
-boards/shots/<object_face>_<face_key>_<YYYYMMDD_HHMMSS>_raw.png
-boards/shots/<object_face>_<face_key>_<YYYYMMDD_HHMMSS>_ann.png
-boards/shots/<object_face>_<face_key>_<YYYYMMDD_HHMMSS>_meta.json
+boards/shots/
+  <object_base>/
+    side<SideLetter>/
+      <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_raw.png
+      <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_ann.png
+      <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_meta.json
 ```
+
+* `*_meta.json` includes camera intrinsics, detected/expected IDs, face YAML, and save paths.
+
+**Alternative layouts (optional)**
+
+* `--layout flat` → everything in `boards/shots/`
+* `--layout by_object` → `boards/shots/<object_base>/...`
+* `--layout split_type` → separate folders; use `--raw_dir`, `--ann_dir`, `--meta_dir`
+
+**Manifest (optional)**
+
+* `--manifest boards/shots/manifest.csv` appends one row per save (paths, object/side, tags, OK flag, intrinsics).
 
 ---
 

--- a/src/capture_isc_face.py
+++ b/src/capture_isc_face.py
@@ -1,26 +1,76 @@
 """
-capture_isc_face.py
+capture_isc_face.py — Face-shot capture for later T_board_object annotation
+Author: Samuel Adebayo
 
-Take one or more wide shots per face for later T_object_from_board annotation.
-- Prompts for object name (or pass --object_name)
-- Lists faces (YAMLs) for that object from boards/tag_registry.yaml
-- Live preview; ENTER to save raw+annotated still + JSON meta
-- Keeps running until you press 'q'
+Summary
+-------
+Capture wide shots per object face with AprilTag overlays and metadata for
+subsequent T_board_object (board→object) computation.
 
-Keys in the preview window:
-  ENTER  -> save shot
-  f      -> switch face
-  o      -> switch object
+What’s new (rev)
+----------------
+- Enter either a full face (e.g. connection_plate_white_sideA) or just a base
+  (e.g. connection_plate_white). If a base is given, the face/side is
+  auto-deduced from live detections using boards/tag_registry.yaml.
+- No terminal prompts while preview is running. Press 'o' to open the in-window
+  object picker; use ↑/↓/W/S/K/J to navigate; Enter selects; Esc cancels.
+- Two right-hand panels:
+    • Info panel: live status (seen vs expected IDs, validation), recent thumbnails,
+      and concise instructions.
+    • Last-saved panel: shows the most recently saved annotated frame.
+  Toggle panels with 'g'. Panels are UI-only and are NOT written into the
+  annotated image.
+- Safety save: if expected tags are not seen, press Enter twice within 3 s to force save.
+- Resizable top-level window; the camera frame remains at the requested resolution.
+
+Saving layout
+-------------
+Default: by object and side
+    boards/shots/<object_base>/side<SideLetter>/
+      <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_{raw,ann}.png
+      <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_meta.json
+
+Filenames are de-duplicated (no repeated “…_sideA_sideA_…”). Optional CSV
+manifest appends one row per save with paths, tags, OK flag, and intrinsics.
+
+Keys (main preview)
+-------------------
+  ENTER  -> save (double-press within 3 s to force if validation fails)
+  o      -> object picker (in-window)
+  a      -> toggle auto face/side (when a base object is chosen)
+  f      -> cycle faces (only when auto is OFF)
+  g      -> toggle gallery / last-saved panels
+  h      -> help overlay
   q or ESC -> quit
+
+CLI highlights
+--------------
+  --calib PATH            Camera intrinsics YAML (fx, fy, cx, cy, dist)
+  --object_name NAME      Base or full face name
+  --width/--height/--fps  Stream settings (e.g., 640×480 @ 30 fps)
+  --panel_w INT           Centre info-panel width (default ~560)
+  --recent_w INT          Right last-saved panel width (default ~480)
+  --layout {flat,by_object,by_object_side,split_type}
+                         Saving layout (default: by_object_side)
+  --manifest PATH         Append a CSV manifest per save
 """
 
-import argparse, os, sys, json, time, datetime
+
+from __future__ import annotations
+import argparse, os, sys, json, time, datetime, re
 import yaml
 import numpy as np
 import cv2
 import pyrealsense2 as rs
 from pathlib import Path
+from typing import List, Dict, Tuple, Optional, Set
+
 from utils.intel_realsense_utils import start_rs, get_frames_with_retry, load_calib, _face_label
+from utils.capture_utils import (
+    draw_detections, make_info_panel, make_recent_panel, text_lines,
+    load_registry, unique_bases, faces_for_base, faces_for_object,
+    parse_base_and_side, ensure_dir, timestamp, _append_manifest
+)
 
 try:
     from pupil_apriltags import Detector
@@ -30,90 +80,63 @@ except Exception as e:
 repo_root = Path(__file__).resolve().parents[1]
 
 
-def _resolve_yaml_path(p: str) -> str | None:
-    if not p:
-        return None
-    p = p.replace("\\", "/")  # tolerate Windows entries
-    cand = Path(p)
-    if not cand.is_absolute():
-        cand = repo_root / cand
-    if not cand.exists():
-        alt = repo_root / "boards" / cand.name  # fallback by basename
-        if alt.exists():
-            cand = alt
-    return str(cand)
+KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT = 2490368, 2621440, 2424832, 2555904
+
+# ---------- path helpers ----------
 
 
-# --------- helpers ---------
-def load_registry(path):
-    if not os.path.exists(path):
-        print(f"[!] tag registry not found: {path}")
-        return {"version": 1, "tags": {}}
-    reg = yaml.safe_load(open(path, "r")) or {}
-    reg.setdefault("tags", {})
-    return reg
+def compose(vis: np.ndarray, panel: np.ndarray) -> np.ndarray:
+    if vis.shape[0] != panel.shape[0]:
+        # match heights
+        panel = cv2.resize(panel, (panel.shape[1], vis.shape[0]))
+    return cv2.hconcat([vis, panel])
+
+# ---------- selection UI ----------
 
 
-def faces_for_object(object_name, registry):
-    """Return list of face entries for the object.
-       Each entry: dict(yaml, object, tag_ids=set(...))"""
-    by_yaml = {}
-    for tid, rec in registry["tags"].items():
-        try:
-            obj = rec.get("object")
-            yml_raw = rec.get("yaml")
-            if obj is None or yml_raw is None:
-                continue
-            if obj != object_name:
-                continue
-            yml = _resolve_yaml_path(yml_raw)
-            if not yml:
-                print(f"[!] Could not resolve yaml path: {yml_raw}")
-                continue
-            by_yaml.setdefault(yml, {"object": obj, "tag_ids": set()})
-            by_yaml[yml]["tag_ids"].add(int(tid))
-        except Exception:
-            continue
+def object_picker_panel(h: int, w: int, bases: List[str], sel: int,
+                        hint: str="Select object (Enter):") -> np.ndarray:
+    pan = np.full((h, w, 3), 240, np.uint8)
+    cv2.putText(pan, hint, (12, 28),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.8, (20, 20, 20), 2, cv2.LINE_AA)
 
-    faces = []
-    for yml, info in by_yaml.items():
-        try:
-            with open(yml, "r") as f:
-                yy = yaml.safe_load(f)
-            obj_field = yy.get("object", info["object"])
-            tags = yy.get("tags", [])
-            if tags and not info["tag_ids"]:
-                info["tag_ids"] = set(int(t["id"]) for t in tags if "id" in t)
-            faces.append({
-                "yaml": yml,
-                "object": obj_field,
-                "tag_ids": sorted(list(info["tag_ids"]))
-            })
-        except Exception as e:
-            print(f"[!] Could not read {yml}: {e}")
-    return faces
+    max_show = min(12, len(bases))
+    start = max(0, min(sel - max_show // 2, len(bases) - max_show))
+    end = min(len(bases), start + max_show)
+
+    y = 60
+    for i in range(start, end):
+        s = bases[i]
+        col = (0, 0, 0) if i != sel else (0, 50, 200)
+        thick = 1 if i != sel else 2
+        prefix = "  " if i != sel else "> "
+        cv2.putText(pan, prefix + s, (18, y),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.65, col, thick, cv2.LINE_AA)
+        y += 26
+
+    tips = "Move: ↑/↓ or W/S (K/J)   Select: Enter   Cancel: Esc   Jump: 1–9"
+    cv2.putText(pan, tips, (12, h - 16),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.55, (60, 60, 60), 1, cv2.LINE_AA)
+    return pan
 
 
-def draw_detections(img, dets, colour=(0, 255, 0)):
-    vis = img.copy()
-    for d in dets:
-        pts = d.corners.astype(int)
-        cv2.polylines(vis, [pts], True, colour, 2)
-        cv2.putText(vis, str(int(d.tag_id)), tuple(pts[0]),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 255), 2)
-    return vis
+# ---------- face selection logic ----------
+def best_face_by_overlap(faces: List[Dict], det_ids: Set[int], prev_idx: int|None=None) -> Tuple[Optional[int], int]:
+    """Return (best_index, best_overlap_count). Tie broken by prev_idx and tag count."""
+    if not faces:
+        return None, 0
+    best_i, best_k, best_total = None, -1, -1
+    for i, f in enumerate(faces):
+        exp = set(f["tag_ids"])
+        k = len(exp.intersection(det_ids))
+        tot = len(exp)
+        key = (k, tot, 1 if (prev_idx is not None and i == prev_idx) else 0)
+        # maximise k, then tot, then prefer staying on same
+        if key > (best_k, best_total, -1):
+            best_i, best_k, best_total = i, k, tot
+    return best_i, best_k
 
-
-def ensure_dir(p):
-    os.makedirs(p, exist_ok=True)
-
-
-def timestamp():
-    return datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-
-
-# --------- main ---------
-
+# ---------- main ----------
 def main():
     ap = argparse.ArgumentParser("Capture wide shots per face for later annotation")
     ap.add_argument("--calib", default="calib_color.yaml")
@@ -121,12 +144,22 @@ def main():
                     help="Path to boards/tag_registry.yaml (defaults to repo_root/boards/tag_registry.yaml)")
     ap.add_argument("--out_dir", default=None,
                     help="Where to save shots; defaults to repo_root/boards/shots")
-    ap.add_argument("--object_name", default=None, help="If omitted, will prompt interactively")
+    ap.add_argument("--object_name", default=None,
+                    help="Either full (e.g. connection_plate_white_sideA) or base (e.g. connection_plate_white).")
     ap.add_argument("--family", default="tag36h11")
     ap.add_argument("--width", type=int, default=640)
     ap.add_argument("--height", type=int, default=480)
     ap.add_argument("--fps", type=int, default=30)
     ap.add_argument("--min_expected", type=int, default=1, help="min expected tags to see from the chosen face")
+    ap.add_argument("--gallery", action="store_true", default=True, help="show thumbnails in panel")
+    ap.add_argument("--panel_w", type=int, default=560, help="info panel width (right side)")
+    ap.add_argument("--recent_w", type=int, default=480, help="right panel width for last-saved preview")
+    ap.add_argument("--layout", choices=["flat", "by_object", "by_object_side", "split_type"],
+                                         default = "by_object_side", help = "folder layout for saved captures")
+    ap.add_argument("--raw_dir", default=None, help="when layout=split_type: raw images dir")
+    ap.add_argument("--ann_dir", default=None, help="when layout=split_type: annotated images dir")
+    ap.add_argument("--meta_dir", default=None, help="when layout=split_type: JSON metadata dir")
+    ap.add_argument("--manifest", default="boards/shots/manifest.csv", help="optional CSV file to append per-capture rows")
 
     args = ap.parse_args()
 
@@ -149,9 +182,27 @@ def main():
     if args.out_dir is None:
         args.out_dir = str(repo_root / "boards" / "shots")
 
+    # -- layout initialisation ---
+    print(f"[i] Layout: {args.layout}")
+
+    if args.layout == "split_type":
+        # Fill defaults safely
+        args.raw_dir = args.raw_dir or str(Path(args.out_dir) / "images")
+        args.ann_dir = args.ann_dir or str(Path(args.out_dir) / "images")
+        args.meta_dir = args.meta_dir or str(Path(args.out_dir) / "meta")
+
+        for d in (args.raw_dir, args.ann_dir, args.meta_dir):
+            if d:
+                os.makedirs(d, exist_ok=True)
+            print(f"[i] Split dirs -> raw={args.raw_dir}, ann={args.ann_dir}, meta={args.meta_dir}")
+    else:
+        os.makedirs(args.out_dir, exist_ok=True)
+
     print(f"[i] Using calib: {args.calib}")
     print(f"[i] Using registry: {args.registry}")
     print(f"[i] Shots will be saved to: {args.out_dir}")
+
+
 
     (fx, fy, cx, cy), K = load_calib(args.calib)
     reg = load_registry(args.registry)
@@ -160,182 +211,256 @@ def main():
     det = Detector(families=args.family, nthreads=4, quad_decimate=1.0, refine_edges=True)
 
     # RealSense colour stream
-
     pipe, cfg = rs.pipeline(), rs.config()
     cfg.enable_stream(rs.stream.color, args.width, args.height, rs.format.bgr8, args.fps)
-    start_rs(pipe, cfg, warmup=15)  # short warmup after start
+    start_rs(pipe, cfg, warmup=15)
+
+    # ---------- UI state ----------
+    state = {
+        "object_base": None,   # str
+        "faces": [],           # list of face dicts (maybe multi-sides)
+        "face_idx": 0,         # current index in faces
+        "auto_side": False,    # auto resolve face from detections
+        "detected_ids": set(), # live set of tag IDs
+        "validation_ok": True,
+        "thumbs": [],          # recent thumbnails
+        "save_warn": False,
+        "save_warn_t0": 0.0,
+    }
+
+    # Prepare object list
+    bases = unique_bases(reg)
+
+    # Initial object from CLI
+    cli_obj = args.object_name.strip() if args.object_name else None
+    if cli_obj:
+        base, side = parse_base_and_side(cli_obj)
+        state["object_base"] = base
+        state["faces"] = faces_for_base(base, reg, repo_root) if side is None else faces_for_object(cli_obj, reg, repo_root)
+        state["auto_side"] = (side is None)
+        state["face_idx"] = 0
+
+    # Modes: 'preview' or 'pick_object'
+    mode = 'preview' if state["object_base"] else 'pick_object'
+    pick_sel = 0
+    gallery_on = bool(args.gallery)
+    show_help = False
+
+    WINDOW_NAME = "Capture Objects' Face"
+    cv2.namedWindow(WINDOW_NAME, cv2.WINDOW_NORMAL)  # user can resize if they want
+    cv2.resizeWindow(WINDOW_NAME, args.width + args.panel_w + args.recent_w, args.height)
+
 
     try:
-        object_name = args.object_name
         while True:
-            # -------- choose object --------
-            if not object_name:
-                object_name = input("[?] Enter object name (e.g., connection_plate_white): ").strip()
-            faces = faces_for_object(object_name, reg)
-            if not faces:
-                # List available objects for convenience
-                objs = {}
-                for tid, rec in reg["tags"].items():
-                    obj = rec.get("object")
-                    yml = rec.get("yaml")
-                    if obj and yml:
-                        objs.setdefault(obj, set()).add(yml)
-                print(f"[!] No faces found for object '{object_name}' in {args.registry}.")
-                if objs:
-                    print("    Known objects:")
-                    for obj, ymls in objs.items():
-                        print(f"      - {obj} ({len(ymls)} face file(s))")
-                ch = input("[?] Try a different object name? [y/N]: ").strip().lower()
-                if ch == "y":
-                    object_name = None
-                    continue
-                else:
-                    print("[i] You can still capture generic shots; they just won’t validate against expected tags.")
-                    faces = []  # proceed with free capture
+            frames = get_frames_with_retry(pipe, cfg, max_retries=2, timeout_ms=2000, do_hw_reset=True)
+            c = np.asanyarray(frames.get_color_frame().get_data())
+            g = cv2.cvtColor(c, cv2.COLOR_BGR2GRAY)
+            dd = det.detect(g, estimate_tag_pose=False)
 
-            # Index faces and let user pick
-            face_idx = 0
-            while True:
-                # build a face menu each loop (files might change)
-                face_menu = []
-                for i, f in enumerate(faces):
-                    face_key = os.path.splitext(os.path.basename(f["yaml"]))[0]
-                    face_menu.append(f"[{i}] {face_key}  tags={f['tag_ids']}  ({f['yaml']})")
-                if face_menu:
-                    print("[i] Faces for", object_name)
-                    for line in face_menu:
-                        print("    ", line)
-                    sel = input(
-                        f"[?] Select face index [0..{len(faces) - 1}] (or 'o' change object, 'q' quit): ").strip()
-                    if sel.lower() == 'q':
-                        return
-                    if sel.lower() == 'o':
-                        object_name = None
-                        break
-                    try:
-                        face_idx = int(sel)
-                        if not (0 <= face_idx < len(faces)):
-                            print("[!] Out of range.")
-                            continue
-                    except Exception:
-                        print("[!] Enter a valid index, 'o', or 'q'.")
-                        continue
-                    face = faces[face_idx]
-                else:
-                    print("[i] Free capture mode (no face validation). Press 'o' to change object or 'q' to quit.")
-                    face = None
+            det_ids = {int(d.tag_id) for d in dd}
+            state["detected_ids"] = det_ids
 
-                # -------- live preview & capture for this face --------
-                expected = set(face["tag_ids"]) if face else set()
-                face_key = os.path.splitext(os.path.basename(face["yaml"]))[0] if face else "unregistered"
-                print("[i] Preview running. ENTER=save, f=switch face, o=switch object, q=quit.")
+            vis = draw_detections(c, dd)
+            face = None
 
-                while True:
-                    frames = get_frames_with_retry(pipe, cfg, max_retries=2, timeout_ms=2000, do_hw_reset=True)
-                    c = np.asanyarray(frames.get_color_frame().get_data())
-                    g = cv2.cvtColor(c, cv2.COLOR_BGR2GRAY)
-                    dd = det.detect(g, estimate_tag_pose=False)
+            # Resolve face
+            if state["faces"]:
+                if state["auto_side"]:
+                    best_i, overlap_k = best_face_by_overlap(state["faces"], det_ids, state.get("face_idx"))
+                    if best_i is not None:
+                        state["face_idx"] = best_i
+                face = state["faces"][state["face_idx"]]
+            state["face"] = face
 
-                    vis = draw_detections(c, dd)
+            # Validate expected tags
+            ok = True
+            if face:
+                expected = set(face["tag_ids"])
+                if expected:
+                    ok = len(expected.intersection(det_ids)) >= max(1, args.min_expected)
+            state["validation_ok"] = ok
 
-                    # Line 1: face label
-                    label = _face_label(face)
-                    cv2.putText(vis, f"Face: {label}", (12, 28),
-                                cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 255), 2)
+            # Overlay status lines on the left image
+            label = _face_label(face) if face else "(unresolved)"
+            cv2.putText(vis, f"Face: {label}", (12, 28), cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 255), 2)
+            if face:
+                expected = set(face["tag_ids"])
+                inter = sorted(list(expected.intersection(det_ids)))
+                msg = f"seen={sorted(list(det_ids))}  exp&seen={inter}"
+                col = (0, 200, 0) if ok else (0, 0, 255)
+            else:
+                msg = f"seen={sorted(list(det_ids))}"
+                col = (0, 200, 200)
+            cv2.putText(vis, msg, (12, 56), cv2.FONT_HERSHEY_SIMPLEX, 0.7, col, 2)
 
-                    det_ids = {int(d.tag_id) for d in dd}
-                    if expected:
-                        ok = len(expected.intersection(det_ids)) >= max(1, args.min_expected)
-                        msg = f"seen={sorted(det_ids)}  exp∩seen={sorted(expected.intersection(det_ids))}"
-                        col = (0, 200, 0) if ok else (0, 0, 255)
-                    else:
-                        ok = True
-                        msg = f"seen={sorted(det_ids)}"
-                        col = (0, 200, 200)
 
-                    # Line 2: detection status
-                    cv2.putText(vis, msg, (12, 56), cv2.FONT_HERSHEY_SIMPLEX, 0.7, col, 2)
+            if mode == 'pick_object':
+                panel_info = object_picker_panel(args.height, args.panel_w, bases, pick_sel)
+            else:
+                panel_info = make_info_panel(args.height, args.panel_w, state, gallery_on=gallery_on)
+                if show_help:
+                    overlay = np.full((args.height, args.panel_w, 3), 230, np.uint8)
+                    text_lines(overlay, [
+                        "Help:",
+                        "ENTER: Save (twice within 3s to force if not OK)",
+                        "a: Toggle auto face/side (when base given)",
+                        "f: Cycle faces (auto OFF)",
+                        "o: Pick object (on-screen picker)",
+                        "g: Toggle gallery thumbnails",
+                        "h: Toggle this help",
+                        "q/ESC: Quit",
+                    ], y0=40)
+                    alpha = 0.9
+                    panel_info = cv2.addWeighted(panel_info, 1 - alpha, overlay, alpha, 0)
+            panel_recent = make_recent_panel(
+                args.height, args.recent_w, state.get("last_saved_ann"), gallery_on
+            )
+            combo = cv2.hconcat([vis, panel_info, panel_recent])
+            cv2.imshow(WINDOW_NAME, combo)
 
-                    # Bottom help
-                    cv2.putText(vis, "ENTER=save  f=face  o=object  q=quit",
-                                (20, args.height - 20), cv2.FONT_HERSHEY_SIMPLEX, 0.6, (255, 255, 255), 2)
+            k = cv2.waitKeyEx(1)
+            if k == -1:
+                k = 0
 
-                    cv2.imshow("Capture face shot", vis)
-                    k = cv2.waitKey(1) & 0xFF
+            ENTER_KEYS = {13, 10}  # CR/LF
+            CANCEL_KEYS = {27}  # Esc (we keep 'q' for global quit in preview)
+            UP_KEYS = {KEY_UP, ord('w'), ord('k')}
+            DOWN_KEYS = {KEY_DOWN, ord('s'), ord('j')}
 
-                    if k in (27, ord('q')):  # ESC or q
-                        return
-
-                    if k == ord('f'):
-                        if faces:
-                            face_idx = (face_idx + 1) % len(faces)
-                            face = faces[face_idx]
-                            expected = set(face["tag_ids"])
-                            face_key = os.path.splitext(os.path.basename(face["yaml"]))[0]
-                            print(f"[i] Switched to face: {_face_label(face)}  expected={sorted(expected)}")
-                        continue
-
-                    # o = change object (leave preview to re-prompt)
-                    if k == ord('o'):
-                        object_name = None
-                        break
-
-                    if k == 13:  # ENTER -> save
-                        if expected and not ok:
-                            print("[!] Expected face tags not visible. Save anyway? [y/N] ", end="", flush=True)
-                            ch = input().strip().lower()
-                            if ch != "y":
-                                continue
-
-                        ts = timestamp()
-                        base = f"{object_name}_{face_key}_{ts}"
-                        raw_path = os.path.normpath(os.path.join(args.out_dir, f"{base}_raw.png"))
-                        ann_path = os.path.normpath(os.path.join(args.out_dir, f"{base}_ann.png"))
-                        meta_path = os.path.normpath(os.path.join(args.out_dir, f"{base}_meta.json"))
-
-                        cv2.imwrite(raw_path, c)
-                        cv2.imwrite(ann_path, vis)
-
-                        meta = {
-                            "object": object_name,
-                            "face_yaml": face["yaml"] if face else None,
-                            "expected_tag_ids": sorted(list(expected)),
-                            "detected_tag_ids": sorted(list(det_ids)),
-                            "image": {
-                                "path_raw": raw_path,
-                                "path_ann": ann_path,
-                                "width": int(args.width),
-                                "height": int(args.height),
-                            },
-                            "camera": {"fx": float(fx), "fy": float(fy), "cx": float(cx), "cy": float(cy)},
-                            "timestamp": ts,
-                        }
-                        with open(meta_path, "w") as f:
-                            json.dump(meta, f, indent=2)
-                        print(f"[+] Saved {raw_path}")
-                        print(f"[+] Saved {ann_path}")
-                        print(f"[+] Saved {meta_path}")
-
-                        # ask user what to do next
-                        nxt = input(
-                            "[?] Save another for this face (Enter), switch (f), change object (o), or quit (q)? ").strip().lower()
-                        if nxt == 'q':
-                            return
-                        if nxt == 'o':
-                            object_name = None
-                            break
-                        if nxt == 'f':
-                            break
-                        # else continue capturing same face
-
-                if object_name is None:
-                    # break to outer loop to select object
+            if mode == 'pick_object':
+                if k in UP_KEYS:
+                    pick_sel = (pick_sel - 1) % max(1, len(bases))
+                elif k in DOWN_KEYS:
+                    pick_sel = (pick_sel + 1) % max(1, len(bases))
+                elif ord('1') <= k <= ord('9'):  # quick jump
+                    idx = (k - ord('1'))
+                    if idx < len(bases):
+                        pick_sel = idx
+                elif k in ENTER_KEYS:
+                    base = bases[pick_sel] if bases else None
+                    if base:
+                        state["object_base"] = base
+                        state["faces"] = faces_for_base(base, reg, repo_root)
+                        state["face_idx"] = 0
+                        state["auto_side"] = True
+                    mode = 'preview'
+                elif k in CANCEL_KEYS:
+                    mode = 'preview'
+                elif k == ord('q'):  # allow quit from picker
                     break
+                continue
+
+            # -------- preview mode (global) --------
+            if k in (ord('q'),):  # q quits from preview
+                break
+            if k in CANCEL_KEYS:  # Esc quits from preview
+                break
+
+            if k == ord('h'):
+                show_help = not show_help
+            elif k == ord('g'):
+                gallery_on = not gallery_on
+            elif k == ord('o'):
+                pick_sel = bases.index(state["object_base"]) if state["object_base"] in bases else 0
+                mode = 'pick_object'
+            elif k == ord('a'):
+                state["auto_side"] = not state["auto_side"] if state["faces"] else False
+            elif k == ord('f'):
+                if state["faces"] and not state["auto_side"]:
+                    state["face_idx"] = (state["face_idx"] + 1) % len(state["faces"])
+            elif k in ENTER_KEYS:
+                # ENTER -> save (with 2-press safeguard if not ok)
+                if face is None:
+                    pass
+                if not ok and face and set(face["tag_ids"]):
+                    now = time.time()
+                    if not state["save_warn"] or (now - state["save_warn_t0"] > 3.0):
+                        state["save_warn"] = True
+                        state["save_warn_t0"] = now
+                        # first press just warns; need second press
+                        continue
+                # proceed save
+                state["save_warn"] = False
+
+                ts = timestamp()
+                obj_full = (face["object"] if face else (state["object_base"] or "unknown"))
+                base_name, side = parse_base_and_side(obj_full)
+                side_code = (side or "unresolved").upper()
+
+                if args.layout == "flat":
+                    save_root = Path(args.out_dir)
+                    file_stub = f"{obj_full}_{ts}"
+                    raw_path = str(save_root / f"{file_stub}_raw.png")
+                    ann_path = str(save_root / f"{file_stub}_ann.png")
+                    meta_path = str(save_root / f"{file_stub}_meta.json")
+                    ensure_dir(save_root)
+                elif args.layout == "by_object":
+                    save_root = Path(args.out_dir) / base_name
+                    file_stub = f"{base_name}_side{side_code}_{ts}"
+                    raw_path = str(save_root / f"{file_stub}_raw.png")
+                    ann_path = str(save_root / f"{file_stub}_ann.png")
+                    meta_path = str(save_root / f"{file_stub}_meta.json")
+                    ensure_dir(save_root)
+                elif args.layout == "by_object_side":
+                    save_root = Path(args.out_dir) / base_name / f"side{side_code}"
+                    file_stub = f"{base_name}_side{side_code}_{ts}"
+                    raw_path = str(save_root / f"{file_stub}_raw.png")
+                    ann_path = str(save_root / f"{file_stub}_ann.png")
+                    meta_path = str(save_root / f"{file_stub}_meta.json")
+                    ensure_dir(save_root)
+                else:  # split_type
+                    file_stub = f"{base_name}_side{side_code}_{ts}"
+                    raw_path = str(Path(args.raw_dir) / f"{file_stub}_raw.png")
+                    ann_path = str(Path(args.ann_dir) / f"{file_stub}_ann.png")
+                    meta_path = str(Path(args.meta_dir) / f"{file_stub}_meta.json")
+
+                cv2.imwrite(raw_path, c)
+                cv2.imwrite(ann_path, vis)
+                state["last_saved_ann"] = vis.copy()
+
+                meta = {
+                    "object_base": base_name,
+                    "object_full": obj_full,
+                    "side": side_code,
+                    "face_yaml": face["yaml"] if face else None,
+                    "expected_tag_ids": sorted(list(set(face["tag_ids"]))) if face else [],
+                    "detected_tag_ids": sorted(list(det_ids)),
+                    "validation_ok": bool(ok),
+                    "auto_face": bool(state["auto_side"]),
+                    "image": {
+                        "path_raw": raw_path,
+                        "path_ann": ann_path,
+                        "path_meta": meta_path,
+                        "width": int(args.width),
+                        "height": int(args.height),
+                    },
+                    "camera": {"fx": float(fx), "fy": float(fy), "cx": float(cx), "cy": float(cy)},
+                    "timestamp": ts,
+                }
+                with open(meta_path, "w") as f:
+                    json.dump(meta, f, indent=2)
+                print(f"[+] Saved {raw_path}")
+                print(f"[+] Saved {ann_path}")
+                print(f"[+] Saved {meta_path}")
+                if args.manifest:
+                    _append_manifest(args.manifest, meta)
+
+                # thumbnail
+                try:
+                    tw = min(320, vis.shape[1])
+                    th = int(vis.shape[0] * tw / vis.shape[1])
+                    thumb = cv2.resize(vis, (tw, th))
+                    state["thumbs"].append(thumb)
+                    if len(state["thumbs"]) > 12:
+                        state["thumbs"] = state["thumbs"][-12:]
+                except Exception:
+                    pass
+
 
     finally:
         pipe.stop()
         cv2.destroyAllWindows()
-
 
 if __name__ == "__main__":
     main()

--- a/src/collect_gt_dataset.py
+++ b/src/collect_gt_dataset.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse, json, os, sys, time
 from dataclasses import dataclass
 from pathlib import Path
+from random import choices
 from typing import Dict, List, Tuple, Optional
 import numpy as np
 import cv2
@@ -376,29 +377,34 @@ def estimate_poses_multi(
     family: str,
     faces: Dict[str, FaceEntry],
     pts3d_by_face: Dict[str, np.ndarray],
+    axes_mode: str = "both",
 ) -> Tuple[np.ndarray, np.ndarray, Dict[str, dict]]:
     """
     Returns:
       anno_vis (left panel), reproj_vis (mid panel), and a dict results keyed by face_key.
-      Each result has: object, face_key, tags_used, T_cam_board, T_cam_object (4x4 lists).
+      Each result has: object, face_key, tags_used, T_cam_board, T_cam_object (4x4 lists),
+      bbox_xywh, bbox_source ('face_kps' or 'fallback_tag'), score breakdown.
     """
     gray = cv2.cvtColor(bgr, cv2.COLOR_BGR2GRAY)
     gray = np.ascontiguousarray(gray)
     K = np.array([[intr.fx,0,intr.cx],[0,intr.fy,intr.cy],[0,0,1]], float)
     dist = intr.dist if intr.dist is not None else np.zeros((1,5), float)
 
-    # Detect tags once per unique tag size (so mixed boards are supported)
+    # Detect tags once per unique tag size (mixed boards supported)
     tag_sizes = sorted({f.tag_size_m for f in faces.values()})
-    print(f'Tag sizes in scene: {tag_sizes}')
     det_by_id: Dict[int, object] = {}
     for tag_size in tag_sizes:
         dets = detect_tags(gray, intr.fx, intr.fy, intr.cx, intr.cy, tag_size, family=family)
         for d in dets:
-            det_by_id[int(d.tag_id)] = d  # latest wins (they all share same 2D corners)
+            det_by_id[int(d.tag_id)] = d  # last one wins
 
     anno = bgr.copy()
     reproj = bgr.copy()
     results: Dict[str, dict] = {}
+
+    # tuning knobs for fallback bbox
+    FALLBACK_SCALE = 3.0  # side length = 3x tag size
+    MIN_AREA = 6000       # px^2 threshold under which we'll switch to fallback
 
     # For each face board that has any visible tag, recover T_cam_board then T_cam_object
     for face_key, fe in faces.items():
@@ -406,16 +412,22 @@ def estimate_poses_multi(
         common = [tid for tid in fe.T_board_tag.keys() if tid in det_by_id]
         if not common and (fe.origin_id not in det_by_id):
             continue
-        if fe.origin_id in det_by_id and det_by_id[fe.origin_id].pose_R is not None:
+
+        # Build T_cam_tag and T_cam_board for whichever tag we use
+        if fe.origin_id in det_by_id and getattr(det_by_id[fe.origin_id], "pose_R", None) is not None:
             d = det_by_id[fe.origin_id]
-            T_cam_board = se3(d.pose_R.astype(float), d.pose_t.reshape(3).astype(float))
+            T_cam_tag   = se3(d.pose_R.astype(float), d.pose_t.reshape(3).astype(float))
+            T_cam_board = T_cam_tag  # origin tag = identity in board frame
             tag_used = fe.origin_id
         else:
             tag_used = max(common, key=lambda tid: getattr(det_by_id[tid], "decision_margin", 0.0))
             d = det_by_id[tag_used]
-            T_cam_tag = se3(d.pose_R.astype(float), d.pose_t.reshape(3).astype(float))
+            T_cam_tag   = se3(d.pose_R.astype(float), d.pose_t.reshape(3).astype(float))
             T_cam_board = T_cam_tag @ inv_se3(fe.T_board_tag[tag_used])
+
         T_cam_obj = T_cam_board @ fe.T_board_object
+
+        # reprojection debug dots on the board
         try:
             pts3d = np.array([[0,0,0],[0.03,0,0],[0,0.03,0],[0,0,0.03]], np.float32)
             uv = project_points(pts3d, T_cam_board, K, dist)
@@ -424,10 +436,18 @@ def estimate_poses_multi(
         except Exception:
             pass
 
+        # --- BBOX from face keypoints (if present) ---
         bbox_xywh = None
+        bbox_source = None
+        score_area = 0.0
+
         if face_key in pts3d_by_face:
-            uv = project_points(pts3d_by_face[face_key], T_cam_obj, K, dist)  # (4,2)
-            x0, y0 = uv.min(axis=0);
+            uv = project_points(pts3d_by_face[face_key], T_cam_obj, K, dist)  # (N,2)
+            # Visualize the points that drive the bbox (cyan)
+            for (u, v) in uv:
+                cv2.circle(anno, (int(u), int(v)), 2, (255, 255, 0), -1)
+
+            x0, y0 = uv.min(axis=0)
             x1, y1 = uv.max(axis=0)
             H, W = bgr.shape[:2]
             x0 = max(0.0, min(W - 1.0, float(x0)))
@@ -435,21 +455,50 @@ def estimate_poses_multi(
             x1 = max(0.0, min(W - 1.0, float(x1)))
             y1 = max(0.0, min(H - 1.0, float(y1)))
             bbox_xywh = [x0, y0, max(0.0, x1 - x0), max(0.0, y1 - y0)]
-            # quick overlay
+            score_area = bbox_xywh[2] * bbox_xywh[3]
+            bbox_source = "face_kps"
+            # draw primary bbox in yellow
             cv2.rectangle(anno, (int(x0), int(y0)), (int(x1), int(y1)), (0, 255, 255), 2)
 
-        # overlay
+        # --- Fallback bbox: inflate a square around the chosen tag ---
+        if (bbox_xywh is None) or (score_area < MIN_AREA):
+            s   = float(fe.tag_size_m) * FALLBACK_SCALE
+            hlf = 0.5 * s
+            # tag-plane square, centered at tag
+            square3d = np.array([[-hlf, -hlf, 0],
+                                 [ hlf, -hlf, 0],
+                                 [ hlf,  hlf, 0],
+                                 [-hlf,  hlf, 0]], np.float32)
+            uv_tag = project_points(square3d, T_cam_tag, K, dist)
+            x0, y0 = uv_tag.min(axis=0)
+            x1, y1 = uv_tag.max(axis=0)
+            H, W = bgr.shape[:2]
+            x0 = max(0.0, min(W - 1.0, float(x0)))
+            y0 = max(0.0, min(H - 1.0, float(y0)))
+            x1 = max(0.0, min(W - 1.0, float(x1)))
+            y1 = max(0.0, min(H - 1.0, float(y1)))
+            bbox_xywh = [x0, y0, max(0.0, x1 - x0), max(0.0, y1 - y0)]
+            score_area = bbox_xywh[2] * bbox_xywh[3]
+            bbox_source = "fallback_tag"
+            # draw fallback bbox in magenta
+            cv2.rectangle(anno, (int(x0), int(y0)), (int(x1), int(y1)), (255, 0, 255), 2)
+
+        # Axes overlay (board/object) according to mode
+        if axes_mode in ("both", "board"):
+            draw_axes(anno, T_cam_board, K, dist, scale=0.06)
+        if axes_mode in ("both", "object"):
+            draw_axes(anno, T_cam_obj, K, dist, scale=0.04)
+
+        # label
         label = f"{fe.object_name}/{fe.face_key}"
-        draw_axes(anno, T_cam_board, K, dist, scale=0.06)
-        draw_axes(anno, T_cam_obj, K, dist, scale=0.04)
-        cv2.putText(anno, label, (12, 24 + 18 * (hash(face_key) % 20)), cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 255, 255),
-                    2)
+        cv2.putText(anno, label, (12, 24 + 18 * (hash(face_key) % 20)),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.55, (0, 255, 255), 2)
 
+        # scoring: prefer more tags; tie-break with bbox area
         num_tags = len(common) if common else (1 if fe.origin_id in det_by_id else 0)
-        score_area = 0.0 if not bbox_xywh else float(bbox_xywh[2] * bbox_xywh[3])
-        score = (num_tags * 1_000.0) + score_area
+        score = (num_tags * 1_000.0) + float(score_area)
 
-        # pack results (store 4x4 lists for JSON cleanliness)
+        # pack results
         results[face_key] = {
             "object": fe.object_name,
             "face_key": fe.face_key,
@@ -459,9 +508,10 @@ def estimate_poses_multi(
             "score": float(score),
             "score_tags": int(num_tags),
             "score_area_px": int(score_area),
+            "bbox_xywh": bbox_xywh,
+            "bbox_source": bbox_source,  # <-- new
             "T_cam_board": {"matrix": T_cam_board.tolist()},
             "T_cam_object": {"matrix": T_cam_obj.tolist()},
-            "bbox_xywh": bbox_xywh,
         }
 
     return anno, reproj, results
@@ -554,6 +604,7 @@ def main():
     ap.add_argument("--rs_fps", type=int, default=30, help="FPS for live mode")
     ap.add_argument("--save_depth", action="store_true",
                     help="If present, save aligned depth as .npy per frame")
+    ap.add_argument("--axes", choices=["both","board","object","none"], default="both", help="Which axes to draw on the left: both(default), board only, or object only, or none")
 
     args = ap.parse_args()
 
@@ -625,7 +676,7 @@ def main():
                              f"Start with --rs_w {intr.width} --rs_h {intr.height} or fix the calibration.")
 
                 # estimate poses
-                anno, reproj, results = estimate_poses_multi(bgr, intr, args.family, faces, pts3d_by_face)
+                anno, reproj, results = estimate_poses_multi(bgr, intr, args.family, faces, pts3d_by_face, axes_mode=args.axes)
                 last_anno, last_reproj = anno, reproj
                 last_bgr, last_depth, last_ts = bgr, depth, ts
                 last_results = results
@@ -669,6 +720,9 @@ def main():
                     lines.append(f"   tag_used: {r['tag_used']}  face: {r['face_key']}")
                     lines.append(
                         f"   score: {int(r['score'])}  (tags={r['score_tags']}, area={r['score_area_px']:,} px)")
+                    lines.append(f"   board: {Path(r['board_yaml']).name}")
+                    lines.append(f"   tag_size_m: {faces[r['face_key']].tag_size_m:.3f}")
+
                     lines.append("")
 
             now = time.time()

--- a/utils/annotation_utils.py
+++ b/utils/annotation_utils.py
@@ -155,10 +155,7 @@ def load_board(board_yaml_path: Path):
     tb[origin] = np.eye(4, dtype=float)
     return origin, tag_size_m, tb
 
-# def detect_tags(image_gray, fx, fy, cx, cy, tag_size_m, family="tag36h11"):
-#     det = Detector(families=family, nthreads=4, quad_decimate=1.0, refine_edges=True)
-#     return det.detect(image_gray, estimate_tag_pose=True,
-#                       camera_params=(fx, fy, cx, cy), tag_size=tag_size_m)
+
 
 def choose_face_key(face_yaml_path: str) -> str:
     # face key = YAML basename without extension

--- a/utils/capture_utils.py
+++ b/utils/capture_utils.py
@@ -1,0 +1,342 @@
+import argparse, os, sys, json, time, datetime, re
+import yaml
+import numpy as np
+import cv2
+import pyrealsense2 as rs
+from pathlib import Path
+from typing import List, Dict, Tuple, Optional, Set
+import csv
+
+SIDE_RE = re.compile(r"^(?P<base>.+?)_side(?P<side>[A-Za-z]+)$")
+
+def _append_manifest(manifest_path: str, meta: dict):
+    """
+    Append one capture to a csv manifest (creates with header if needed)
+    """
+    os.makedirs(os.path.dirname(manifest_path), exist_ok=True)
+    row = {
+        "timestamp": meta.get("timestamp", ""),
+        "object_base": meta.get("object_base", ""),
+        "object_full": meta.get("object_full", ""),
+        "side": meta.get("side", ""),
+        "face_yaml": meta.get("face_yaml", "") or "",
+        "path_raw": meta["image"].get("path_raw", ""),
+        "path_ann": meta["image"].get("path_ann", ""),
+        "path_meta": meta["image"].get("path_meta", ""),
+        "width": meta["image"].get("width", 0),
+        "height": meta["image"].get("height", 0),
+        "fx": meta["camera"].get("fx", 0.0),
+        "fy": meta["camera"].get("fy", 0.0),
+        "cx": meta["camera"].get("cx", 0.0),
+        "cy": meta["camera"].get("cy", 0.0),
+        "detected_ids": " ".join(map(str, meta.get("detected_tag_ids", []))),
+        "expected_ids": " ".join(map(str, meta.get("expected_tag_ids", []))),
+        "validation_ok": int(bool(meta.get("validation_ok", False))),
+        "auto_face": int(bool(meta.get("auto_face", False))),
+        }
+    header = list(row.keys())
+    write_header = not os.path.exists(manifest_path)
+    with open(manifest_path, "a", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=header)
+        if write_header:
+                w.writeheader()
+        w.writerow(row)
+
+
+def _resolve_yaml_path(repo_root, p: str) -> str | None:
+    if not p:
+        return None
+    p = p.replace("\\", "/")  # tolerate Windows entries
+    cand = Path(p)
+    if not cand.is_absolute():
+        cand = repo_root / cand
+    if not cand.exists():
+        alt = repo_root / "boards" / cand.name  # fallback by basename
+        if alt.exists():
+            cand = alt
+    return str(cand)
+
+def _wrap_lines(lines, max_w, scale=0.60, thick=1, font=cv2.FONT_HERSHEY_SIMPLEX):
+    """Word-wrap each line to fit max_w pixels."""
+    out = []
+    for line in lines:
+        words = line.split()
+        cur = ""
+        for w in words:
+            test = (cur + " " + w).strip()
+            (tw, _), _ = cv2.getTextSize(test, font, scale, thick)
+            if tw <= max_w or not cur:
+                cur = test
+            else:
+                out.append(cur)
+                cur = w
+        if cur:
+            out.append(cur)
+    return out
+
+def make_recent_panel(h: int, w: int, last_img: np.ndarray, show: bool) -> np.ndarray:
+    # black background
+    panel = np.zeros((h, w, 3), np.uint8)
+    if not show or last_img is None:
+        return panel  # keep black
+
+    # fit-preserving resize with 12px margins
+    INNER = 12
+    tgt_w = max(1, w - 2*INNER)
+    tgt_h = max(1, h - 2*INNER)
+    scale = min(tgt_w / last_img.shape[1], tgt_h / last_img.shape[0])
+    new_w = max(1, int(last_img.shape[1] * scale))
+    new_h = max(1, int(last_img.shape[0] * scale))
+    img = cv2.resize(last_img, (new_w, new_h))
+
+    x0 = INNER + (tgt_w - new_w) // 2
+    y0 = INNER + (tgt_h - new_h) // 2
+    panel[y0:y0+new_h, x0:x0+new_w] = img
+
+    # header tag
+    cv2.putText(panel, "Last saved", (12, 26),
+                cv2.FONT_HERSHEY_SIMPLEX, 0.7, (200,200,200), 2, cv2.LINE_AA)
+    return panel
+
+
+def make_info_panel(h: int, w: int, state: dict, gallery_on: bool=True) -> np.ndarray:
+    # Colours
+    BG = (245, 245, 245)
+    CARD_BG = (255, 255, 255)
+    BORDER = (210, 210, 210)
+    TITLE = (40, 40, 40)
+    TEXT  = (30, 30, 30)
+    OK_BG = (40, 160, 60)
+    BAD_BG = (30, 70, 190)
+
+    panel = np.full((h, w, 3), BG, np.uint8)
+    M, S = 14, 12  # margin, spacing
+    INNER = 12
+    SCALE = 0.60
+    THICK = 1
+    TITLE_SCALE = 0.8
+
+    def draw_card(y, title, body_lines, h_fixed=None, status=None):
+        inner_w = w - 2*M - 2*INNER
+        wrapped = _wrap_lines(body_lines, inner_w, SCALE, THICK)
+        body_h = 22 * len(wrapped)
+        H = h_fixed if h_fixed is not None else (50 + body_h + INNER)
+        x0, y0, x1, y1 = M, y, w - M, min(h - M, y + H)
+        # card
+        cv2.rectangle(panel, (x0, y0), (x1, y1), CARD_BG, -1)
+        cv2.rectangle(panel, (x0, y0), (x1, y1), BORDER, 1)
+        # title
+        cv2.putText(panel, title, (x0 + INNER, y0 + 28),
+                    cv2.FONT_HERSHEY_SIMPLEX, TITLE_SCALE, TITLE, 2, cv2.LINE_AA)
+        # status chip
+        if status is not None:
+            txt, good = status
+            (tw, th), _ = cv2.getTextSize(txt, cv2.FONT_HERSHEY_SIMPLEX, 0.55, 2)
+            pad = 6
+            rx1 = x1 - INNER
+            rx0 = rx1 - tw - 2*pad
+            ry0 = y0 + 10
+            ry1 = ry0 + th + 2*pad
+            cv2.rectangle(panel, (rx0, ry0), (rx1, ry1), OK_BG if good else BAD_BG, -1)
+            cv2.putText(panel, txt, (rx0 + pad, ry1 - pad - 2),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.55, (255,255,255), 1, cv2.LINE_AA)
+        # body
+        yy = y0 + 50
+        for s in wrapped:
+            if yy + 18 >= y1 - INNER: break  # truncate if needed
+            cv2.putText(panel, s, (x0 + INNER, yy),
+                        cv2.FONT_HERSHEY_SIMPLEX, SCALE, TEXT, THICK, cv2.LINE_AA)
+            yy += 22
+        return y1
+
+    # ----- gather state
+    obj_base = state.get("object_base")
+    face = state.get("face")
+    auto = state.get("auto_side", False)
+    det_ids = sorted(list(state.get("detected_ids", [])))
+    exp_ids = sorted(list(set(face["tag_ids"])) if face else [])
+    overlap = sorted(list(set(det_ids).intersection(exp_ids))) if face else []
+    ok = state.get("validation_ok", True)
+    save_warn = state.get("save_warn", False)
+
+    # ----- INFO card
+    lines = []
+    if obj_base: lines.append(f"Object base: {obj_base}")
+    if face:
+        b, side = parse_base_and_side(face['object'])
+        face_key = os.path.splitext(os.path.basename(face["yaml"]))[0]
+        lines += [
+            f"Resolved face: {face['object']} (side={side or '?'})",
+            f"Face key: {face_key}",
+        ]
+    else:
+        lines.append("Resolved face: (none)")
+    lines += [f"Auto-face: {'ON' if auto else 'OFF'}",
+              f"Seen IDs: {det_ids}"]
+    if face:
+        lines += [f"Expected IDs: {exp_ids}", f"Overlap: {overlap}"]
+
+    y = M
+    y = draw_card(y, "Info", lines, status=("OK" if ok else "NOT OK", ok)) + S
+
+    # ----- INSTRUCTIONS card (ASCII-only)
+    instr = [
+        "- ENTER: Save (double-press within 3s to force if tags missing)",
+        "- a: Toggle auto face/side (when base is chosen)",
+        "- f: Cycle faces (works when auto is OFF)",
+        "- o: Object picker (Up/Down or W/S/K/J; Enter selects; Esc cancels)",
+        "- g: Toggle gallery thumbnails",
+        "- h: Help overlay",
+        "- q or Esc: Quit",
+    ]
+    y = draw_card(y, "Instructions", instr) + S
+
+    # ----- GALLERY card (single column, truncates safely)
+    if gallery_on:
+        thumbs = state.get("thumbs", []) or []
+        if thumbs:
+            x0, y0, x1 = M, y, w - M
+            inner_w = x1 - x0 - 2*INNER
+            y_cursor = y0 + 50
+            # header
+            y1 = min(h - M, y0 + 50 + 8)  # temp
+            cv2.rectangle(panel, (x0, y0), (x1, h - M), CARD_BG, -1)
+            cv2.rectangle(panel, (x0, y0), (x1, h - M), BORDER, 1)
+            cv2.putText(panel, "Recent shots", (x0 + INNER, y0 + 28),
+                        cv2.FONT_HERSHEY_SIMPLEX, TITLE_SCALE, TITLE, 2, cv2.LINE_AA)
+            # thumbnails (most recent first)
+            for th in thumbs[::-1]:
+                if th is None: continue
+                scale = min(1.0, inner_w / th.shape[1])
+                th_res = cv2.resize(th, (int(th.shape[1]*scale), int(th.shape[0]*scale)))
+                h_avail = (h - M) - y_cursor - INNER
+                if th_res.shape[0] > h_avail:
+                    if h_avail <= 0: break
+                    th_res = th_res[:h_avail, :]
+                # clip-safe paste
+                y2 = min(y_cursor + th_res.shape[0], panel.shape[0])
+                xL = x0 + INNER
+                xR = min(xL + th_res.shape[1], panel.shape[1])
+                if y_cursor >= y2 or xL >= xR: break
+                panel[y_cursor:y2, xL:xR] = th_res[:y2 - y_cursor, :xR - xL]
+                y_cursor = y2 + 8
+            # advance y to bottom of card
+            y = min(h - M, y_cursor + INNER) + S
+        else:
+            y = draw_card(y, "Recent shots", ["(none yet)"]) + S
+
+    # footer warn strip
+    if save_warn:
+        warn = "Press ENTER again within 3s to confirm save"
+        (tw, th), _ = cv2.getTextSize(warn, cv2.FONT_HERSHEY_SIMPLEX, 0.6, 2)
+        cv2.putText(panel, warn, (max(M, (w - tw)//2), h - 16),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0,0,200), 2, cv2.LINE_AA)
+
+    return panel
+
+
+# ---------- registry helpers ----------
+def load_registry(path: str) -> Dict:
+    if not os.path.exists(path):
+        print(f"[!] tag registry not found: {path}")
+        return {"version": 1, "tags": {}}
+    reg = yaml.safe_load(open(path, "r")) or {}
+    reg.setdefault("tags", {})
+    return reg
+
+def faces_for_object(object_name: str, registry: Dict, repo_root) -> List[Dict]:
+    """Return list of face entries for the *full* object name.
+       Each entry: dict(yaml, object, tag_ids=set(...))"""
+    by_yaml = {}
+    for tid, rec in registry["tags"].items():
+        try:
+            obj = rec.get("object")
+            yml_raw = rec.get("yaml")
+            if obj is None or yml_raw is None:
+                continue
+            if obj != object_name:
+                continue
+            yml = _resolve_yaml_path(repo_root, yml_raw)
+            if not yml:
+                print(f"[!] Could not resolve yaml path: {yml_raw}")
+                continue
+            by_yaml.setdefault(yml, {"object": obj, "tag_ids": set()})
+            by_yaml[yml]["tag_ids"].add(int(tid))
+        except Exception:
+            continue
+
+    faces = []
+    for yml, info in by_yaml.items():
+        try:
+            with open(yml, "r") as f:
+                yy = yaml.safe_load(f) or {}
+            obj_field = yy.get("object", info["object"])
+            tags = yy.get("tags", [])
+            if tags and not info["tag_ids"]:
+                info["tag_ids"] = set(int(t["id"]) for t in tags if "id" in t)
+            faces.append({
+                "yaml": yml,
+                "object": obj_field,
+                "tag_ids": sorted(list(info["tag_ids"]))
+            })
+        except Exception as e:
+            print(f"[!] Could not read {yml}: {e}")
+    return faces
+
+def parse_base_and_side(name: str) -> Tuple[str, Optional[str]]:
+    m = SIDE_RE.match(name)
+    if m:
+        return m.group("base"), m.group("side")
+    return name, None
+
+def unique_bases(registry: Dict) -> List[str]:
+    bases: Set[str] = set()
+    for rec in registry.get("tags", {}).values():
+        obj = rec.get("object")
+        if not obj:
+            continue
+        b, _ = parse_base_and_side(obj)
+        bases.add(b)
+    return sorted(bases)
+
+def objects_for_base(base: str, registry: Dict) -> List[str]:
+    """All full object names for a base (e.g., ..._sideA/B/C/D)."""
+    fulls = set()
+    for rec in registry.get("tags", {}).values():
+        obj = rec.get("object")
+        if not obj:
+            continue
+        b, _ = parse_base_and_side(obj)
+        if b == base:
+            fulls.add(obj)
+    return sorted(fulls)
+
+def faces_for_base(base: str, registry: Dict, repo_root) -> List[Dict]:
+    out = []
+    for full in objects_for_base(base, registry):
+        out.extend(faces_for_object(full, registry, repo_root))
+    # stable order: by object, then yaml basename
+    out.sort(key=lambda f: (f["object"], os.path.basename(f["yaml"])))
+    return out
+
+# ---------- UI helpers ----------
+def draw_detections(img, dets, colour=(0, 255, 0)):
+    vis = img.copy()
+    for d in dets:
+        pts = d.corners.astype(int)
+        cv2.polylines(vis, [pts], True, colour, 2)
+        cv2.putText(vis, str(int(d.tag_id)), tuple(pts[0]),
+                    cv2.FONT_HERSHEY_SIMPLEX, 0.8, (0, 255, 255), 2)
+    return vis
+
+def ensure_dir(p):
+    os.makedirs(p, exist_ok=True)
+
+def timestamp():
+    return datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+def text_lines(panel, lines, x=12, y0=28, dy=22, colour=(0,0,0), scale=0.6, thick=1):
+    y = y0
+    for s in lines:
+        cv2.putText(panel, s, (x, y), cv2.FONT_HERSHEY_SIMPLEX, scale, colour, thick, cv2.LINE_AA)
+        y += dy


### PR DESCRIPTION

**Summary**
Improves the face-shot capture workflow with better usability, safer saves, and more structured outputs.

**Key changes**

* **Auto side/face** when given a base object (toggle with `a`).
* **In-window object picker** (`o`, arrow keys/W/S/K/J, Enter/Esc).
* **Panels**: Info + Last saved preview (`g` toggles).
* **Double-press Enter** to force save if tags missing.
* **Bug fixes**: duplicate filenames, gallery crash.
* **New save layouts** (`by_object_side` default, `flat`, `by_object`, `split_type`) + optional CSV manifest.

**Usage**

```bash
python -m src.capture_isc_face --calib calib_color.yaml --width 640 --height 480
# base name only
python -m src.capture_isc_face --object_name connection_plate_white
```

**Outputs (default layout)**

```
boards/shots/<object_base>/sideA/<object_base>_sideA_<ts>_{raw,ann}.png
boards/shots/<object_base>/sideA/<object_base>_sideA_<ts>_meta.json
```

**Docs**
README capture section updated; `capture_isc_face.py` docstring updated
