### PR TITLE
Docs/joss readiness ai usage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Report a reproducible bug in PoseTag.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug in PoseTag.
+
+        Please provide enough detail for another user or maintainer to
+        reproduce the issue. Scientific correctness and reproducibility matter
+        more than quick guesses, so concrete inputs, commands, and outputs are
+        especially helpful.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the bug and the expected behaviour.
+      placeholder: A short explanation of what happened and what you expected.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: List the exact steps needed to reproduce the problem.
+      placeholder: |
+        1. Install PoseTag with ...
+        2. Run ...
+        3. Open ...
+        4. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: inputs
+    attributes:
+      label: Inputs and data
+      description: Describe the calibration files, board YAMLs, media, or other inputs involved.
+      placeholder: Include file names, sample paths, units, resolutions, or minimal synthetic inputs when possible.
+    validations:
+      required: true
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed result
+      description: Paste the error, incorrect output, or unexpected behaviour.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result
+      description: Explain what should have happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Report the software environment used for the reproduction.
+      placeholder: |
+        - OS:
+        - Python version:
+        - Install method:
+        - Camera source:
+        - Optional dependencies in use:
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I confirmed this issue is reproducible with the steps above.
+          required: true
+        - label: I included enough detail for another person to attempt reproduction.
+          required: true
+        - label: If the issue may affect pose maths, calibration, units, or schemas, I described the scientific impact.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: PoseTag contribution guide
+    url: https://github.com/exponentialR/posetag/blob/develop/CONTRIBUTING.md
+    about: Read how to report reproducible issues, validate workflows, and propose changes.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature request
+description: Propose an improvement or new capability for PoseTag.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for proposed improvements to PoseTag.
+
+        Please focus on the user need, scientific or reproducibility benefit,
+        and likely workflow impact.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or need
+      description: What limitation, pain point, or missing capability are you trying to address?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the feature or improvement you want.
+    validations:
+      required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: Workflow impact
+      description: Explain which PoseTag workflow stages this would affect.
+      placeholder: For example calibration, board creation, annotation, collection, packaging, testing, or documentation.
+    validations:
+      required: true
+  - type: textarea
+    id: scientific
+    attributes:
+      label: Scientific and reproducibility considerations
+      description: Note any implications for pose conventions, units, schemas, validation, or reproducibility.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Describe any workaround or alternative you considered.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I explained why this request would help users or maintainers.
+          required: true
+        - label: I described any expected scientific, schema, or reproducibility impact.
+          required: true

--- a/.github/ISSUE_TEMPLATE/research_use_case.yml
+++ b/.github/ISSUE_TEMPLATE/research_use_case.yml
@@ -1,0 +1,58 @@
+name: Research use case
+description: Describe how PoseTag is being used or evaluated in research work.
+title: "[Research Use Case]: "
+labels:
+  - research-use
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to document a research, experimental, or evaluation
+        use case involving PoseTag.
+
+        These reports can help demonstrate public research use and clarify
+        future requirements.
+  - type: textarea
+    id: context
+    attributes:
+      label: Research context
+      description: Describe the project, task, or study in which PoseTag is being used.
+    validations:
+      required: true
+  - type: textarea
+    id: workflow
+    attributes:
+      label: PoseTag workflow used
+      description: Which stages or tools are part of your workflow?
+    validations:
+      required: true
+  - type: textarea
+    id: objects
+    attributes:
+      label: Objects, sensors, and data conditions
+      description: Describe relevant objects, camera setup, calibration assumptions, and capture conditions.
+    validations:
+      required: true
+  - type: textarea
+    id: outcomes
+    attributes:
+      label: Outcomes and value
+      description: What did PoseTag enable, and what evidence can be shared publicly?
+    validations:
+      required: true
+  - type: textarea
+    id: gaps
+    attributes:
+      label: Limitations or requested improvements
+      description: Describe missing features, pain points, or scientific concerns.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I am sharing only information that can be disclosed publicly.
+          required: true
+        - label: I described the use case clearly enough to help guide future development.
+          required: true

