### PR TITLE
Validate Step 1 ChArUco calibration workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,10 @@ htmlcov/
 .venv/
 venv/
 env/
+
+# Local PoseTag projects and generated calibration/capture artifacts
+my_project/
+
+# Editable-install/build metadata
+*.egg-info/
+src/*.egg-info/

--- a/README.md
+++ b/README.md
@@ -178,30 +178,41 @@ output; otherwise it reports that PDF output is optional and continues.
 
 Press `SPACE` to capture a sample and `ENTER` to solve. Outputs a
 `calib_color.yaml` containing `fx`, `fy`, `cx`, `cy`, distortion, image size,
-and reprojection RMS. With `--project_root`, output defaults to
-`<root>/calib/calib_color.yaml`.
+and reprojection RMS. With `--project_root`, the latest calibration defaults to
+`<root>/calib/calib_color.yaml`. Each run also stores raw calibration samples
+under `<root>/calib/images/set_XX/` and a timestamped snapshot under
+`<root>/calib/runs/<UTC-timestamp>/`.
 
 **Generic webcam**
 
 ```bash
-posetag-calib-charuco --source opencv --cam 0 \
-  --squares-x 5 --squares-y 3 --square-length-mm 50 --marker-length-mm 37 --dict 7X7_100
+posetag-calib-charuco --project_root my_project --source opencv --cam 0 \
+  --squares-x 3 --squares-y 5 --square-length-mm 50 --marker-length-mm 37 --dict 7X7_50
 ```
 
 **Intel RealSense**
 
 ```bash
-posetag-calib-charuco --source realsense --width 640 --height 480 --fps 30
+posetag-calib-charuco --project_root my_project --source realsense \
+  --width 640 --height 480 --fps 30 \
+  --squares-x 3 --squares-y 5 --square-length-mm 50 --marker-length-mm 37 --dict 7X7_50
 ```
 
 **Video file**
 
 ```bash
-posetag-calib-charuco --source video --video sample.mp4
+posetag-calib-charuco --project_root my_project --source video --video sample.mp4 \
+  --squares-x 3 --squares-y 5 --square-length-mm 50 --marker-length-mm 37 --dict 7X7_50
 ```
 
-Keep print scale at 100%. OpenCV webcams treat `--width` / `--height` as
+Keep print scale at `100%` / `Actual size`, and ensure `--squares-x`,
+`--squares-y`, `--square-length-mm`, `--marker-length-mm`, and `--dict` match
+the printed ChArUco board. OpenCV webcams treat `--width` / `--height` as
 best-effort; the YAML records the actual stream size used during calibration.
+Use the recorded `image_width` / `image_height` for downstream capture.
+
+For the full Step 1 contract, failure modes, and verification checklist, see
+[`docs/workflows/step1_calibrate_charuco.md`](docs/workflows/step1_calibrate_charuco.md).
 
 Sample `calib_color.yaml`:
 

--- a/STEP1_CALIBRATION_REPORT.md
+++ b/STEP1_CALIBRATION_REPORT.md
@@ -32,6 +32,7 @@ leaving the legacy calibration loop in place as temporary technical debt.
   calibration output folders.
 - Unreadable video paths fail before creating calibration output folders.
 - Video EOF exits the capture loop with a clear message instead of hanging.
+- Pressing `q` exits cleanly without solving or printing a traceback.
 - `--source realsense` fails clearly when `pyrealsense2` is unavailable.
 - Invalid ArUco dictionary names fail clearly and list supported dictionary
   names.
@@ -87,6 +88,7 @@ Hardware-free tests added for:
 - Missing `--video` validation.
 - Missing/unreadable video path validation before project artifacts are created.
 - Video EOF behavior.
+- Clean `q` exit behavior.
 - Missing RealSense dependency validation.
 - Legacy script `--help` resolution from a checkout.
 - Project IO layout creation.

--- a/STEP1_CALIBRATION_REPORT.md
+++ b/STEP1_CALIBRATION_REPORT.md
@@ -1,0 +1,125 @@
+# Step 1 Calibration Report
+
+## Current Implementation Summary
+
+Step 1 is exposed through the canonical PoseTag command:
+
+```bash
+posetag-calib-charuco
+```
+
+The command entry point is `posetag.cli.charuco:main`. It remains a thin
+wrapper around the existing `utils.charuco_calibrate` implementation. That
+legacy module still owns the interactive OpenCV capture loop and ChArUco
+calibration solve. This is intentional for issue #28: no calibration maths,
+coordinate conventions, units, or algorithms were changed.
+
+Reusable validation, project IO, dictionary parsing, and YAML serialization
+helpers now live in:
+
+```text
+src/posetag/pipelines/charuco_calibration.py
+```
+
+This keeps new testable behavior under the canonical `posetag` namespace while
+leaving the legacy calibration loop in place as temporary technical debt.
+
+## What Was Fixed
+
+- `posetag-calib-charuco --help` can be exercised through the canonical CLI
+  wrapper with explicit argv.
+- `--source video` without `--video` fails before opening hardware or creating
+  calibration output folders.
+- `--source realsense` fails clearly when `pyrealsense2` is unavailable.
+- Invalid ArUco dictionary names fail clearly and list supported dictionary
+  names.
+- Project calibration IO preparation is reusable and hardware-free.
+- Default latest output path is deterministic:
+
+```text
+<project_root>/calib/calib_color.yaml
+```
+
+- Each run creates:
+
+```text
+<project_root>/calib/images/set_XX/
+<project_root>/calib/runs/<UTC-timestamp>/
+```
+
+- Explicit `--out` overrides the latest calibration output path.
+- Calibration YAML schema generation and writing can be tested with synthetic
+  calibration values.
+- README Step 1 now reflects the canonical command and actual output layout.
+- Added a dedicated workflow document:
+
+```text
+docs/workflows/step1_calibrate_charuco.md
+```
+
+## Commands Tested
+
+Exact commands run during this validation:
+
+```bash
+python3 -m unittest tests.test_step1_charuco_calibration -v
+python3 -m unittest discover -s tests -v
+python3 -m pip install -e .
+/Users/samueladebayo/Library/Python/3.11/bin/posetag-calib-charuco --help
+/Users/samueladebayo/Library/Python/3.11/bin/posetag-calib-charuco --source video
+/Users/samueladebayo/Library/Python/3.11/bin/posetag-calib-charuco --dict bogus
+/Users/samueladebayo/Library/Python/3.11/bin/posetag-calib-charuco --source realsense
+```
+
+The installed script directory was not on this shell's `PATH`, so the installed
+console script was invoked by absolute path.
+
+Hardware-free tests added for:
+
+- CLI help resolution.
+- Dictionary parsing success and failure.
+- Missing `--video` validation.
+- Missing RealSense dependency validation.
+- Project IO layout creation.
+- Explicit `--out` override.
+- Calibration YAML schema writing and `yaml.safe_load` round-trip.
+
+Manual hardware-dependent validation remains required for actual webcam,
+RealSense, and video calibration quality because this patch deliberately avoids
+mocking the OpenCV solve path beyond YAML serialization.
+
+## Outputs And Schema Verified
+
+The generated calibration YAML round-trips with `yaml.safe_load` and contains:
+
+- `image_width`
+- `image_height`
+- `camera_matrix`
+- `distortion_coefficients`
+- `reproj_rms`
+- `model`
+- `notes`
+
+The schema remains compatible with the existing sample in the README:
+
+```yaml
+model: plumb_bob
+notes: ChArUco 3x5, square=50.0mm, marker=37.0mm, dict=7X7_50
+```
+
+## Remaining Technical Debt
+
+- The canonical CLI still delegates to `utils.charuco_calibrate`, a legacy
+  top-level module.
+- The interactive capture loop, OpenCV display code, and calibration solve are
+  still coupled in that legacy module.
+- Hardware-backed smoke tests are not automated; manual webcam, RealSense, and
+  representative video validation should be recorded separately.
+- The project still depends on OpenCV's installed ChArUco API shape, so
+  cross-version manual checks are useful before a release.
+
+## Next Recommended Workflow Step
+
+Proceed to Step 2 validation only after a real calibration run has produced a
+reasonable `reproj_rms`, and after confirming downstream capture will use the
+same `image_width` and `image_height` recorded in `calib_color.yaml`.

--- a/STEP1_CALIBRATION_REPORT.md
+++ b/STEP1_CALIBRATION_REPORT.md
@@ -39,7 +39,8 @@ leaving the legacy calibration loop in place as temporary technical debt.
 - The UI sample threshold now matches the solver threshold by default:
   `--min-corners` defaults to `4`, and smaller values are promoted to `4`.
 - Direct checkout usage of `python utils/charuco_calibrate.py --help` is
-  preserved as a temporary legacy-script compatibility path.
+  preserved as a temporary legacy-script compatibility path by adding both the
+  repository root and `src/` to `sys.path` when needed.
 - Project calibration IO preparation is reusable and hardware-free.
 - Default latest output path is deterministic:
 

--- a/STEP1_CALIBRATION_REPORT.md
+++ b/STEP1_CALIBRATION_REPORT.md
@@ -30,9 +30,15 @@ leaving the legacy calibration loop in place as temporary technical debt.
   wrapper with explicit argv.
 - `--source video` without `--video` fails before opening hardware or creating
   calibration output folders.
+- Unreadable video paths fail before creating calibration output folders.
+- Video EOF exits the capture loop with a clear message instead of hanging.
 - `--source realsense` fails clearly when `pyrealsense2` is unavailable.
 - Invalid ArUco dictionary names fail clearly and list supported dictionary
   names.
+- The UI sample threshold now matches the solver threshold by default:
+  `--min-corners` defaults to `4`, and smaller values are promoted to `4`.
+- Direct checkout usage of `python utils/charuco_calibrate.py --help` is
+  preserved as a temporary legacy-script compatibility path.
 - Project calibration IO preparation is reusable and hardware-free.
 - Default latest output path is deterministic:
 
@@ -79,7 +85,10 @@ Hardware-free tests added for:
 - CLI help resolution.
 - Dictionary parsing success and failure.
 - Missing `--video` validation.
+- Missing/unreadable video path validation before project artifacts are created.
+- Video EOF behavior.
 - Missing RealSense dependency validation.
+- Legacy script `--help` resolution from a checkout.
 - Project IO layout creation.
 - Explicit `--out` override.
 - Calibration YAML schema writing and `yaml.safe_load` round-trip.

--- a/docs/workflows/step1_calibrate_charuco.md
+++ b/docs/workflows/step1_calibrate_charuco.md
@@ -76,6 +76,10 @@ When `--out` is omitted, the latest calibration is always written to:
 - `--dict`
   ArUco dictionary name, for example `4X4_50`, `5X5_250`, `6X6_1000`,
   `7X7_50`, or `APRILTAG_36H11`.
+- `--min-corners`
+  Minimum detected ChArUco corners required before the UI marks a sample as
+  acceptable. The default is `4`, matching the minimum used before solving.
+  Smaller user-supplied values are promoted to `4`.
 
 The command fails before opening hardware if the dictionary name is not
 supported by the installed OpenCV build.
@@ -181,6 +185,10 @@ Required top-level fields:
 - `--source video` without `--video` fails with a clear message.
 - `--source realsense` fails clearly when `pyrealsense2` is not installed.
 - Unsupported dictionary names fail before opening camera hardware.
+- Missing or unreadable video paths fail before creating calibration run
+  folders.
+- Video EOF exits the capture loop with a clear message instead of waiting
+  forever for keyboard input.
 - A webcam index that cannot be opened reports the failing camera index.
 - A video path that cannot be opened reports the failing path.
 - Too few accepted samples, or too few samples after corner-count filtering,

--- a/docs/workflows/step1_calibrate_charuco.md
+++ b/docs/workflows/step1_calibrate_charuco.md
@@ -1,0 +1,205 @@
+# Step 1: Calibrate The Colour Camera With ChArUco
+
+This workflow validates the PoseTag Step 1 command:
+
+```bash
+posetag-calib-charuco --project_root <path> --source opencv --cam 0
+```
+
+Step 1 estimates colour-camera intrinsics and lens distortion from a printed
+ChArUco board. The calibration algorithm and OpenCV model are unchanged from
+the legacy implementation; this document records the user-facing contract,
+outputs, and checks needed before moving to Step 2.
+
+## Scientific Assumptions
+
+- The printed ChArUco board must be flat, rigid, and printed at `100%` /
+  `Actual size`.
+- `--square-length-mm` is the physical side length of one chessboard square in
+  millimetres.
+- `--marker-length-mm` is the physical side length of the ArUco marker inside
+  each square in millimetres.
+- The dictionary passed with `--dict` must match the printed board exactly.
+- Calibration is for the colour image stream only.
+- OpenCV webcam resolution requests are best effort. PoseTag records the actual
+  image size used for calibration in `image_width` and `image_height`.
+- Downstream capture should use the same colour resolution recorded in
+  `calib_color.yaml`.
+
+## Command Examples
+
+Generic OpenCV webcam:
+
+```bash
+posetag-calib-charuco --project_root my_project --source opencv --cam 0 \
+  --squares-x 3 --squares-y 5 --square-length-mm 50 --marker-length-mm 37 --dict 7X7_50
+```
+
+Intel RealSense colour stream:
+
+```bash
+posetag-calib-charuco --project_root my_project --source realsense \
+  --width 640 --height 480 --fps 30 \
+  --squares-x 3 --squares-y 5 --square-length-mm 50 --marker-length-mm 37 --dict 7X7_50
+```
+
+Video file:
+
+```bash
+posetag-calib-charuco --project_root my_project --source video --video sample.mp4 \
+  --squares-x 3 --squares-y 5 --square-length-mm 50 --marker-length-mm 37 --dict 7X7_50
+```
+
+Explicit output override:
+
+```bash
+posetag-calib-charuco --project_root my_project --source video --video sample.mp4 \
+  --out exported/calib_color.yaml
+```
+
+When `--out` is omitted, the latest calibration is always written to:
+
+```text
+<project_root>/calib/calib_color.yaml
+```
+
+## Board Arguments
+
+- `--squares-x`
+  Number of ChArUco squares along the board x direction.
+- `--squares-y`
+  Number of ChArUco squares along the board y direction.
+- `--square-length-mm`
+  Physical square size in millimetres.
+- `--marker-length-mm`
+  Physical marker size in millimetres.
+- `--dict`
+  ArUco dictionary name, for example `4X4_50`, `5X5_250`, `6X6_1000`,
+  `7X7_50`, or `APRILTAG_36H11`.
+
+The command fails before opening hardware if the dictionary name is not
+supported by the installed OpenCV build.
+
+## Controls
+
+- `SPACE`: save the current frame as a calibration sample when enough ChArUco
+  corners are detected.
+- `ENTER`: solve calibration from the collected samples.
+- `q`: quit without solving.
+
+Use diverse views: move and tilt the board so it appears across the frame,
+including near corners and edges, while avoiding blur and glare.
+
+## Project Directory Side Effects
+
+With `--project_root my_project`, PoseTag initializes or reuses:
+
+```text
+my_project/
+  boards/
+  shots/
+  objects/
+  datasets/
+  calib/
+    calib_color.yaml
+    images/
+      set_01/
+    runs/
+      <UTC-timestamp>/
+        config.yaml
+        calib_color.yaml
+```
+
+Each calibration invocation creates a new sample image folder:
+
+```text
+<project_root>/calib/images/set_01/
+<project_root>/calib/images/set_02/
+...
+```
+
+Each invocation also creates a timestamped run snapshot:
+
+```text
+<project_root>/calib/runs/YYYY-MM-DDTHH-MM-SSZ/
+```
+
+The latest calibration path remains deterministic:
+
+```text
+<project_root>/calib/calib_color.yaml
+```
+
+If `--out <path>` is supplied, the latest calibration YAML is written to that
+path instead. The run snapshot still stores a copy at:
+
+```text
+<project_root>/calib/runs/<UTC-timestamp>/calib_color.yaml
+```
+
+## Calibration YAML Schema
+
+The output YAML round-trips with `yaml.safe_load` and contains:
+
+```yaml
+image_width: 640
+image_height: 480
+camera_matrix:
+  fx: 600.0
+  fy: 610.0
+  cx: 320.0
+  cy: 240.0
+  data:
+  - [600.0, 0.0, 320.0]
+  - [0.0, 610.0, 240.0]
+  - [0.0, 0.0, 1.0]
+distortion_coefficients:
+  k1: -0.1
+  k2: 0.02
+  p1: 0.001
+  p2: -0.002
+  k3: 0.0
+  data:
+  - [-0.1, 0.02, 0.001, -0.002, 0.0]
+reproj_rms: 0.123
+model: plumb_bob
+notes: ChArUco 3x5, square=50.0mm, marker=37.0mm, dict=7X7_50
+```
+
+Required top-level fields:
+
+- `image_width`
+- `image_height`
+- `camera_matrix`
+- `distortion_coefficients`
+- `reproj_rms`
+- `model`
+- `notes`
+
+## Common Failure Modes
+
+- `--source video` without `--video` fails with a clear message.
+- `--source realsense` fails clearly when `pyrealsense2` is not installed.
+- Unsupported dictionary names fail before opening camera hardware.
+- A webcam index that cannot be opened reports the failing camera index.
+- A video path that cannot be opened reports the failing path.
+- Too few accepted samples, or too few samples after corner-count filtering,
+  stops before writing calibration output.
+- Poor print scale, glare, blur, or using the wrong dictionary can cause weak
+  detections and high reprojection error.
+
+## Verify Before Step 2
+
+Before building boards in Step 2:
+
+1. Confirm the YAML exists at `<project_root>/calib/calib_color.yaml` or at the
+   explicit `--out` path you supplied.
+2. Load it with `yaml.safe_load` and confirm the required top-level fields are
+   present.
+3. Check `image_width` and `image_height`; use the same colour resolution in
+   downstream capture.
+4. Inspect `reproj_rms`. Lower is better; unexpectedly large values suggest
+   blur, wrong board dimensions, wrong dictionary, insufficient viewpoint
+   diversity, or print scaling errors.
+5. Check `<project_root>/calib/runs/<timestamp>/config.yaml` to confirm the
+   board dimensions, dictionary, source, and sample count match the run.

--- a/docs/workflows/step1_calibrate_charuco.md
+++ b/docs/workflows/step1_calibrate_charuco.md
@@ -89,7 +89,7 @@ supported by the installed OpenCV build.
 - `SPACE`: save the current frame as a calibration sample when enough ChArUco
   corners are detected.
 - `ENTER`: solve calibration from the collected samples.
-- `q`: quit without solving.
+- `q`: quit cleanly without solving or writing a calibration YAML.
 
 Use diverse views: move and tilt the board so it appears across the frame,
 including near corners and edges, while avoiding blur and glare.

--- a/src/posetag/cli/charuco.py
+++ b/src/posetag/cli/charuco.py
@@ -1,7 +1,7 @@
 """PoseTag CLI wrapper for ChArUco camera calibration."""
 
 
-def main():
+def main(argv=None):
     from utils.charuco_calibrate import main as _main
 
-    return _main()
+    return _main(argv)

--- a/src/posetag/pipelines/charuco_calibration.py
+++ b/src/posetag/pipelines/charuco_calibration.py
@@ -1,0 +1,211 @@
+"""Reusable helpers for PoseTag Step 1 ChArUco camera calibration.
+
+This module intentionally keeps camera capture and calibration solving in the
+existing CLI implementation for now.  The helpers here cover validation,
+project IO preparation, and YAML serialization so they can be tested without
+camera hardware.
+"""
+
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Union
+
+import cv2
+import numpy as np
+import yaml
+
+from posetag.utils.project_config import ensure_project_dirs, resolve_project_root
+
+
+class CharucoCalibrationError(ValueError):
+    """User-facing validation error for ChArUco calibration setup."""
+
+
+@dataclass(frozen=True)
+class CalibrationProjectIO:
+    """Resolved Step 1 project paths."""
+
+    project_root: Path
+    calib_dir: Path
+    images_dir: Path
+    run_dir: Path
+    out_yaml: Path
+
+
+def _aruco_module():
+    aruco = getattr(cv2, "aruco", None)
+    if aruco is None:
+        raise CharucoCalibrationError(
+            "Installed OpenCV build does not provide cv2.aruco; install an "
+            "OpenCV build with ArUco/ChArUco support."
+        )
+    return aruco
+
+
+def _dictionary_ids() -> dict[str, Optional[int]]:
+    aruco = _aruco_module()
+    return {
+        "4X4_50": getattr(aruco, "DICT_4X4_50", None),
+        "4X4_100": getattr(aruco, "DICT_4X4_100", None),
+        "4X4_250": getattr(aruco, "DICT_4X4_250", None),
+        "4X4_1000": getattr(aruco, "DICT_4X4_1000", None),
+        "5X5_50": getattr(aruco, "DICT_5X5_50", None),
+        "5X5_100": getattr(aruco, "DICT_5X5_100", None),
+        "5X5_250": getattr(aruco, "DICT_5X5_250", None),
+        "5X5_1000": getattr(aruco, "DICT_5X5_1000", None),
+        "6X6_50": getattr(aruco, "DICT_6X6_50", None),
+        "6X6_100": getattr(aruco, "DICT_6X6_100", None),
+        "6X6_250": getattr(aruco, "DICT_6X6_250", None),
+        "6X6_1000": getattr(aruco, "DICT_6X6_1000", None),
+        "7X7_50": getattr(aruco, "DICT_7X7_50", None),
+        "7X7_100": getattr(aruco, "DICT_7X7_100", None),
+        "7X7_250": getattr(aruco, "DICT_7X7_250", None),
+        "7X7_1000": getattr(aruco, "DICT_7X7_1000", None),
+        "APRILTAG_36H11": getattr(aruco, "DICT_APRILTAG_36h11", None),
+    }
+
+
+def supported_dictionary_names() -> list[str]:
+    """Return the ChArUco/Aruco dictionary names supported by this OpenCV build."""
+
+    return sorted(name for name, value in _dictionary_ids().items() if value is not None)
+
+
+def normalize_dictionary_name(name: str) -> str:
+    """Normalize user-facing dictionary spelling without changing semantics."""
+
+    return name.upper().replace("-", "_")
+
+
+def get_dictionary(name: str):
+    """Return an OpenCV ArUco dictionary object from a user-facing name."""
+
+    normalized = normalize_dictionary_name(name)
+    aruco = _aruco_module()
+    dictionary_id = _dictionary_ids().get(normalized)
+    if dictionary_id is None:
+        supported = ", ".join(supported_dictionary_names())
+        raise CharucoCalibrationError(
+            f"Unsupported ArUco dictionary '{name}'. Supported dictionaries: {supported}"
+        )
+    return aruco.getPredefinedDictionary(dictionary_id)
+
+
+def validate_capture_args(source: str, video: Optional[str], realsense_module: Any) -> None:
+    """Validate source-specific arguments before opening hardware or writing files."""
+
+    if source == "video" and not video:
+        raise CharucoCalibrationError("--video path is required when --source=video")
+    if source == "realsense" and realsense_module is None:
+        raise CharucoCalibrationError(
+            "pyrealsense2 is not available; install PoseTag with the 'realsense' "
+            "extra or use --source opencv|video"
+        )
+
+
+def now_iso_utc() -> str:
+    """Return the run-directory timestamp format used by Step 1."""
+
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
+
+
+def prepare_project_io(
+    project_root: Optional[Union[Path, str]],
+    out: Optional[Union[Path, str]] = None,
+    timestamp: Optional[str] = None,
+) -> CalibrationProjectIO:
+    """Resolve the PoseTag project and create deterministic Step 1 output paths."""
+
+    pr = Path(resolve_project_root(project_root))
+    ensure_project_dirs(pr)
+
+    calib_dir = pr / "calib"
+    images_root = calib_dir / "images"
+    runs_root = calib_dir / "runs"
+    calib_dir.mkdir(parents=True, exist_ok=True)
+    images_root.mkdir(parents=True, exist_ok=True)
+    runs_root.mkdir(parents=True, exist_ok=True)
+
+    existing_indices: list[int] = []
+    for path in images_root.iterdir():
+        if not path.is_dir() or not path.name.startswith("set_"):
+            continue
+        try:
+            existing_indices.append(int(path.name.split("_")[-1]))
+        except ValueError:
+            continue
+    next_index = max(existing_indices, default=0) + 1
+    images_dir = images_root / f"set_{next_index:02d}"
+    images_dir.mkdir(parents=True, exist_ok=True)
+
+    run_dir = runs_root / (timestamp or now_iso_utc())
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    out_yaml = Path(out).expanduser() if out else calib_dir / "calib_color.yaml"
+    out_yaml.parent.mkdir(parents=True, exist_ok=True)
+
+    return CalibrationProjectIO(
+        project_root=pr,
+        calib_dir=calib_dir,
+        images_dir=images_dir,
+        run_dir=run_dir,
+        out_yaml=out_yaml,
+    )
+
+
+def build_calibration_yaml(
+    image_width: int,
+    image_height: int,
+    camera_matrix: Any,
+    distortion_coefficients: Any,
+    reproj_rms: float,
+    notes: str,
+    model: str = "plumb_bob",
+) -> dict[str, Any]:
+    """Build the public calibration YAML schema from solved intrinsics."""
+
+    k = np.asarray(camera_matrix, dtype=float)
+    dist = np.asarray(distortion_coefficients, dtype=float).reshape(1, -1)
+
+    fx, fy = float(k[0, 0]), float(k[1, 1])
+    cx, cy = float(k[0, 2]), float(k[1, 2])
+    k1 = float(dist[0, 0]) if dist.shape[1] > 0 else 0.0
+    k2 = float(dist[0, 1]) if dist.shape[1] > 1 else 0.0
+    p1 = float(dist[0, 2]) if dist.shape[1] > 2 else 0.0
+    p2 = float(dist[0, 3]) if dist.shape[1] > 3 else 0.0
+    k3 = float(dist[0, 4]) if dist.shape[1] > 4 else 0.0
+
+    return {
+        "image_width": int(image_width),
+        "image_height": int(image_height),
+        "camera_matrix": {
+            "fx": fx,
+            "fy": fy,
+            "cx": cx,
+            "cy": cy,
+            "data": k.tolist(),
+        },
+        "distortion_coefficients": {
+            "k1": k1,
+            "k2": k2,
+            "p1": p1,
+            "p2": p2,
+            "k3": k3,
+            "data": dist.tolist(),
+        },
+        "reproj_rms": float(reproj_rms),
+        "model": model,
+        "notes": notes,
+    }
+
+
+def write_calibration_yaml(path: Union[Path, str], data: dict[str, Any]) -> None:
+    """Write calibration YAML using the public schema."""
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with target.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(data, handle)

--- a/tests/test_step1_charuco_calibration.py
+++ b/tests/test_step1_charuco_calibration.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import numpy as np
+import yaml
+
+from posetag.cli import charuco as charuco_cli
+from posetag.pipelines.charuco_calibration import (
+    CharucoCalibrationError,
+    build_calibration_yaml,
+    get_dictionary,
+    prepare_project_io,
+    write_calibration_yaml,
+)
+
+
+class CharucoCalibrationStep1Tests(unittest.TestCase):
+    def test_cli_help_resolves(self) -> None:
+        stdout = StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            with redirect_stdout(stdout):
+                charuco_cli.main(["--help"])
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("Colour ChArUco calibration", stdout.getvalue())
+        self.assertIn("--source", stdout.getvalue())
+
+    def test_console_script_target_help_resolves_after_install(self) -> None:
+        code = (
+            "from posetag.cli.charuco import main\n"
+            "try:\n"
+            "    main(['--help'])\n"
+            "except SystemExit as exc:\n"
+            "    raise SystemExit(exc.code)\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Colour ChArUco calibration", result.stdout)
+
+    def test_dictionary_parsing_accepts_valid_name(self) -> None:
+        dictionary = get_dictionary("7X7_50")
+
+        self.assertIsNotNone(dictionary)
+
+    def test_dictionary_parsing_rejects_invalid_name_clearly(self) -> None:
+        with self.assertRaises(CharucoCalibrationError) as ctx:
+            get_dictionary("not-a-dictionary")
+
+        self.assertIn("Unsupported ArUco dictionary", str(ctx.exception))
+        self.assertIn("7X7_50", str(ctx.exception))
+
+    def test_missing_video_for_video_source_fails_clearly(self) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            charuco_cli.main(["--source", "video"])
+
+        self.assertIn("--video path is required", str(ctx.exception))
+
+    def test_realsense_source_without_dependency_fails_clearly(self) -> None:
+        with patch("utils.charuco_calibrate.rs", None):
+            with self.assertRaises(SystemExit) as ctx:
+                charuco_cli.main(["--source", "realsense"])
+
+        self.assertIn("pyrealsense2 is not available", str(ctx.exception))
+
+    def test_project_io_preparation_creates_calibration_layout(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            env = {
+                "HOME": str(base / "home"),
+                "XDG_CONFIG_HOME": str(base / ".config"),
+            }
+
+            with patch.dict(os.environ, env, clear=False):
+                project_io = prepare_project_io(
+                    project_root=project_root,
+                    timestamp="2026-04-25T12-00-00Z",
+                )
+
+            self.assertTrue((project_root / "calib").is_dir())
+            self.assertTrue((project_root / "calib" / "images" / "set_01").is_dir())
+            self.assertTrue(
+                (project_root / "calib" / "runs" / "2026-04-25T12-00-00Z").is_dir()
+            )
+            self.assertEqual(
+                project_io.out_yaml.resolve(),
+                (project_root / "calib" / "calib_color.yaml").resolve(),
+            )
+
+    def test_explicit_out_overrides_default_calibration_yaml_path(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            out_yaml = base / "custom" / "camera.yaml"
+            env = {
+                "HOME": str(base / "home"),
+                "XDG_CONFIG_HOME": str(base / ".config"),
+            }
+
+            with patch.dict(os.environ, env, clear=False):
+                project_io = prepare_project_io(
+                    project_root=project_root,
+                    out=out_yaml,
+                    timestamp="2026-04-25T12-00-00Z",
+                )
+
+            self.assertEqual(project_io.out_yaml, out_yaml)
+            self.assertTrue(out_yaml.parent.is_dir())
+
+    def test_calibration_yaml_schema_writes_and_round_trips(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "calib_color.yaml"
+            camera_matrix = np.array(
+                [
+                    [600.0, 0.0, 320.0],
+                    [0.0, 610.0, 240.0],
+                    [0.0, 0.0, 1.0],
+                ]
+            )
+            distortion = np.array([[-0.1, 0.02, 0.001, -0.002, 0.0]])
+            data = build_calibration_yaml(
+                image_width=640,
+                image_height=480,
+                camera_matrix=camera_matrix,
+                distortion_coefficients=distortion,
+                reproj_rms=0.123,
+                notes="ChArUco 3x5, square=50.0mm, marker=37.0mm, dict=7X7_50",
+            )
+
+            write_calibration_yaml(path, data)
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+            for key in (
+                "image_width",
+                "image_height",
+                "camera_matrix",
+                "distortion_coefficients",
+                "reproj_rms",
+                "model",
+                "notes",
+            ):
+                self.assertIn(key, loaded)
+            self.assertEqual(loaded["image_width"], 640)
+            self.assertEqual(loaded["image_height"], 480)
+            self.assertEqual(loaded["model"], "plumb_bob")
+            self.assertEqual(loaded["camera_matrix"]["fx"], 600.0)
+            self.assertEqual(loaded["distortion_coefficients"]["k1"], -0.1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_step1_charuco_calibration.py
+++ b/tests/test_step1_charuco_calibration.py
@@ -157,6 +157,51 @@ class CharucoCalibrationStep1Tests(unittest.TestCase):
             self.assertIn("video ended", stdout.getvalue())
             self.assertIn("Need at least", str(ctx.exception))
 
+    def test_q_exits_cleanly_without_traceback_or_solve(self) -> None:
+        class FakeVideoCapture:
+            def __init__(self, _path: str) -> None:
+                self.released = False
+
+            def isOpened(self) -> bool:
+                return True
+
+            def read(self):
+                frame = np.zeros((20, 20, 3), dtype=np.uint8)
+                return True, frame
+
+            def release(self) -> None:
+                self.released = True
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            env = {
+                "HOME": str(base / "home"),
+                "XDG_CONFIG_HOME": str(base / ".config"),
+            }
+            stdout = StringIO()
+
+            with patch.dict(os.environ, env, clear=False):
+                with patch("utils.charuco_calibrate.cv2.VideoCapture", FakeVideoCapture):
+                    with patch("utils.charuco_calibrate.cv2.imshow"):
+                        with patch("utils.charuco_calibrate.cv2.waitKey", return_value=ord("q")):
+                            with patch("utils.charuco_calibrate.cv2.destroyAllWindows"):
+                                with redirect_stdout(stdout):
+                                    result = charuco_cli.main(
+                                        [
+                                            "--project_root",
+                                            str(project_root),
+                                            "--source",
+                                            "video",
+                                            "--video",
+                                            str(base / "sample.mp4"),
+                                        ]
+                                    )
+
+            self.assertEqual(result, 0)
+            self.assertIn("quit requested", stdout.getvalue())
+            self.assertFalse((project_root / "calib" / "calib_color.yaml").exists())
+
     def test_realsense_source_without_dependency_fails_clearly(self) -> None:
         with patch("utils.charuco_calibrate.rs", None):
             with self.assertRaises(SystemExit) as ctx:

--- a/tests/test_step1_charuco_calibration.py
+++ b/tests/test_step1_charuco_calibration.py
@@ -64,6 +64,26 @@ class CharucoCalibrationStep1Tests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Colour ChArUco calibration", result.stdout)
 
+    def test_direct_script_fallback_adds_repo_root_and_src(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        repo_src = repo_root / "src"
+        original_path = sys.path[:]
+
+        try:
+            sys.path[:] = [
+                path
+                for path in sys.path
+                if path not in {str(repo_root), str(repo_src)}
+            ]
+
+            charuco_calibrate._ensure_checkout_import_paths()
+
+            self.assertIn(str(repo_root), sys.path)
+            self.assertIn(str(repo_src), sys.path)
+            self.assertLess(sys.path.index(str(repo_src)), sys.path.index(str(repo_root)))
+        finally:
+            sys.path[:] = original_path
+
     def test_dictionary_parsing_accepts_valid_name(self) -> None:
         dictionary = get_dictionary("7X7_50")
 

--- a/tests/test_step1_charuco_calibration.py
+++ b/tests/test_step1_charuco_calibration.py
@@ -14,6 +14,7 @@ import numpy as np
 import yaml
 
 from posetag.cli import charuco as charuco_cli
+from utils import charuco_calibrate
 from posetag.pipelines.charuco_calibration import (
     CharucoCalibrationError,
     build_calibration_yaml,
@@ -52,6 +53,17 @@ class CharucoCalibrationStep1Tests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Colour ChArUco calibration", result.stdout)
 
+    def test_direct_legacy_script_help_resolves_from_checkout(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "utils/charuco_calibrate.py", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Colour ChArUco calibration", result.stdout)
+
     def test_dictionary_parsing_accepts_valid_name(self) -> None:
         dictionary = get_dictionary("7X7_50")
 
@@ -70,12 +82,92 @@ class CharucoCalibrationStep1Tests(unittest.TestCase):
 
         self.assertIn("--video path is required", str(ctx.exception))
 
+    def test_missing_video_path_fails_before_project_artifacts(self) -> None:
+        class FakeClosedVideoCapture:
+            def __init__(self, _path: str) -> None:
+                pass
+
+            def isOpened(self) -> bool:
+                return False
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            env = {
+                "HOME": str(base / "home"),
+                "XDG_CONFIG_HOME": str(base / ".config"),
+            }
+
+            with patch.dict(os.environ, env, clear=False):
+                with patch("utils.charuco_calibrate.cv2.VideoCapture", FakeClosedVideoCapture):
+                    with self.assertRaises(SystemExit) as ctx:
+                        charuco_cli.main(
+                            [
+                                "--project_root",
+                                str(project_root),
+                                "--source",
+                                "video",
+                                "--video",
+                                str(base / "missing.mp4"),
+                            ]
+                        )
+
+            self.assertIn("Could not open video", str(ctx.exception))
+            self.assertFalse((project_root / "calib").exists())
+
+    def test_video_eof_exits_capture_loop_clearly(self) -> None:
+        class FakeVideoCapture:
+            def __init__(self, _path: str) -> None:
+                self.released = False
+
+            def isOpened(self) -> bool:
+                return True
+
+            def read(self):
+                return False, None
+
+            def release(self) -> None:
+                self.released = True
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            env = {
+                "HOME": str(base / "home"),
+                "XDG_CONFIG_HOME": str(base / ".config"),
+            }
+            stdout = StringIO()
+
+            with patch.dict(os.environ, env, clear=False):
+                with patch("utils.charuco_calibrate.cv2.VideoCapture", FakeVideoCapture):
+                    with patch("utils.charuco_calibrate.cv2.destroyAllWindows"):
+                        with self.assertRaises(SystemExit) as ctx:
+                            with redirect_stdout(stdout):
+                                charuco_cli.main(
+                                    [
+                                        "--project_root",
+                                        str(project_root),
+                                        "--source",
+                                        "video",
+                                        "--video",
+                                        str(base / "empty.mp4"),
+                                    ]
+                                )
+
+            self.assertIn("video ended", stdout.getvalue())
+            self.assertIn("Need at least", str(ctx.exception))
+
     def test_realsense_source_without_dependency_fails_clearly(self) -> None:
         with patch("utils.charuco_calibrate.rs", None):
             with self.assertRaises(SystemExit) as ctx:
                 charuco_cli.main(["--source", "realsense"])
 
         self.assertIn("pyrealsense2 is not available", str(ctx.exception))
+
+    def test_min_corners_default_matches_solver_threshold(self) -> None:
+        args = charuco_calibrate.parse_args([])
+
+        self.assertEqual(args.min_corners, 4)
 
     def test_project_io_preparation_creates_calibration_layout(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/utils/charuco_calibrate.py
+++ b/utils/charuco_calibrate.py
@@ -20,14 +20,14 @@ What it does
 Typical usage
 -------------
 # Generic webcam (default source)
-python charuco_calibrate.py --source opencv --cam 0 --squares-x 5 --squares-y 3 \
+posetag-calib-charuco --source opencv --cam 0 --squares-x 5 --squares-y 3 \
   --square-length-mm 50 --marker-length-mm 37 --dict 7X7_100
 
 # RealSense
-python charuco_calibrate.py --source realsense --width 640 --height 480 --fps 30
+posetag-calib-charuco --source realsense --width 640 --height 480 --fps 30
 
 # From a video
-python charuco_calibrate.py --source video --video sample.mp4
+posetag-calib-charuco --source video --video sample.mp4
 """
 
 from __future__ import annotations
@@ -43,18 +43,17 @@ try:
 except Exception:
     rs = None
 
-# Project helpers (prefer packaged utils, but support repo-local utils/)
-try:
-    from posetag.utils.project_config import resolve_project_root, ensure_project_dirs  # type: ignore
-except Exception:
-    try:
-        from gt6dof_atag.utils.project_config import resolve_project_root, ensure_project_dirs  # type: ignore
-    except Exception:
-        try:
-            from utils.project_config import resolve_project_root, ensure_project_dirs  # type: ignore
-        except Exception:
-            resolve_project_root = None  # type: ignore
-            ensure_project_dirs = None   # type: ignore
+# Canonical PoseTag helpers.  The capture/calibration loop remains in this
+# legacy module temporarily; pure validation, IO, and YAML helpers live in
+# posetag.pipelines so they can be tested without camera hardware.
+from posetag.pipelines.charuco_calibration import (  # type: ignore
+    CharucoCalibrationError,
+    build_calibration_yaml,
+    get_dictionary,
+    prepare_project_io,
+    validate_capture_args,
+    write_calibration_yaml,
+)
 
 
 class _HelpFmt(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
@@ -62,7 +61,7 @@ class _HelpFmt(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpForma
     pass
 
 
-def parse_args():
+def build_parser():
     ap = argparse.ArgumentParser(
         "Colour ChArUco calibration (RealSense, generic webcam, or video)",
         formatter_class=_HelpFmt,
@@ -100,27 +99,11 @@ def parse_args():
                     help="Explicit project root; otherwise resolved via config/env/home logic.")
     ap.add_argument("--out", type=str, default=None,
                     help="Output YAML file (default: <project_root>/calib/calib_color.yaml)")
-    return ap.parse_args()
+    return ap
 
 
-def get_dictionary(name: str):
-    """Return an OpenCV ArUco dictionary object from a human-friendly name."""
-    name = name.upper().replace("-", "_")
-    aruco = cv2.aruco
-    MAP = {
-        "4X4_50": aruco.DICT_4X4_50, "4X4_100": aruco.DICT_4X4_100,
-        "4X4_250": aruco.DICT_4X4_250, "4X4_1000": getattr(aruco, "DICT_4X4_1000", None),
-        "5X5_50": aruco.DICT_5X5_50, "5X5_100": aruco.DICT_5X5_100,
-        "5X5_250": aruco.DICT_5X5_250, "5X5_1000": aruco.DICT_5X5_1000,
-        "6X6_50": aruco.DICT_6X6_50, "6X6_100": aruco.DICT_6X6_100,
-        "6X6_250": aruco.DICT_6X6_250, "6X6_1000": aruco.DICT_6X6_1000,
-        "7X7_50": aruco.DICT_7X7_50, "7X7_100": aruco.DICT_7X7_100,
-        "7X7_250": aruco.DICT_7X7_250, "7X7_1000": aruco.DICT_7X7_1000,
-        "APRILTAG_36H11": getattr(aruco, "DICT_APRILTAG_36h11", None),
-    }
-    if name not in MAP or MAP[name] is None:
-        raise ValueError(f"Unsupported dictionary {name}")
-    return aruco.getPredefinedDictionary(MAP[name])
+def parse_args(argv=None):
+    return build_parser().parse_args(argv)
 
 
 def make_board(aruco, sx, sy, square_m, marker_m, dictionary):
@@ -132,53 +115,20 @@ def make_board(aruco, sx, sy, square_m, marker_m, dictionary):
     raise RuntimeError("Your OpenCV build lacks both CharucoBoard APIs.")
 
 
-def _now_iso_utc():
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
-
-
 def _prepare_project_io(args) -> tuple[Path, Path, Path, Path, Path]:
     """
     Resolve project root and prepare:
       calib_dir, images_root, run_dir (unique), out_yaml.
     Returns (project_root, calib_dir, images_root, run_dir, out_yaml)
     """
-    # Resolve project root (explicit → env/config/default)
-    if resolve_project_root is not None and ensure_project_dirs is not None:
-        pr = Path(resolve_project_root(args.project_root))
-        ensure_project_dirs(pr)
-    else:
-        # Fallback: cwd/posetag_project to avoid breaking older installs
-        pr = Path.cwd() / "posetag_project"
-        pr.mkdir(parents=True, exist_ok=True)
-
-    calib_dir = pr / "calib"
-    images_root = calib_dir / "images"
-    runs_root = calib_dir / "runs"
-    calib_dir.mkdir(parents=True, exist_ok=True)
-    images_root.mkdir(parents=True, exist_ok=True)
-    runs_root.mkdir(parents=True, exist_ok=True)
-
-    # Next images set_XX
-    existing = sorted([p.name for p in images_root.iterdir() if p.is_dir() and p.name.startswith("set_")])
-    if existing:
-        try:
-            last_idx = int(existing[-1].split("_")[-1])
-        except Exception:
-            last_idx = 0
-    else:
-        last_idx = 0
-    new_set_dir = images_root / f"set_{last_idx + 1:02d}"
-    new_set_dir.mkdir(parents=True, exist_ok=True)
-
-    # Per-run directory
-    run_dir = runs_root / _now_iso_utc()
-    run_dir.mkdir(parents=True, exist_ok=True)
-
-    # Output yaml path
-    out_yaml = Path(args.out) if args.out else (calib_dir / "calib_color.yaml")
-    out_yaml.parent.mkdir(parents=True, exist_ok=True)
-
-    return pr, calib_dir, new_set_dir, run_dir, out_yaml
+    project_io = prepare_project_io(args.project_root, args.out)
+    return (
+        project_io.project_root,
+        project_io.calib_dir,
+        project_io.images_dir,
+        project_io.run_dir,
+        project_io.out_yaml,
+    )
 
 
 def calibrate_from_charuco(samples_corners, samples_ids, board, image_size):
@@ -242,9 +192,15 @@ def calibrate_from_charuco(samples_corners, samples_ids, board, image_size):
     return rms, K, dist, rvecs, tvecs
 
 
-def main():
+def main(argv=None):
     """CLI entry point: capture frames, collect ChArUco corners, calibrate, and write YAML."""
-    args = parse_args()
+    args = parse_args(argv)
+
+    try:
+        validate_capture_args(args.source, args.video, rs)
+        dictionary = get_dictionary(args.dict)
+    except CharucoCalibrationError as exc:
+        raise SystemExit(str(exc)) from exc
 
     # ----- Project-aware IO layout (always) -----
     pr, calib_dir, images_dir, run_dir, out_yaml = _prepare_project_io(args)
@@ -255,7 +211,6 @@ def main():
 
     # ----- ArUco/board setup -----
     aruco = cv2.aruco
-    dictionary = get_dictionary(args.dict)
 
     square_m = args.square_length_mm / 1000.0
     marker_m = args.marker_length_mm / 1000.0
@@ -416,29 +371,21 @@ def main():
 
     # write main YAML (latest)
     dist = np.asarray(dist, dtype=float).reshape(1, -1)  # ensure shape (1, N)
-    fx, fy, cx, cy = float(K[0, 0]), float(K[1, 1]), float(K[0, 2]), float(K[1, 2])
-    k1 = float(dist[0, 0]) if dist.shape[1] > 0 else 0.0
-    k2 = float(dist[0, 1]) if dist.shape[1] > 1 else 0.0
-    p1 = float(dist[0, 2]) if dist.shape[1] > 2 else 0.0
-    p2 = float(dist[0, 3]) if dist.shape[1] > 3 else 0.0
-    k3 = float(dist[0, 4]) if dist.shape[1] > 4 else 0.0
 
     print(f"[i] Reprojection RMS = {ret:.3f} px")
     print("[i] K =\n", K)
     print("[i] dist =", dist.ravel())
 
-    calib_data = dict(
+    calib_data = build_calibration_yaml(
         image_width=args.width,
         image_height=args.height,
-        camera_matrix=dict(fx=fx, fy=fy, cx=cx, cy=cy, data=K.tolist()),
-        distortion_coefficients=dict(k1=k1, k2=k2, p1=p1, p2=p2, k3=k3, data=dist.tolist()),
+        camera_matrix=K,
+        distortion_coefficients=dist,
         reproj_rms=float(ret),
-        model="plumb_bob",
         notes=f"ChArUco {args.squares_x}x{args.squares_y}, square={args.square_length_mm}mm, "
-              f"marker={args.marker_length_mm}mm, dict={args.dict}"
+              f"marker={args.marker_length_mm}mm, dict={args.dict}",
     )
-    with open(out_yaml, "w") as f:
-        yaml.safe_dump(calib_data, f)
+    write_calibration_yaml(out_yaml, calib_data)
     print(f"[i] wrote {out_yaml}")
 
     # Run snapshot: config + calibration copy

--- a/utils/charuco_calibrate.py
+++ b/utils/charuco_calibrate.py
@@ -368,7 +368,8 @@ def main(argv=None):
             elif k == 13:
                 break
             elif k == ord('q'):
-                raise KeyboardInterrupt
+                print("[i] quit requested; exiting without calibration.")
+                return 0
     finally:
         _stop()
         cv2.destroyAllWindows()

--- a/utils/charuco_calibrate.py
+++ b/utils/charuco_calibrate.py
@@ -46,14 +46,27 @@ except Exception:
 # Canonical PoseTag helpers.  The capture/calibration loop remains in this
 # legacy module temporarily; pure validation, IO, and YAML helpers live in
 # posetag.pipelines so they can be tested without camera hardware.
-from posetag.pipelines.charuco_calibration import (  # type: ignore
-    CharucoCalibrationError,
-    build_calibration_yaml,
-    get_dictionary,
-    prepare_project_io,
-    validate_capture_args,
-    write_calibration_yaml,
-)
+try:
+    from posetag.pipelines.charuco_calibration import (  # type: ignore
+        CharucoCalibrationError,
+        build_calibration_yaml,
+        get_dictionary,
+        prepare_project_io,
+        validate_capture_args,
+        write_calibration_yaml,
+    )
+except ModuleNotFoundError:
+    repo_src = Path(__file__).resolve().parents[1] / "src"
+    if repo_src.is_dir() and str(repo_src) not in sys.path:
+        sys.path.insert(0, str(repo_src))
+    from posetag.pipelines.charuco_calibration import (  # type: ignore
+        CharucoCalibrationError,
+        build_calibration_yaml,
+        get_dictionary,
+        prepare_project_io,
+        validate_capture_args,
+        write_calibration_yaml,
+    )
 
 
 class _HelpFmt(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
@@ -87,7 +100,8 @@ def build_parser():
                     help="Requested capture height (best effort for OpenCV webcams).")
     ap.add_argument("--fps", type=int, default=30,
                     help="Requested frames per second (best effort for OpenCV webcams).")
-    ap.add_argument("--min-corners", type=int, default=1, help="min ChArUco corners per sample")
+    ap.add_argument("--min-corners", type=int, default=4,
+                    help="min ChArUco corners per sample; values below 4 are promoted to 4")
     ap.add_argument("--min-samples", type=int, default=30, help="min accepted samples before solve")
     ap.add_argument("--auto", action="store_true")
     ap.add_argument("--auto-interval", type=int, default=10)
@@ -129,6 +143,58 @@ def _prepare_project_io(args) -> tuple[Path, Path, Path, Path, Path]:
         project_io.run_dir,
         project_io.out_yaml,
     )
+
+
+def _open_capture_source(args):
+    """Open the requested capture source without creating project artifacts."""
+
+    if args.source == "realsense":
+        pipe, cfg = rs.pipeline(), rs.config()
+        cfg.enable_stream(rs.stream.color, args.width, args.height, rs.format.bgr8, args.fps)
+        pipe.start(cfg)
+
+        def _read_frame():
+            frames = pipe.wait_for_frames()
+            cframe = frames.get_color_frame()
+            return None if not cframe else np.asanyarray(cframe.get_data())
+
+        def _stop():
+            pipe.stop()
+
+        return _read_frame, _stop
+
+    if args.source == "opencv":
+        cap = cv2.VideoCapture(args.cam)
+        if not cap.isOpened():
+            raise SystemExit(f"Could not open camera index {args.cam}")
+        cap.set(cv2.CAP_PROP_FRAME_WIDTH, args.width)
+        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, args.height)
+        cap.set(cv2.CAP_PROP_FPS, args.fps)
+
+        def _read_frame():
+            ok, frame = cap.read()
+            return frame if ok else None
+
+        def _stop():
+            cap.release()
+
+        return _read_frame, _stop
+
+    if args.source == "video":
+        cap = cv2.VideoCapture(args.video)
+        if not cap.isOpened():
+            raise SystemExit(f"Could not open video: {args.video}")
+
+        def _read_frame():
+            ok, frame = cap.read()
+            return frame if ok else None
+
+        def _stop():
+            cap.release()
+
+        return _read_frame, _stop
+
+    raise SystemExit(f"Unsupported source: {args.source}")
 
 
 def calibrate_from_charuco(samples_corners, samples_ids, board, image_size):
@@ -201,13 +267,7 @@ def main(argv=None):
         dictionary = get_dictionary(args.dict)
     except CharucoCalibrationError as exc:
         raise SystemExit(str(exc)) from exc
-
-    # ----- Project-aware IO layout (always) -----
-    pr, calib_dir, images_dir, run_dir, out_yaml = _prepare_project_io(args)
-    print(f"[i] Project root = {pr}")
-    print(f"[i] Samples folder = {images_dir}")
-    print(f"[i] Run folder = {run_dir}")
-    args.out = str(out_yaml)  # ensure consistent path downstream
+    args.min_corners = max(4, args.min_corners)
 
     # ----- ArUco/board setup -----
     aruco = cv2.aruco
@@ -223,49 +283,18 @@ def main(argv=None):
         det_params = aruco.DetectorParameters_create()
 
     # ----- Source setup -----
-    if args.source == "realsense":
-        if rs is None:
-            sys.exit("pyrealsense2 not available; use --source opencv|video")
-        pipe, cfg = rs.pipeline(), rs.config()
-        cfg.enable_stream(rs.stream.color, args.width, args.height, rs.format.bgr8, args.fps)
-        profile = pipe.start(cfg)
+    _read_frame, _stop = _open_capture_source(args)
 
-        def _read_frame():
-            frames = pipe.wait_for_frames()
-            cframe = frames.get_color_frame()
-            return None if not cframe else np.asanyarray(cframe.get_data())
-
-        def _stop():
-            pipe.stop()
-
-    elif args.source == "opencv":
-        cap = cv2.VideoCapture(args.cam)
-        if not cap.isOpened():
-            sys.exit(f"Could not open camera index {args.cam}")
-        cap.set(cv2.CAP_PROP_FRAME_WIDTH, args.width)
-        cap.set(cv2.CAP_PROP_FRAME_HEIGHT, args.height)
-        cap.set(cv2.CAP_PROP_FPS, args.fps)
-
-        def _read_frame():
-            ok, frame = cap.read()
-            return frame if ok else None
-
-        def _stop():
-            cap.release()
-
-    elif args.source == "video":
-        if not args.video:
-            sys.exit("--video path is required when --source=video")
-        cap = cv2.VideoCapture(args.video)
-        if not cap.isOpened():
-            sys.exit(f"Could not open video: {args.video}")
-
-        def _read_frame():
-            ok, frame = cap.read()
-            return frame if ok else None
-
-        def _stop():
-            cap.release()
+    try:
+        # ----- Project-aware IO layout -----
+        pr, calib_dir, images_dir, run_dir, out_yaml = _prepare_project_io(args)
+        print(f"[i] Project root = {pr}")
+        print(f"[i] Samples folder = {images_dir}")
+        print(f"[i] Run folder = {run_dir}")
+        args.out = str(out_yaml)  # ensure consistent path downstream
+    except Exception:
+        _stop()
+        raise
 
     # ----- Capture loop -----
     samples_corners, samples_ids = [], []
@@ -278,6 +307,9 @@ def main(argv=None):
         while True:
             color = _read_frame()
             if color is None:
+                if args.source == "video":
+                    print("[i] video ended; solving with collected samples.")
+                    break
                 continue
 
             # For non-RealSense, sync image_size to actual stream
@@ -348,7 +380,7 @@ def main(argv=None):
     # ----- Solve & write results -----
     img_size = (args.width, args.height)
     # ---- filter weak samples before solving ----
-    REQUIRED = max(4, args.min_corners)  # charuco solver needs at least 4 per view
+    REQUIRED = args.min_corners  # charuco solver needs at least 4 per view
     filtered_corners, filtered_ids = [], []
     for ch_c, ch_id in zip(samples_corners, samples_ids):
         if ch_c is not None and ch_id is not None and len(ch_c) >= REQUIRED:

--- a/utils/charuco_calibrate.py
+++ b/utils/charuco_calibrate.py
@@ -43,6 +43,17 @@ try:
 except Exception:
     rs = None
 
+
+def _ensure_checkout_import_paths() -> None:
+    """Make direct ``python utils/charuco_calibrate.py`` work from a checkout."""
+
+    repo_root = Path(__file__).resolve().parents[1]
+    repo_src = repo_root / "src"
+    for path in (repo_root, repo_src):
+        if path.is_dir() and str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+
+
 # Canonical PoseTag helpers.  The capture/calibration loop remains in this
 # legacy module temporarily; pure validation, IO, and YAML helpers live in
 # posetag.pipelines so they can be tested without camera hardware.
@@ -56,9 +67,7 @@ try:
         write_calibration_yaml,
     )
 except ModuleNotFoundError:
-    repo_src = Path(__file__).resolve().parents[1] / "src"
-    if repo_src.is_dir() and str(repo_src) not in sys.path:
-        sys.path.insert(0, str(repo_src))
+    _ensure_checkout_import_paths()
     from posetag.pipelines.charuco_calibration import (  # type: ignore
         CharucoCalibrationError,
         build_calibration_yaml,


### PR DESCRIPTION
@qub-arise, based on issue #28, this PR aims to validate and harden the Step 1 ChArUco colour-camera calibration workflow for PoseTag.

## Summary

This PR makes `posetag-calib-charuco` genuinely usable and testable from a fresh editable install while preserving the existing OpenCV ChArUco calibration algorithm and scientific assumptions.

It adds small canonical PoseTag helpers for:

- source and dictionary validation
- deterministic project calibration IO preparation
- calibration YAML schema construction and writing
- hardware-free test coverage around CLI behavior and output schema

The interactive capture loop and calibration solve remain in the existing legacy module for now, with that technical debt documented explicitly.

## Documentation

- Adds `docs/workflows/step1_calibrate_charuco.md` with webcam, RealSense, and video examples.
- Updates README Step 1 to match the canonical `posetag-calib-charuco` workflow.
- Adds `STEP1_CALIBRATION_REPORT.md` with implementation summary, tested commands, verified schema, and remaining technical debt.

## Notes

Real calibration images and local `my_project/` outputs are intentionally ignored and not committed. Hardware-backed calibration quality still needs manual review before Step 2 validation.

Closes #28.
