### PR TITLE
fix/charuco_project_root

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -46,20 +46,28 @@ python -m src.gen_april_tags --project_root my_project --tag-size-mm 40 --ids 19
 
 ### 1) Calibrate the colour camera (ChArUco)
 
-SPACE to capture a sample; ENTER to solve:
+SPACE to capture a sample; ENTER to solve. Outputs a `calib_color.yaml` (fx, fy, cx, cy, k1..k3, image size, RMS).
+With `--project_root`, output defaults to `<root>/calib/calib_color.yaml`.
+
+**Generic webcam (default)**
+```bash
+python charuco_calibrate.py --source opencv --cam 0 \
+  --squares-x 5 --squares-y 3 --square-length-mm 50 --marker-length-mm 37 --dict 7X7_100
+````
+
+**Intel RealSense**
 
 ```bash
-python charuco_calibrate.py --squares-x 5 --squares-y 3 \
-  --square-length-mm 50 --marker-length-mm 37 --dict 7X7_1000 \
-  --width 640 --height 480 --min-samples 30 --out calib_color.yaml
+python charuco_calibrate.py --source realsense --width 640 --height 480 --fps 30
 ```
 
-Outputs `calib_color.yaml` with:
+**Video file**
 
-* `camera_matrix` (fx, fy, cx, cy)
-* `distortion_coefficients` (k1, k2, p1, p2, k3)
-* `image_width`, `image_height` (keep these consistent later)
-* `reproj_rms` (px)
+```bash
+python charuco_calibrate.py --source video --video sample.mp4
+```
+
+<sub>Keep print scale at 100%. OpenCV webcams treat --width/--height as best-effort; the YAML records the actual stream size.</sub>
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -45,7 +45,7 @@ python -m src.gen_april_tags --project_root my_project --tag-size-mm 40 --ids 19
 ---
 
 ### 1) Calibrate the colour camera (ChArUco)
-
+![calibration-grab](media/calibration.gif)
 SPACE to capture a sample; ENTER to solve. Outputs a `calib_color.yaml` (fx, fy, cx, cy, k1..k3, image size, RMS).
 With `--project_root`, output defaults to `<root>/calib/calib_color.yaml`.
 

--- a/utils/charuco_calibrate.py
+++ b/utils/charuco_calibrate.py
@@ -1,10 +1,41 @@
+"""
+Colour ChArUco camera calibration (OpenCV webcam, Intel RealSense, or video file).
+
+What it does
+------------
+- Detects ArUco/ChArUco corners from a live camera or video.
+- Lets you collect multiple views (SPACE), then solves intrinsics/distortion (ENTER).
+- Writes a `calib_color.yaml` with explicit fields (fx, fy, cx, cy, k1..k3, image size, RMS).
+- If `--project_root` is provided, initializes a project tree and defaults output to
+  `<root>/calib/calib_color.yaml` (unless `--out` is set).
+
+Typical usage
+-------------
+# Generic webcam (default source)
+python charuco_calibrate.py --source opencv --cam 0 --squares-x 5 --squares-y 3 \
+  --square-length-mm 50 --marker-length-mm 37 --dict 7X7_100
+
+# RealSense
+python charuco_calibrate.py --source realsense --width 640 --height 480 --fps 30
+
+# From a video
+python charuco_calibrate.py --source video --video sample.mp4
+"""
+
 import argparse, yaml
+import sys
 import numpy as np
 import cv2
-import pyrealsense2 as rs
 import os, datetime
-from pathlib import  Path
+from pathlib import Path
 
+# RealSense is optional; general webcams/video should work without it
+try:
+    import pyrealsense2 as rs
+except Exception:
+    rs = None
+
+# Project bootstrap helpers (optional)
 try:
     from utils.project_config import resolve_project_root, ensure_project_dirs
 except Exception:
@@ -12,25 +43,54 @@ except Exception:
     ensure_project_dirs = None
 
 
+class _HelpFmt(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
+    """Show defaults and preserve newlines in help/epilog."""
+    pass
+
+
 def parse_args():
-    ap = argparse.ArgumentParser("RealSense colour ChArUco calibration (API-compatible)")
+    ap = argparse.ArgumentParser(
+        "Colour ChArUco calibration (RealSense, generic webcam, or video)",
+        formatter_class=_HelpFmt,
+        epilog=(
+            "Controls:\n"
+            "  SPACE  add sample    ENTER  solve    q  quit\n\n"
+            "Tips:\n"
+            "  - Print the board at 100% and pass correct --square-length-mm / --marker-length-mm.\n"
+            "  - For OpenCV webcams, requested --width/--height are best-effort; the YAML records actual size."
+        ),
+    )
     ap.add_argument("--squares-x", type=int, default=3)
     ap.add_argument("--squares-y", type=int, default=5)
-    ap.add_argument("--square-length-mm", type=float, default=50.0)
-    ap.add_argument("--marker-length-mm", type=float, default=37.0)
-    ap.add_argument("--dict", type=str, default="7X7_50")
-    ap.add_argument("--width", type=int, default=640)
-    ap.add_argument("--height", type=int, default=480)
-    ap.add_argument("--fps", type=int, default=30)
+    ap.add_argument("--square-length-mm", type=float, default=50.0,
+                    help="Size of one ChArUco square (mm).")
+    ap.add_argument("--marker-length-mm", type=float, default=37.0,
+                    help="Size of the ArUco marker inside each square (mm).")
+    ap.add_argument("--dict", type=str, default="7X7_50",
+                    help="ArUco dictionary (e.g., 4X4_50, 5X5_250, 6X6_1000, 7X7_1000, APRILTAG_36H11).")
+    ap.add_argument("--width", type=int, default=640,
+                    help="Requested capture width (best effort for OpenCV webcams).")
+    ap.add_argument("--height", type=int, default=480,
+                    help="Requested capture height (best effort for OpenCV webcams).")
+    ap.add_argument("--fps", type=int, default=30,
+                    help="Requested frames per second (best effort for OpenCV webcams).")
     ap.add_argument("--min-corners", type=int, default=1, help="min ChArUco corners per sample")
     ap.add_argument("--min-samples", type=int, default=30, help="min accepted samples before solve")
-    ap.add_argument("--out", type=str, default="calib_color.yaml")
     ap.add_argument("--auto", action="store_true")
     ap.add_argument("--auto-interval", type=int, default=10)
-
+    ap.add_argument("--source", choices=["opencv", "realsense", "video"], default="opencv",
+                    help="Camera source: generic OpenCV webcam (default), Intel RealSense, or a video file")
+    ap.add_argument("--cam", type=int, default=0, help="OpenCV camera index when --source=opencv")
+    ap.add_argument("--video", type=str, default=None, help="Video path when --source=video")
+    ap.add_argument("--project_root", type=Path, default=None,
+                    help="If set, initialize project layout and (when --out is not given) save to <project_root>/calib/calib_color.yaml")
+    ap.add_argument("--out", type=str, default=None,
+                    help="Output YAML file (default: <root>/calib/calib_color.yaml if --project_root is set; otherwise calib_color.yaml in CWD)")
     return ap.parse_args()
 
+
 def get_dictionary(name: str):
+    """Return an OpenCV ArUco dictionary object from a human-friendly name."""
     name = name.upper().replace("-", "_")
     aruco = cv2.aruco
     MAP = {
@@ -48,14 +108,18 @@ def get_dictionary(name: str):
         raise ValueError(f"Unsupported dictionary {name}")
     return aruco.getPredefinedDictionary(MAP[name])
 
+
 def make_board(aruco, sx, sy, square_m, marker_m, dictionary):
+    """Create a ChArUco board using the OpenCV API available in the installed version."""
     if hasattr(aruco, "CharucoBoard") and callable(getattr(aruco, "CharucoBoard")):
         return aruco.CharucoBoard((sx, sy), square_m, marker_m, dictionary)
     if hasattr(aruco, "CharucoBoard_create"):
         return aruco.CharucoBoard_create(sx, sy, square_m, marker_m, dictionary)
     raise RuntimeError("Your OpenCV build lacks both CharucoBoard APIs.")
 
+
 def calibrate_from_charuco(samples_corners, samples_ids, board, image_size):
+    """Run calibration using Charuco corners; falls back to classic calibrateCamera if needed."""
     aruco = cv2.aruco
     if hasattr(aruco, "calibrateCameraCharuco"):
         return aruco.calibrateCameraCharuco(
@@ -81,7 +145,8 @@ def calibrate_from_charuco(samples_corners, samples_ids, board, image_size):
     elif hasattr(board, "chessboardCorners"):
         all_corners3d = board.chessboardCorners
     else:
-        raise RuntimeError("CharucoBoard has neither getChessboardCorners() nor chessboardCorners")
+        raise RuntimeError("ChArUco board missing expected corner accessors")
+
     all_corners3d = np.asarray(all_corners3d, dtype=np.float32)
     N_all = all_corners3d.shape[0]
 
@@ -94,11 +159,13 @@ def calibrate_from_charuco(samples_corners, samples_ids, board, image_size):
         mask = (ids >= 0) & (ids < N_all)
         if not np.any(mask):
             continue
-        ids = ids[mask]; img = img[mask]
+        ids = ids[mask]
+        img = img[mask]
         if len(ids) < 6:
             continue
         obj = all_corners3d[ids, :]
-        objpoints.append(obj); imgpoints.append(img)
+        objpoints.append(obj)
+        imgpoints.append(img)
 
     if len(objpoints) < 10:
         raise RuntimeError(f"Not enough valid views for fallback calibration (got {len(objpoints)}, need ≥10).")
@@ -111,48 +178,121 @@ def calibrate_from_charuco(samples_corners, samples_ids, board, image_size):
     )
     return rms, K, dist, rvecs, tvecs
 
+
 def main():
+    """CLI entry point: capture frames, collect ChArUco corners, calibrate, and write YAML."""
     args = parse_args()
+
+    # Project-aware default output path
+    if getattr(args, "project_root", None) is not None:
+        if resolve_project_root is None or ensure_project_dirs is None:
+            print("Warning: --project_root provided but project helpers unavailable; proceeding without init.",
+                  file=sys.stderr)
+            pr = Path(args.project_root)
+        else:
+            pr = Path(resolve_project_root(args.project_root))
+            ensure_project_dirs(str(pr))
+        if args.out is None:
+            out_path = pr / "calib" / "calib_color.yaml"
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            args.out = str(out_path)
+    else:
+        if args.out is None:
+            args.out = "calib_color.yaml"
+
     aruco = cv2.aruco
     dictionary = get_dictionary(args.dict)
-    calibration_folder = 'calib_images'; os.makedirs(calibration_folder, exist_ok=True)
-    calib_folders = sorted([fd for fd in os.listdir(calibration_folder) if os.path.isdir(os.path.join(calibration_folder, fd))])
+
+    # Prepare calibration image dump folder
+    calibration_folder = "calib_images"
+    os.makedirs(calibration_folder, exist_ok=True)
+    calib_folders = sorted(
+        [fd for fd in os.listdir(calibration_folder) if os.path.isdir(os.path.join(calibration_folder, fd))]
+    )
     last_sub_calib_folder = calib_folders[-1] if len(calib_folders) > 0 else None
     if last_sub_calib_folder is None:
-        new_sub_calib_folder = os.path.join(calibration_folder, 'set_01')
+        new_sub_calib_folder = os.path.join(calibration_folder, "set_01")
     else:
-        last_index = int(last_sub_calib_folder.split('_')[-1])
+        last_index = int(last_sub_calib_folder.split("_")[-1])
         new_index = last_index + 1
-        new_sub_calib_folder = os.path.join(calibration_folder, f'set_{new_index:02d}')
+        new_sub_calib_folder = os.path.join(calibration_folder, f"set_{new_index:02d}")
     os.makedirs(new_sub_calib_folder, exist_ok=True)
     print(f"[i] Created new calibration image folder: {new_sub_calib_folder}")
 
+    # Build ChArUco board
     square_m = args.square_length_mm / 1000.0
     marker_m = args.marker_length_mm / 1000.0
     board = make_board(aruco, args.squares_x, args.squares_y, square_m, marker_m, dictionary)
 
+    # Detector setup
     has_charuco_detector = hasattr(aruco, "CharucoDetector")
     if has_charuco_detector:
         chdet = aruco.CharucoDetector(board)
     else:
         det_params = aruco.DetectorParameters_create()
 
-    # RealSense colour
-    pipe, cfg = rs.pipeline(), rs.config()
-    cfg.enable_stream(rs.stream.color, args.width, args.height, rs.format.bgr8, args.fps)
-    profile = pipe.start(cfg)
+    # --- Camera/video source setup ---
+    if args.source == "realsense":
+        if rs is None:
+            sys.exit("pyrealsense2 not available; use --source opencv|video")
+        pipe, cfg = rs.pipeline(), rs.config()
+        cfg.enable_stream(rs.stream.color, args.width, args.height, rs.format.bgr8, args.fps)
+        profile = pipe.start(cfg)
+
+        def _read_frame():
+            frames = pipe.wait_for_frames()
+            cframe = frames.get_color_frame()
+            return None if not cframe else np.asanyarray(cframe.get_data())
+
+        def _stop():
+            pipe.stop()
+
+    elif args.source == "opencv":
+        cap = cv2.VideoCapture(args.cam)
+        if not cap.isOpened():
+            sys.exit(f"Could not open camera index {args.cam}")
+        # Best effort; actual size may differ
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, args.width)
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, args.height)
+        cap.set(cv2.CAP_PROP_FPS, args.fps)
+
+        def _read_frame():
+            ok, frame = cap.read()
+            return frame if ok else None
+
+        def _stop():
+            cap.release()
+
+    elif args.source == "video":
+        if not args.video:
+            sys.exit("--video path is required when --source=video")
+        cap = cv2.VideoCapture(args.video)
+        if not cap.isOpened():
+            sys.exit(f"Could not open video: {args.video}")
+
+        def _read_frame():
+            ok, frame = cap.read()
+            return frame if ok else None
+
+        def _stop():
+            cap.release()
 
     samples_corners, samples_ids = [], []
     auto_tick = 0
 
     print("[i] Move/tilt the board; SPACE=add, ENTER=solve, q=quit")
     try:
+        first = True
         while True:
-            frames = pipe.wait_for_frames()
-            cframe = frames.get_color_frame()
-            if not cframe:
+            color = _read_frame()
+            if color is None:
                 continue
-            color = np.asanyarray(cframe.get_data())
+
+            # For non-RealSense, sync image_size to actual stream
+            if first and args.source != "realsense":
+                args.height, args.width = int(color.shape[0]), int(color.shape[1])
+                first = False
+
             gray = cv2.cvtColor(color, cv2.COLOR_BGR2GRAY)
 
             if has_charuco_detector:
@@ -166,8 +306,9 @@ def main():
                 corners, ids, _ = aruco.detectMarkers(gray, dictionary, parameters=det_params)
                 if ids is not None and len(ids) > 0:
                     aruco.refineDetectedMarkers(gray, board, corners, ids, rejectedCorners=None, parameters=det_params)
-                ret, ch_corners, ch_ids = aruco.interpolateCornersCharuco(
-                    markerCorners=corners, markerIds=ids, image=gray, board=board)
+                _, ch_corners, ch_ids = aruco.interpolateCornersCharuco(
+                    markerCorners=corners, markerIds=ids, image=gray, board=board
+                )
 
             vis = color.copy()
             if not has_charuco_detector and ids is not None and len(ids) > 0:
@@ -176,9 +317,10 @@ def main():
                 aruco.drawDetectedCornersCharuco(vis, ch_corners, ch_ids)
 
             good = ch_corners is not None and ch_ids is not None and len(ch_corners) >= args.min_corners
-            cv2.putText(vis, f"samples={len(samples_corners)}", (20,40), cv2.FONT_HERSHEY_SIMPLEX, 1, (0,255,255), 2)
-            cv2.putText(vis, "BOARD: OK" if good else "BOARD: not ready",
-                        (20,80), cv2.FONT_HERSHEY_SIMPLEX, 0.9, (0,200,0) if good else (0,0,255), 2)
+            cv2.putText(vis, f"samples={len(samples_corners)}", (20, 40),
+                        cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 255), 2)
+            cv2.putText(vis, "BOARD: OK" if good else "BOARD: not ready", (20, 80),
+                        cv2.FONT_HERSHEY_SIMPLEX, 0.9, (0, 200, 0) if good else (0, 0, 255), 2)
             cv2.imshow("ChArUco Calibration", vis)
             k = cv2.waitKey(1) & 0xFF
 
@@ -204,7 +346,7 @@ def main():
             elif k == ord('q'):
                 raise KeyboardInterrupt
     finally:
-        pipe.stop()
+        _stop()
         cv2.destroyAllWindows()
 
     need = max(10, args.min_samples)
@@ -218,12 +360,12 @@ def main():
 
     # ---- write YAML with explicit keys ----
     dist = np.asarray(dist, dtype=float).reshape(1, -1)  # ensure shape (1, N)
-    fx, fy, cx, cy = float(K[0,0]), float(K[1,1]), float(K[0,2]), float(K[1,2])
-    k1 = float(dist[0,0]) if dist.shape[1] > 0 else 0.0
-    k2 = float(dist[0,1]) if dist.shape[1] > 1 else 0.0
-    p1 = float(dist[0,2]) if dist.shape[1] > 2 else 0.0
-    p2 = float(dist[0,3]) if dist.shape[1] > 3 else 0.0
-    k3 = float(dist[0,4]) if dist.shape[1] > 4 else 0.0
+    fx, fy, cx, cy = float(K[0, 0]), float(K[1, 1]), float(K[0, 2]), float(K[1, 2])
+    k1 = float(dist[0, 0]) if dist.shape[1] > 0 else 0.0
+    k2 = float(dist[0, 1]) if dist.shape[1] > 1 else 0.0
+    p1 = float(dist[0, 2]) if dist.shape[1] > 2 else 0.0
+    p2 = float(dist[0, 3]) if dist.shape[1] > 3 else 0.0
+    k3 = float(dist[0, 4]) if dist.shape[1] > 4 else 0.0
 
     print(f"[i] Reprojection RMS = {ret:.3f} px")
     print("[i] K =\n", K)
@@ -248,6 +390,7 @@ def main():
     with open(args.out, "w") as f:
         yaml.safe_dump(data, f)
     print(f"[i] wrote {args.out}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION

Refresh the ChArUco calibration section to match the code: supports OpenCV webcams by default, RealSense and video as options; `--project_root` sets the default output to `<root>/calib/calib_color.yaml`. Replaces the previous RealSense-only .

new commands for `--source {opencv,realsense,video}`, note on project-aware default output, concise tips.