--- a/.github/ISSUE_TEMPLATE/workflow_validation.yml
+++ b/.github/ISSUE_TEMPLATE/workflow_validation.yml
@@ -1,0 +1,73 @@
+name: Workflow validation
+description: Record results from validating a documented PoseTag workflow.
+title: "[Workflow Validation]: "
+labels:
+  - workflow-validation
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template to document a successful or failed validation of a
+        PoseTag workflow.
+
+        These reports help build public evidence for installability,
+        documentation accuracy, and reproducibility.
+  - type: input
+    id: workflow_name
+    attributes:
+      label: Workflow name
+      description: Which workflow or stage did you validate?
+      placeholder: Installation, tag generation, calibration, board creation, annotation, dataset collection, or workflow linting.
+    validations:
+      required: true
+  - type: textarea
+    id: objective
+    attributes:
+      label: Validation objective
+      description: What were you trying to confirm?
+    validations:
+      required: true
+  - type: textarea
+    id: commands
+    attributes:
+      label: Commands run
+      description: List the exact commands or steps used.
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Report the environment used for validation.
+      placeholder: |
+        - OS:
+        - Python version:
+        - Install method:
+        - Camera or media source:
+        - Relevant optional dependencies:
+    validations:
+      required: true
+  - type: textarea
+    id: result
+    attributes:
+      label: Result
+      description: Describe what succeeded, what failed, and what outputs were produced.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Link or paste logs, screenshots, sample outputs, or notes that support the result.
+    validations:
+      required: false
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I included enough information for another person to repeat this validation.
+          required: true
+        - label: I described whether the documented instructions matched the actual behaviour.
+          required: true

--- a/AI_USAGE.md
+++ b/AI_USAGE.md
@@ -1,0 +1,57 @@
+# AI Usage Disclosure
+
+PoseTag was originally developed by the human author without generative AI
+assistance.
+
+During later repository preparation and maintenance, generative AI tools have
+been used in a limited assistive role. In particular, Codex has been used for
+implementation support, refactoring assistance, test scaffolding, documentation
+drafting, and repository cleanup.
+
+Additional conversational AI assistance may have been used for planning,
+prompt design, review of development strategy, and JOSS-readiness preparation.
+This assistance did not determine the core scientific design, pose conventions,
+software architecture, or research framing of PoseTag.
+
+## Scope of AI Assistance
+
+AI tools have been used to assist with:
+
+- repository audit and review
+- prompt design for implementation tasks
+- refactoring suggestions
+- test scaffolding
+- documentation drafting
+- JOSS-readiness planning
+- review of proposed maintenance and release-preparation steps
+
+## Human Review and Responsibility
+
+All accepted AI-assisted contributions were reviewed, edited where necessary,
+tested where applicable, and validated by the human author(s) before being
+incorporated into the project.
+
+The human author(s) made the core scientific, architectural, and design
+decisions for PoseTag, including decisions related to pose conventions,
+workflow design, software structure, documentation direction, and release
+planning.
+
+The human author(s) remain responsible for the correctness, originality,
+licensing compliance, and ethical/legal compliance of the repository and any
+associated publication materials.
+
+## JOSS Submission Note
+
+If PoseTag is submitted to the Journal of Open Source Software, this disclosure
+will be updated as needed to include the specific tools/models and versions used,
+and to align with the final JOSS paper text.
+
+Generative AI will not be used to produce conversational responses to JOSS
+editors or reviewers, except where explicitly permitted by JOSS policy, such as
+translation support.
+
+## Intended Use of This Disclosure
+
+This file is intended as a repository-level transparency statement and can be
+adapted later for release notes, contributor-facing documentation, or JOSS paper
+materials if required.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,112 @@
+# Contributing to PoseTag
+
+Thanks for contributing to PoseTag.
+
+PoseTag is scientific Python software for generating reproducible ground-truth
+6-DoF object poses. Contributions should prioritise scientific correctness,
+reproducibility, installability, and documentation accuracy over superficial
+cleanup.
+
+## Project Priorities
+
+When proposing changes, please keep these principles in mind:
+
+- preserve scientific correctness before convenience
+- preserve reproducibility before broad refactoring
+- keep pose conventions, units, schemas, and output assumptions explicit
+- prefer small, reviewable changes over wide cleanup passes
+- use canonical PoseTag naming where possible
+
+The core pose composition contract is:
+
+```text
+T_cam_object = T_cam_board @ T_board_object
+```
+
+Do not change pose maths, coordinate conventions, quaternion ordering, angle
+units, translation units, or output schemas casually. If a future change needs
+to affect those areas, it should be discussed explicitly and documented with
+tests.
+
+## Opening Useful Issues
+
+Please use the GitHub issue templates to keep reports reproducible and useful.
+
+- Use `Bug report` for reproducible failures or incorrect behaviour.
+- Use `Workflow validation` to report whether a documented workflow worked in
+  practice, including exact commands and environment details.
+- Use `Research use case` to document public research or evaluation contexts in
+  which PoseTag is being used.
+- Use `Feature request` for proposed improvements or missing capabilities.
+
+Helpful issue reports usually include:
+
+- the exact commands or steps you ran
+- relevant input files, media types, calibration assumptions, and resolutions
+- the observed output or error
+- the expected behaviour
+- the operating system, Python version, and install method
+- any scientific or reproducibility impact
+
+## Running Tests
+
+Run the current automated test suite from the repository root:
+
+```bash
+python3 -m unittest discover -s tests
+```
+
+If you touch packaging, naming compatibility, scientific logic, schemas, or
+workflow-critical behaviour, please add or update tests where possible.
+
+## Validating Workflow Steps
+
+If you change documentation, developer infrastructure, or GitHub workflow
+files, please validate the relevant steps and report the exact commands used.
+
+For GitHub Actions workflow linting, run:
+
+```bash
+./scripts/check-workflows.sh
+```
+
+That script uses a local `actionlint` binary when available, or Docker with the
+`rhysd/actionlint` image when Docker is running.
+
+For user-facing workflow validation, please record:
+
+- what workflow stage you validated
+- the commands and inputs used
+- the environment used
+- what outputs were produced
+- whether the documented instructions matched actual behaviour
+
+Opening a `Workflow validation` issue is a good way to capture that evidence in
+public.
+
+## Proposing Changes
+
+Before opening a pull request, please:
+
+1. read the relevant code and docs carefully
+2. identify the scientific or workflow invariant that must be preserved
+3. keep the change set as small and coherent as practical
+4. update tests and docs when public behaviour changes
+5. explain the motivation, scope, and verification in the pull request
+
+Good pull requests usually make it easy to answer:
+
+- what changed
+- why it changed
+- how it was tested or validated
+- whether any naming, schema, or workflow behaviour changed
+
+## Documentation and Open Development Evidence
+
+PoseTag is being prepared for a reproducible scientific software release and a
+future JOSS submission. Public issues, validation reports, contributor
+discussion, and documented fixes all help build evidence of healthy open
+development.
+
+If you identify a documentation mismatch, installation problem, workflow gap,
+or reproducibility concern, reporting it clearly is a valuable contribution.

--- a/JOSS_READINESS.md
+++ b/JOSS_READINESS.md
@@ -1,0 +1,231 @@
+# PoseTag JOSS Readiness Checklist
+
+This document is a living checklist for preparing PoseTag for a future
+Journal of Open Source Software (JOSS) submission.
+
+This checklist is a planning document, not a claim that PoseTag is currently
+ready for JOSS submission.
+
+It is intended to help track repository, packaging, documentation,
+reproducibility, governance, and paper-preparation work without changing the
+scientific contract of the software.
+
+## How to use this checklist
+
+- Update status as work progresses.
+- Add links or short notes as evidence where useful.
+- Prefer concrete evidence over assumptions.
+- If a requirement is only partially met, mark it clearly and record the gap.
+
+Suggested status markers:
+
+- `[ ]` Not yet satisfied
+- `[~]` In progress or partially satisfied
+- `[x]` Satisfied
+
+---
+
+## 1. Repository Availability and Public Access
+
+- [ ] Repository is public and accessible without special credentials.
+- [ ] Repository can be cloned by an external user from the canonical public URL.
+- [ ] Default branch and active development branch are clear to outside users.
+- [ ] Repository metadata uses the canonical PoseTag identity consistently.
+- [ ] Archived or legacy repository names, if any, are explained or redirected.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 2. Licensing
+
+- [ ] Repository includes an OSI-approved licence file.
+- [ ] Package metadata and repository licence information agree.
+- [ ] Third-party assets, models, sample data, and generated artefacts have
+  compatible licensing or clear exclusions.
+- [ ] Any bundled dependencies or copied code have appropriate attribution.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 3. Issue Tracker and Public Development
+
+- [ ] Public issue tracker is enabled and visible.
+- [ ] Users can report bugs, ask questions, and request features publicly.
+- [ ] At least six months of public development history exists before
+  submission.
+- [ ] Commit and issue history shows active software development rather than a
+  one-time code dump.
+- [ ] Important design or maintenance decisions are discoverable from issues,
+  PRs, or project docs.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 4. Demonstrated Research Use
+
+- [ ] PoseTag has been used in real research, internal experiments, or
+  reproducible pilot studies.
+- [ ] There is a clear statement of the research problem PoseTag supports.
+- [ ] Example outputs or datasets demonstrate the software in practice.
+- [ ] Any claims about scientific use are supportable with citations, reports,
+  or public artefacts.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 5. Installability
+
+- [ ] Fresh-clone installation works on a supported Python version.
+- [ ] Editable install works for development workflows.
+- [ ] Install instructions are documented and match the actual package state.
+- [ ] Core CLI entry points resolve after installation.
+- [ ] Optional dependencies and extras are documented clearly.
+- [ ] Platform-specific dependencies are called out explicitly.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 6. Documentation
+
+- [ ] README explains what PoseTag does and who it is for.
+- [ ] Installation instructions are current and tested.
+- [ ] Core workflows are documented end to end.
+- [ ] Scientific conventions are documented explicitly.
+- [ ] Inputs, outputs, file layouts, and required metadata are described.
+- [ ] Common failure modes and troubleshooting guidance are documented.
+- [ ] Canonical PoseTag commands, package names, and migration notes are
+  consistent across docs.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 7. Tests and Continuous Integration
+
+- [ ] Automated tests exist for critical scientific and schema invariants.
+- [ ] Test suite runs in CI on supported platforms or Python versions.
+- [ ] CI status is visible publicly.
+- [ ] Packaging or install smoke checks run in CI.
+- [ ] Failures are actionable and not ignored routinely.
+- [ ] Coverage is sufficient for the current maturity of the project.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 8. Contribution Process and Governance
+
+- [ ] Contribution guidance exists for new contributors.
+- [ ] Maintainer expectations for issues, PRs, and review are documented.
+- [ ] Code of conduct or equivalent contributor expectations are available.
+- [ ] Development setup is documented for contributors.
+- [ ] Decision-making and review responsibilities are clear enough for an
+  external reviewer to understand project stewardship.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 9. Releases and Changelog
+
+- [ ] Tagged releases exist or a release plan is documented.
+- [ ] Versioning approach is clear and consistent.
+- [ ] Changes between releases are documented in a changelog or release notes.
+- [ ] Release artefacts are reproducible and correspond to repository tags.
+- [ ] Breaking changes or migration steps are documented where relevant.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 10. Citation Metadata
+
+- [ ] `CITATION.cff` or equivalent citation metadata exists.
+- [ ] Citation metadata matches repository authorship and title.
+- [ ] Citation guidance is visible to users in the repository.
+- [ ] DOI strategy is defined if releases will be archived through Zenodo or a
+  similar service.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 11. JOSS Paper Materials
+
+- [ ] JOSS paper repository materials are prepared in the expected format.
+- [ ] Paper includes summary, statement of need, and references.
+- [ ] Paper claims match what the software currently does.
+- [ ] Installation and usage described in the paper match the repository.
+- [ ] Author list, affiliations, and acknowledgements are ready.
+- [ ] Review-facing reproducibility notes are collected.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## 12. AI Usage Disclosure
+
+- [ ] Repository contains a clear disclosure describing any AI-assisted repository preparation, maintenance, documentation, or development work.
+- [ ] Scope of AI assistance is described accurately.
+- [ ] Human review, editing, testing, and validation responsibilities are
+  stated explicitly.
+- [ ] Human responsibility for scientific, architectural, legal, and
+  publication decisions is stated explicitly.
+- [ ] JOSS paper materials can be updated consistently with the repository
+  disclosure if needed.
+
+Notes:
+
+- Evidence:
+- Open questions:
+
+---
+
+## Recommended Pre-Submission Review Pass
+
+Before submitting to JOSS, confirm all of the following:
+
+- [ ] A new external user can install and run the documented PoseTag workflow.
+- [ ] Scientific assumptions and output conventions are explicit and tested.
+- [ ] Repository naming, package naming, and CLI naming are consistent.
+- [ ] Public metadata, citation files, and paper materials agree.
+- [ ] AI usage disclosure is present and aligned with the final paper text.
+


### PR DESCRIPTION
This PR adds lightweight documentation and GitHub issue infrastructure to support PoseTag's JOSS-oriented open development.

It adds:

- `JOSS_READINESS.md`
- `AI_USAGE.md`
- `CONTRIBUTING.md`
- issue templates for bug reports, feature requests, workflow validation, and research use cases

Closes #23  
Closes #24

## Scope

- documentation-only
- no code changes
- no packaging changes
- no scientific behaviour changes
---


Reviewed the new docs and templates for consistency with the current repository workflow, including:
