### PR TITLE
Validate make-board workflow and tag registry outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,67 +257,97 @@ reproj_rms: 0.13782644794293097
 
 ![make-board](media/make_board.gif)
 
-Capture one view with all tags visible, pick an **origin** ID, and write a face
-YAML plus update the tag registry under your active project. Outputs live under
-`<root>/boards/...`.
+Capture one view with all tags on a face visible, pick an **origin** ID, and
+write a face YAML plus update the project tag registry. The board frame is the
+origin tag centre; board x/y axes follow the origin tag axes; planar boards
+should have z offsets approximately equal to `0`.
 
 **OpenCV webcam**
 
 ```bash
-posetag-make-board \
+posetag-make-board --project_root my_project \
+  --source opencv --cam 0 \
   --object_name connection_plate_white_sideA \
   --calib calib_color.yaml \
-  --tag_size_mm 80 \
-  --save_shot
+  --tag_size_mm 80
 ```
 
 **Intel RealSense**
 
 ```bash
-posetag-make-board \
+posetag-make-board --project_root my_project \
   --source realsense --width 640 --height 480 --fps 30 \
-  --object_name connection_plate_white_sideA --calib calib_color.yaml --tag_size_mm 80
+  --object_name connection_plate_white_sideA \
+  --calib calib_color.yaml \
+  --tag_size_mm 80
 ```
 
 **From a video**
 
 ```bash
-posetag-make-board \
+posetag-make-board --project_root my_project \
   --source video --video sample.mp4 \
-  --object_name connection_plate_white_sideA --calib calib_color.yaml --tag_size_mm 80
+  --object_name connection_plate_white_sideA \
+  --calib calib_color.yaml \
+  --tag_size_mm 80
 ```
+
+`--tag_size_mm` is the physical black-square edge size of the AprilTags in
+millimetres. The board YAML stores this as `tag_size_m` in metres.
+
+With `--project_root my_project --calib calib_color.yaml`, PoseTag first looks
+for the Step 1 calibration at:
+
+```text
+my_project/calib/calib_color.yaml
+```
+
+Absolute calibration paths are used exactly as supplied. Relative paths retain
+legacy compatibility after the project calibration lookup.
+
+Controls and prompts:
+
+- `ENTER`: capture the current frame and estimate tag poses.
+- `ESC`: exit cleanly without writing board YAML.
+- After capture, enter the comma-separated tag IDs to include, then choose the
+  origin ID from the selected IDs.
 
 **Outputs**
 
-- `<root>/boards/<object_face>.yaml`
-  with `origin_id`, `tag_size_m`, and per-tag 2D offsets plus yaw.
-- `<root>/boards/tag_registry.yaml`
-  with tag-ID to face-YAML mappings, updated on each run.
-- Optional `<root>/boards/shots/*` audit images when `--save_shot` is enabled.
+- `my_project/boards/<object_name>.yaml`
+  with `origin_id`, `tag_size_m`, and per-tag `cx`, `cy`, and `yaw_deg`.
+- `my_project/boards/tag_registry.yaml`
+  with tag-ID to face-YAML mappings.
+- Optional `my_project/boards/shots/*` audit images when `--save_shot` is
+  enabled.
 
 Tips:
 
 - add `--project_root <path>` to create or select a project explicitly
 - otherwise the resolver uses your current or last project
+- use `--out_dir`, `--registry`, and `--shots_dir` to override board, registry,
+  and audit-shot paths
 - use `--z_thresh` (default `0.01` m) to enforce planarity
 - use `--allow_nonplanar` to proceed with a warning
+- source and calibration failures are checked before board YAML or registry
+  output artifacts are created
 
 **Example board YAML** (`connection_plate_white_sideA.yaml`)
 
 ```yaml
 object: connection_plate_white_sideA
 family: tag36h11
-tag_size_m: 0.04
+tag_size_m: 0.08
 origin_id: 52
 tags:
 - id: 52
   cx: 0.0
-  cy: 2.7755575615628914e-17
-  yaw_deg: -6.095899809673727e-15
+  cy: 0.0
+  yaw_deg: 0.0
 - id: 53
-  cx: -0.0014025137524277254
-  cy: -0.1884154905688507
-  yaw_deg: 179.95955209337157
+  cx: 0.1
+  cy: -0.2
+  yaw_deg: 180.0
 notes: "Board frame = origin tag centre; x,y follow origin tag axes; z ≈ 0."
 ```
 
@@ -327,15 +357,17 @@ notes: "Board frame = origin tag centre; x,y follow origin tag axes; z ≈ 0."
 version: 1
 updated: "2025-11-09T18:50:42Z"
 tags:
-  "52": {object: connection_plate_white_sideA, yaml: /home/samuel/posetag/project-2025-11-08T23-10-29Z/boards/connection_plate_white_sideA.yaml}
-  "53": {object: connection_plate_white_sideA, yaml: /home/samuel/posetag/project-2025-11-08T23-10-29Z/boards/connection_plate_white_sideA.yaml}
-  "54": {object: connection_plate_white_sideA, yaml: /home/samuel/posetag/project-2025-11-08T23-10-29Z/boards/connection_plate_white_sideA.yaml}
-  "55": {object: connection_plate_white_sideA, yaml: /home/samuel/posetag/project-2025-11-08T23-10-29Z/boards/connection_plate_white_sideA.yaml}
+  "52":
+    object: connection_plate_white_sideA
+    yaml: my_project/boards/connection_plate_white_sideA.yaml
+  "53":
+    object: connection_plate_white_sideA
+    yaml: my_project/boards/connection_plate_white_sideA.yaml
 ```
 
 The registry is updated each time you run `posetag-make-board`. If the same tag
-ID is already mapped to another face, you’ll be warned so you can resolve the
-conflict intentionally.
+ID is already mapped to another board YAML, PoseTag warns and preserves the
+existing mapping so conflicts are not silently overwritten.
 
 Faces may use different tag sizes; each face YAML stores its own `tag_size_m`.
 

--- a/src/make_board.py
+++ b/src/make_board.py
@@ -16,16 +16,10 @@ Defaults are *project-aware*: if `--project_root` is omitted, we resolve one via
 utils.project_config.resolve_project_root (env/config/home logic).
 """
 
-import argparse, os, sys, yaml, numpy as np, cv2, datetime, tempfile, shutil
+import argparse, sys, numpy as np, cv2, datetime
 from math import atan2, degrees
 from pathlib import Path
-from typing import Optional, Tuple
-
-# ---- Tag detector (pupil-apriltags) ----
-try:
-    from pupil_apriltags import Detector
-except Exception as e:
-    raise SystemExit("Install pupil-apriltags: pip install pupil-apriltags") from e
+from typing import Tuple
 
 # ---- Optional RealSense ----
 try:
@@ -33,41 +27,19 @@ try:
 except Exception:
     rs = None
 
-# ---- Project root helpers ----
-try:
-    from utils.project_config import resolve_project_root, ensure_project_dirs
-except Exception:
-    resolve_project_root = None
-    ensure_project_dirs = None
-
-
-# --------- IO helpers ---------
-def _now_iso_utc() -> str:
-    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H-%M-%SZ")
-
-
-def _atomic_write_yaml(path: Path, data: dict) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    fd, tmp = tempfile.mkstemp(prefix="._tmp_yaml_", dir=str(path.parent))
-    os.close(fd)
-    with open(tmp, "w") as f:
-        yaml.safe_dump(data, f, sort_keys=False)
-    shutil.move(tmp, str(path))
-
-
-def load_calib(path: str) -> Tuple[Tuple[float, float, float, float], np.ndarray, np.ndarray]:
-    if not os.path.exists(path):
-        print(f"[!] {path} not found.")
-        print("    Run ChArUco calibration to generate calib_color.yaml first.")
-        sys.exit(1)
-    y = yaml.safe_load(open(path)) or {}
-    cm = y["camera_matrix"]; dc = y.get("distortion_coefficients", {})
-    fx, fy, cx, cy = float(cm["fx"]), float(cm["fy"]), float(cm["cx"]), float(cm["cy"])
-    K = np.array([[fx, 0, cx], [0, fy, cy], [0, 0, 1]], float)
-    # Distortion is not required by pupil-apriltags pose solver (assumes pinhole).
-    D = np.array([[dc.get("k1", 0.0), dc.get("k2", 0.0), dc.get("p1", 0.0),
-                   dc.get("p2", 0.0), dc.get("k3", 0.0)]], float)
-    return (fx, fy, cx, cy), K, D
+from posetag.pipelines.make_board import (
+    MakeBoardError,
+    build_board_yaml,
+    load_calibration_yaml,
+    load_registry,
+    prepare_project_paths,
+    preview_project_root,
+    resolve_calibration_path,
+    save_registry,
+    update_registry_entries,
+    validate_source_args,
+    write_board_yaml,
+)
 
 
 def se3(R, t):
@@ -86,18 +58,15 @@ def inv_se3(T):
     return Ti
 
 
-def load_registry(path: Path) -> dict:
-    if not path.exists():
-        return {"version": 1, "updated": None, "tags": {}}
-    reg = yaml.safe_load(open(path)) or {}
-    reg.setdefault("version", 1)
-    reg.setdefault("tags", {})
-    return reg
-
-
-def save_registry(path: Path, reg: dict) -> None:
-    reg["updated"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
-    _atomic_write_yaml(path, reg)
+def _load_detector_class():
+    try:
+        from pupil_apriltags import Detector
+    except Exception as exc:
+        raise MakeBoardError(
+            "pupil-apriltags is not available; install PoseTag with the 'apriltags' "
+            "extra or run `python -m pip install pupil-apriltags`."
+        ) from exc
+    return Detector
 
 
 # --------- CLI ---------
@@ -106,9 +75,10 @@ class _HelpFmt(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpForma
     pass
 
 
-def parse_args():
+def build_parser():
     ap = argparse.ArgumentParser(
-        "Interactive AprilTag board builder (project-aware)",
+        prog="posetag-make-board",
+        description="Interactive AprilTag board builder (project-aware)",
         formatter_class=_HelpFmt,
         epilog=(
             "Workflow:\n"
@@ -151,29 +121,24 @@ def parse_args():
     ap.add_argument("--allow_nonplanar", action="store_true",
                     help="Warn but still write YAML even if |z| > z_thresh.")
 
-    return ap.parse_args()
+    return ap
+
+
+def parse_args(argv=None):
+    return build_parser().parse_args(argv)
 
 
 def _resolve_paths(args) -> Tuple[Path, Path, Path, Path]:
     """Resolve project root and default output paths."""
-    # Project root
-    if resolve_project_root is not None:
-        pr = Path(resolve_project_root(args.project_root))
-        if ensure_project_dirs is not None:
-            ensure_project_dirs(pr)
-    else:
-        pr = Path(args.project_root).expanduser().resolve() if args.project_root else Path.cwd()
-
-    # Defaults under <project_root>/boards
-    boards_dir = Path(args.out_dir) if args.out_dir else pr / "boards"
-    shots_dir = Path(args.shots_dir) if args.shots_dir else boards_dir / "shots"
-    registry = Path(args.registry) if args.registry else boards_dir / "tag_registry.yaml"
-
-    boards_dir.mkdir(parents=True, exist_ok=True)
-    if args.save_shot:
-        shots_dir.mkdir(parents=True, exist_ok=True)
-
-    return pr, boards_dir, shots_dir, registry
+    paths = prepare_project_paths(
+        project_root=args.project_root,
+        object_name=args.object_name,
+        out_dir=args.out_dir,
+        shots_dir=args.shots_dir,
+        registry=args.registry,
+        save_shot=args.save_shot,
+    )
+    return paths.project_root, paths.boards_dir, paths.shots_dir, paths.registry_path
 
 
 def _open_source(args):
@@ -213,9 +178,8 @@ def _open_source(args):
         return _read, _stop
 
     # video
-    if not args.video:
-        sys.exit("--video path is required when --source=video")
-    cap = cv2.VideoCapture(args.video)
+    video_path = str(Path(args.video).expanduser())
+    cap = cv2.VideoCapture(video_path)
     if not cap.isOpened():
         sys.exit(f"Could not open video: {args.video}")
 
@@ -230,27 +194,40 @@ def _open_source(args):
 
 
 # --------- Main ---------
-def main():
-    args = parse_args()
-    project_root, boards_dir, shots_dir, registry_path = _resolve_paths(args)
+def main(argv=None):
+    args = parse_args(argv)
 
-    # Calib: allow relative path under project_root
-    calib_path = Path(args.calib)
-    # If no calib_path given
-    if calib_path is not None:
-        if not calib_path.is_absolute():
-            cand = (project_root / 'calib' / calib_path)
-            if cand.exists():
-                calib_path = cand
-    else:
-        calib_path = (project_root / 'calib/calib_color.yaml')
-        print(f'Calibration yaml not provided defaulting to recent calib path found in {calib_path}')
-    (fx, fy, cx, cy), K, _D = load_calib(str(calib_path))
+    try:
+        validate_source_args(args.source, args.video, rs)
+        project_root_for_calib = preview_project_root(args.project_root)
+        calib_path = resolve_calibration_path(project_root_for_calib, args.calib)
+        calib = load_calibration_yaml(calib_path)
+        Detector = _load_detector_class()
+    except MakeBoardError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    read_frame, stop = _open_source(args)
+    try:
+        paths = prepare_project_paths(
+            project_root=args.project_root,
+            object_name=args.object_name,
+            out_dir=args.out_dir,
+            shots_dir=args.shots_dir,
+            registry=args.registry,
+            save_shot=args.save_shot,
+        )
+    except Exception:
+        stop()
+        raise
+
+    project_root = paths.project_root
+    shots_dir = paths.shots_dir
+    registry_path = paths.registry_path
+
+    fx, fy, cx, cy = calib.camera_params
 
     tag_size_m = args.tag_size_mm / 1000.0
     det = Detector(families=args.family, nthreads=4, quad_decimate=1.0, refine_edges=True)
-
-    read_frame, stop = _open_source(args)
 
     # ---- Live preview & capture ----
     print(f"[i] Project root = {project_root}")
@@ -263,6 +240,9 @@ def main():
         while True:
             c = read_frame()
             if c is None:
+                if args.source == "video":
+                    print("[i] video ended before a board frame was captured; exiting without writing board YAML.")
+                    return 0
                 continue
             g = cv2.cvtColor(c, cv2.COLOR_BGR2GRAY)
 
@@ -277,8 +257,9 @@ def main():
             cv2.imshow("Select a view (ENTER to use)", vis)
             k = cv2.waitKey(1) & 0xFF
             if k == 27:  # ESC
-                return
-            if k == 13:  # ENTER
+                print("[i] quit requested; exiting without writing board YAML.")
+                return 0
+            if k in (10, 13):  # ENTER
                 frame = c.copy()
                 g2 = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
                 dets = det.detect(
@@ -356,16 +337,15 @@ def main():
     entries.sort(key=lambda e: e["id"])
 
     # ---- Write board YAML ----
-    out_path = boards_dir / f"{args.object_name}.yaml"
-    board = dict(
-        object=args.object_name,
+    out_path = paths.board_yaml_path
+    board = build_board_yaml(
+        object_name=args.object_name,
         family=args.family,
-        tag_size_m=tag_size_m,
-        origin_id=int(origin_id),
-        tags=entries,
-        notes="Board frame = origin tag centre; x,y follow origin tag axes; z ≈ 0."
+        tag_size_mm=args.tag_size_mm,
+        origin_id=origin_id,
+        entries=entries,
     )
-    _atomic_write_yaml(out_path, board)
+    write_board_yaml(out_path, board)
     print(f"[i] Wrote {out_path}")
     print("[i] Example entries:")
     for e in entries:
@@ -373,24 +353,16 @@ def main():
 
     # ---- Update registry ----
     reg = load_registry(registry_path)
-    updated, conflicts = 0, []
-    for e in entries:
-        tid = str(e["id"])
-        current = reg["tags"].get(tid)
-        if current is None or current.get("yaml") == str(out_path):
-            reg["tags"][tid] = {"object": args.object_name, "yaml": str(out_path)}
-            updated += 1
-        else:
-            conflicts.append((tid, current["yaml"], str(out_path)))
+    registry_update = update_registry_entries(reg, board["tags"], args.object_name, out_path)
 
-    if conflicts:
+    if registry_update.conflicts:
         print("[!] Registry conflicts:")
-        for tid, oldp, newp in conflicts:
-            print(f"    tag {tid}: {oldp}  ->  {newp}")
+        for conflict in registry_update.conflicts:
+            print(f"    tag {conflict.tag_id}: {conflict.existing_yaml}  ->  {conflict.requested_yaml}")
         # By design we *don't* overwrite automatically here. Edit or delete the old mapping if intended.
 
     save_registry(registry_path, reg)
-    print(f"[i] Registry updated ({updated} entries) at {registry_path}")
+    print(f"[i] Registry updated ({registry_update.updated} entries) at {registry_path}")
 
 
 if __name__ == "__main__":

--- a/src/make_board.py
+++ b/src/make_board.py
@@ -206,6 +206,16 @@ def main(argv=None):
     except MakeBoardError as exc:
         raise SystemExit(str(exc)) from exc
 
+    fx, fy, cx, cy = calib.camera_params
+
+    tag_size_m = args.tag_size_mm / 1000.0
+    try:
+        det = Detector(families=args.family, nthreads=4, quad_decimate=1.0, refine_edges=True)
+    except Exception as exc:
+        raise SystemExit(
+            f"Could not initialize AprilTag detector for family '{args.family}': {exc}"
+        ) from exc
+
     read_frame, stop = _open_source(args)
     try:
         paths = prepare_project_paths(
@@ -223,11 +233,6 @@ def main(argv=None):
     project_root = paths.project_root
     shots_dir = paths.shots_dir
     registry_path = paths.registry_path
-
-    fx, fy, cx, cy = calib.camera_params
-
-    tag_size_m = args.tag_size_mm / 1000.0
-    det = Detector(families=args.family, nthreads=4, quad_decimate=1.0, refine_edges=True)
 
     # ---- Live preview & capture ----
     print(f"[i] Project root = {project_root}")

--- a/src/posetag/cli/make_board.py
+++ b/src/posetag/cli/make_board.py
@@ -1,7 +1,7 @@
 """PoseTag CLI wrapper for AprilTag board creation."""
 
 
-def main():
+def main(argv=None):
     from make_board import main as _main
 
-    return _main()
+    return _main(argv)

--- a/src/posetag/pipelines/make_board.py
+++ b/src/posetag/pipelines/make_board.py
@@ -1,0 +1,338 @@
+"""Reusable helpers for PoseTag Step 2 board building.
+
+The interactive capture loop remains in the legacy top-level ``make_board``
+module for now.  The helpers here cover validation, path preparation, board
+YAML construction, calibration loading, and tag-registry updates so Step 2 can
+be tested without camera hardware.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import shutil
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Sequence, Union
+
+import numpy as np
+import yaml
+
+try:
+    from posetag.utils.project_config import ensure_project_dirs, resolve_project_root
+except ModuleNotFoundError:
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from posetag.utils.project_config import ensure_project_dirs, resolve_project_root
+
+
+BOARD_NOTES = "Board frame = origin tag centre; x,y follow origin tag axes; z ≈ 0."
+
+
+class MakeBoardError(ValueError):
+    """User-facing validation error for Step 2 board building."""
+
+
+@dataclass(frozen=True)
+class CalibrationData:
+    """Loaded camera intrinsics needed by pupil-apriltags pose estimation."""
+
+    path: Path
+    camera_params: tuple[float, float, float, float]
+    camera_matrix: np.ndarray
+    distortion_coefficients: np.ndarray
+
+
+@dataclass(frozen=True)
+class MakeBoardPaths:
+    """Resolved Step 2 project and output paths."""
+
+    project_root: Path
+    boards_dir: Path
+    shots_dir: Path
+    registry_path: Path
+    board_yaml_path: Path
+
+
+@dataclass(frozen=True)
+class RegistryConflict:
+    """A tag registry conflict that was not overwritten."""
+
+    tag_id: str
+    existing_yaml: str
+    requested_yaml: str
+
+
+@dataclass(frozen=True)
+class RegistryUpdate:
+    """Summary of registry updates applied in memory."""
+
+    updated: int
+    conflicts: tuple[RegistryConflict, ...]
+
+
+def _atomic_write_yaml(path: Union[Path, str], data: Mapping[str, Any]) -> None:
+    """Write YAML atomically to avoid partial registry/board files."""
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix="._tmp_yaml_", dir=str(target.parent))
+    os.close(fd)
+    tmp = Path(tmp_name)
+    try:
+        with tmp.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(dict(data), handle, sort_keys=False)
+        shutil.move(str(tmp), str(target))
+    finally:
+        if tmp.exists():
+            tmp.unlink()
+
+
+def preview_project_root(project_root: Optional[Union[Path, str]]) -> Path:
+    """Resolve a project root for read-only validation.
+
+    An explicit ``--project_root`` is normalized without creating directories.
+    When no root is supplied, PoseTag's existing project resolver is used so
+    default behavior remains compatible with earlier workflow steps.
+    """
+
+    if project_root is not None:
+        return Path(project_root).expanduser().resolve()
+    return Path(resolve_project_root(None))
+
+
+def resolve_calibration_path(
+    project_root: Union[Path, str],
+    calib: Optional[Union[Path, str]] = "calib_color.yaml",
+) -> Path:
+    """Resolve the calibration YAML used by Step 2.
+
+    Relative calibration names are project-aware: PoseTag first checks
+    ``<project_root>/calib/<name>`` and then falls back to the literal relative
+    path for compatibility with older script usage.
+    """
+
+    raw = Path(calib or "calib_color.yaml").expanduser()
+    if raw.is_absolute():
+        return raw
+
+    project_candidate = Path(project_root).expanduser().resolve() / "calib" / raw
+    if project_candidate.exists() or not raw.exists():
+        return project_candidate
+    return raw
+
+
+def load_calibration_yaml(path: Union[Path, str]) -> CalibrationData:
+    """Load and validate the Step 1 colour-camera calibration YAML."""
+
+    target = Path(path)
+    if not target.exists():
+        raise MakeBoardError(
+            f"Calibration YAML not found: {target}. Run Step 1 to create calib_color.yaml first."
+        )
+
+    try:
+        with target.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise MakeBoardError(f"Malformed calibration YAML: {target}: {exc}") from exc
+    except OSError as exc:
+        raise MakeBoardError(f"Could not read calibration YAML: {target}: {exc}") from exc
+
+    if not isinstance(data, Mapping):
+        raise MakeBoardError(f"Malformed calibration YAML: {target} must contain a mapping.")
+
+    camera_matrix = data.get("camera_matrix")
+    if not isinstance(camera_matrix, Mapping):
+        raise MakeBoardError(
+            f"Malformed calibration YAML: {target} is missing camera_matrix fields."
+        )
+
+    missing = [name for name in ("fx", "fy", "cx", "cy") if name not in camera_matrix]
+    if missing:
+        joined = ", ".join(f"camera_matrix.{name}" for name in missing)
+        raise MakeBoardError(f"Malformed calibration YAML: {target} is missing {joined}.")
+
+    try:
+        fx = float(camera_matrix["fx"])
+        fy = float(camera_matrix["fy"])
+        cx = float(camera_matrix["cx"])
+        cy = float(camera_matrix["cy"])
+    except (TypeError, ValueError) as exc:
+        raise MakeBoardError(
+            f"Malformed calibration YAML: {target} camera_matrix values must be numeric."
+        ) from exc
+
+    distortion = data.get("distortion_coefficients") or {}
+    if not isinstance(distortion, Mapping):
+        raise MakeBoardError(
+            f"Malformed calibration YAML: {target} distortion_coefficients must be a mapping."
+        )
+
+    camera_matrix_array = np.array([[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]], float)
+    distortion_array = np.array(
+        [
+            [
+                float(distortion.get("k1", 0.0)),
+                float(distortion.get("k2", 0.0)),
+                float(distortion.get("p1", 0.0)),
+                float(distortion.get("p2", 0.0)),
+                float(distortion.get("k3", 0.0)),
+            ]
+        ],
+        float,
+    )
+    return CalibrationData(
+        path=target,
+        camera_params=(fx, fy, cx, cy),
+        camera_matrix=camera_matrix_array,
+        distortion_coefficients=distortion_array,
+    )
+
+
+def validate_source_args(source: str, video: Optional[str], realsense_module: Any) -> None:
+    """Validate source-specific arguments before opening hardware or writing files."""
+
+    if source == "video":
+        if not video:
+            raise MakeBoardError("--video path is required when --source=video")
+        if not Path(video).expanduser().exists():
+            raise MakeBoardError(f"Could not open video: {video}")
+    if source == "realsense" and realsense_module is None:
+        raise MakeBoardError(
+            "pyrealsense2 is not available; install PoseTag with the 'realsense' "
+            "extra or use --source opencv|video"
+        )
+
+
+def prepare_project_paths(
+    project_root: Optional[Union[Path, str]],
+    object_name: str,
+    out_dir: Optional[Union[Path, str]] = None,
+    shots_dir: Optional[Union[Path, str]] = None,
+    registry: Optional[Union[Path, str]] = None,
+    save_shot: bool = False,
+) -> MakeBoardPaths:
+    """Resolve and create the Step 2 output layout."""
+
+    pr = Path(resolve_project_root(project_root))
+    ensure_project_dirs(pr)
+
+    boards_dir = Path(out_dir).expanduser() if out_dir else pr / "boards"
+    resolved_shots_dir = Path(shots_dir).expanduser() if shots_dir else boards_dir / "shots"
+    registry_path = Path(registry).expanduser() if registry else boards_dir / "tag_registry.yaml"
+    board_yaml_path = boards_dir / f"{object_name}.yaml"
+
+    boards_dir.mkdir(parents=True, exist_ok=True)
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    if save_shot:
+        resolved_shots_dir.mkdir(parents=True, exist_ok=True)
+
+    return MakeBoardPaths(
+        project_root=pr,
+        boards_dir=boards_dir,
+        shots_dir=resolved_shots_dir,
+        registry_path=registry_path,
+        board_yaml_path=board_yaml_path,
+    )
+
+
+def build_board_yaml(
+    object_name: str,
+    family: str,
+    tag_size_mm: float,
+    origin_id: int,
+    entries: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Build the public board YAML schema from computed tag entries."""
+
+    tag_size_m = float(tag_size_mm) / 1000.0
+    tags: list[dict[str, Any]] = []
+    for entry in entries:
+        tags.append(
+            {
+                "id": int(entry["id"]),
+                "cx": float(entry["cx"]),
+                "cy": float(entry["cy"]),
+                "yaw_deg": float(entry["yaw_deg"]),
+            }
+        )
+
+    tags.sort(key=lambda item: item["id"])
+    return {
+        "object": object_name,
+        "family": family,
+        "tag_size_m": tag_size_m,
+        "origin_id": int(origin_id),
+        "tags": tags,
+        "notes": BOARD_NOTES,
+    }
+
+
+def write_board_yaml(path: Union[Path, str], board: Mapping[str, Any]) -> None:
+    """Write a board YAML file."""
+
+    _atomic_write_yaml(Path(path), board)
+
+
+def load_registry(path: Union[Path, str]) -> dict[str, Any]:
+    """Load the tag registry, returning an empty versioned registry if absent."""
+
+    target = Path(path)
+    if not target.exists():
+        return {"version": 1, "updated": None, "tags": {}}
+    try:
+        with target.open("r", encoding="utf-8") as handle:
+            registry = yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:
+        raise MakeBoardError(f"Malformed tag registry YAML: {target}: {exc}") from exc
+    if not isinstance(registry, dict):
+        raise MakeBoardError(f"Malformed tag registry YAML: {target} must contain a mapping.")
+    registry.setdefault("version", 1)
+    tags = registry.setdefault("tags", {})
+    if not isinstance(tags, dict):
+        raise MakeBoardError(f"Malformed tag registry YAML: {target} tags must be a mapping.")
+    return registry
+
+
+def update_registry_entries(
+    registry: dict[str, Any],
+    entries: Iterable[Mapping[str, Any]],
+    object_name: str,
+    board_yaml_path: Union[Path, str],
+) -> RegistryUpdate:
+    """Update registry mappings without overwriting conflicting tag IDs."""
+
+    tags = registry.setdefault("tags", {})
+    requested_yaml = str(Path(board_yaml_path))
+    updated = 0
+    conflicts: list[RegistryConflict] = []
+
+    for entry in entries:
+        tag_id = str(int(entry["id"]))
+        current = tags.get(tag_id)
+        if current is None or current.get("yaml") == requested_yaml:
+            tags[tag_id] = {"object": object_name, "yaml": requested_yaml}
+            updated += 1
+            continue
+
+        conflicts.append(
+            RegistryConflict(
+                tag_id=tag_id,
+                existing_yaml=str(current.get("yaml")),
+                requested_yaml=requested_yaml,
+            )
+        )
+
+    return RegistryUpdate(updated=updated, conflicts=tuple(conflicts))
+
+
+def save_registry(path: Union[Path, str], registry: Mapping[str, Any]) -> None:
+    """Write the tag registry with an updated UTC timestamp."""
+
+    data = dict(registry)
+    data["updated"] = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+    _atomic_write_yaml(Path(path), data)

--- a/src/posetag/pipelines/make_board.py
+++ b/src/posetag/pipelines/make_board.py
@@ -171,20 +171,18 @@ def load_calibration_yaml(path: Union[Path, str]) -> CalibrationData:
         raise MakeBoardError(
             f"Malformed calibration YAML: {target} distortion_coefficients must be a mapping."
         )
+    distortion_values: list[float] = []
+    for name in ("k1", "k2", "p1", "p2", "k3"):
+        try:
+            distortion_values.append(float(distortion.get(name, 0.0)))
+        except (TypeError, ValueError) as exc:
+            raise MakeBoardError(
+                f"Malformed calibration YAML: {target} "
+                f"distortion_coefficients.{name} must be numeric."
+            ) from exc
 
     camera_matrix_array = np.array([[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]], float)
-    distortion_array = np.array(
-        [
-            [
-                float(distortion.get("k1", 0.0)),
-                float(distortion.get("k2", 0.0)),
-                float(distortion.get("p1", 0.0)),
-                float(distortion.get("p2", 0.0)),
-                float(distortion.get("k3", 0.0)),
-            ]
-        ],
-        float,
-    )
+    distortion_array = np.array([distortion_values], float)
     return CalibrationData(
         path=target,
         camera_params=(fx, fy, cx, cy),

--- a/tests/test_step2_make_board.py
+++ b/tests/test_step2_make_board.py
@@ -1,0 +1,451 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import numpy as np
+import yaml
+
+import make_board as legacy_make_board
+from posetag.cli import make_board as make_board_cli
+from posetag.pipelines.make_board import (
+    build_board_yaml,
+    load_registry,
+    prepare_project_paths,
+    resolve_calibration_path,
+    save_registry,
+    update_registry_entries,
+    write_board_yaml,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _write_calibration(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(
+            {
+                "image_width": 640,
+                "image_height": 480,
+                "camera_matrix": {
+                    "fx": 600.0,
+                    "fy": 610.0,
+                    "cx": 320.0,
+                    "cy": 240.0,
+                },
+                "distortion_coefficients": {
+                    "k1": 0.0,
+                    "k2": 0.0,
+                    "p1": 0.0,
+                    "p2": 0.0,
+                    "k3": 0.0,
+                },
+            },
+            handle,
+        )
+
+
+class FakeDetector:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def detect(self, *args, **kwargs):
+        return []
+
+
+class MakeBoardStep2Tests(unittest.TestCase):
+    def isolated_env(self, base: Path) -> dict[str, str]:
+        return {
+            "HOME": str(base / "home"),
+            "XDG_CONFIG_HOME": str(base / ".config"),
+        }
+
+    def test_cli_help_resolves(self) -> None:
+        stdout = StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            with redirect_stdout(stdout):
+                make_board_cli.main(["--help"])
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("Interactive AprilTag board builder", stdout.getvalue())
+        self.assertIn("--source", stdout.getvalue())
+
+    def test_console_script_target_help_resolves_after_install(self) -> None:
+        code = (
+            "from posetag.cli.make_board import main\n"
+            "try:\n"
+            "    main(['--help'])\n"
+            "except SystemExit as exc:\n"
+            "    raise SystemExit(exc.code)\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Interactive AprilTag board builder", result.stdout)
+
+    def test_direct_legacy_script_help_resolves_from_checkout(self) -> None:
+        result = subprocess.run(
+            [sys.executable, "src/make_board.py", "--help"],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Interactive AprilTag board builder", result.stdout)
+
+    def test_direct_legacy_script_help_resolves_outside_checkout_cwd(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            result = subprocess.run(
+                [sys.executable, str(REPO_ROOT / "src" / "make_board.py"), "--help"],
+                cwd=tmpdir,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Interactive AprilTag board builder", result.stdout)
+
+    def test_missing_video_for_video_source_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            with self.assertRaises(SystemExit) as ctx:
+                make_board_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--object_name",
+                        "connection_plate_white_sideA",
+                        "--source",
+                        "video",
+                    ]
+                )
+
+            self.assertIn("--video path is required", str(ctx.exception))
+            self.assertFalse((project_root / "boards").exists())
+
+    def test_unreadable_video_path_fails_before_project_artifacts(self) -> None:
+        class FakeClosedVideoCapture:
+            def __init__(self, _path: str) -> None:
+                pass
+
+            def isOpened(self) -> bool:
+                return False
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            video = base / "empty.mp4"
+            video.touch()
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+
+            with patch.dict(os.environ, self.isolated_env(base), clear=False):
+                with patch("make_board._load_detector_class", return_value=FakeDetector):
+                    with patch("make_board.cv2.VideoCapture", FakeClosedVideoCapture):
+                        with self.assertRaises(SystemExit) as ctx:
+                            make_board_cli.main(
+                                [
+                                    "--project_root",
+                                    str(project_root),
+                                    "--object_name",
+                                    "connection_plate_white_sideA",
+                                    "--source",
+                                    "video",
+                                    "--video",
+                                    str(video),
+                                ]
+                            )
+
+            self.assertIn("Could not open video", str(ctx.exception))
+            self.assertFalse((project_root / "boards").exists())
+
+    def test_realsense_source_without_dependency_fails_clearly(self) -> None:
+        with patch("make_board.rs", None):
+            with self.assertRaises(SystemExit) as ctx:
+                make_board_cli.main(
+                    [
+                        "--object_name",
+                        "connection_plate_white_sideA",
+                        "--source",
+                        "realsense",
+                    ]
+                )
+
+        self.assertIn("pyrealsense2 is not available", str(ctx.exception))
+
+    def test_missing_calibration_yaml_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            with self.assertRaises(SystemExit) as ctx:
+                make_board_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--object_name",
+                        "connection_plate_white_sideA",
+                    ]
+                )
+
+            self.assertIn("Calibration YAML not found", str(ctx.exception))
+            self.assertFalse((project_root / "boards").exists())
+
+    def test_malformed_calibration_yaml_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib = project_root / "calib" / "calib_color.yaml"
+            calib.parent.mkdir(parents=True)
+            calib.write_text("not_camera_matrix: true\n", encoding="utf-8")
+
+            with self.assertRaises(SystemExit) as ctx:
+                make_board_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--object_name",
+                        "connection_plate_white_sideA",
+                    ]
+                )
+
+            self.assertIn("Malformed calibration YAML", str(ctx.exception))
+            self.assertFalse((project_root / "boards").exists())
+
+    def test_calibration_resolution_finds_project_calib_color_yaml(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            expected = project_root / "calib" / "calib_color.yaml"
+            _write_calibration(expected)
+
+            resolved = resolve_calibration_path(project_root, "calib_color.yaml")
+
+            self.assertEqual(resolved.resolve(), expected.resolve())
+
+    def test_project_path_preparation_creates_expected_board_paths(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            with patch.dict(os.environ, self.isolated_env(base), clear=False):
+                paths = prepare_project_paths(
+                    project_root=project_root,
+                    object_name="connection_plate_white_sideA",
+                )
+
+            self.assertTrue((project_root / "boards").is_dir())
+            self.assertEqual(paths.boards_dir.resolve(), (project_root / "boards").resolve())
+            self.assertEqual(
+                paths.board_yaml_path.resolve(),
+                (project_root / "boards" / "connection_plate_white_sideA.yaml").resolve(),
+            )
+            self.assertEqual(
+                paths.registry_path.resolve(),
+                (project_root / "boards" / "tag_registry.yaml").resolve(),
+            )
+
+    def test_explicit_output_overrides_are_respected(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            out_dir = base / "custom_boards"
+            registry = base / "registry" / "tags.yaml"
+            shots_dir = base / "audit_shots"
+
+            with patch.dict(os.environ, self.isolated_env(base), clear=False):
+                paths = prepare_project_paths(
+                    project_root=project_root,
+                    object_name="connection_plate_white_sideA",
+                    out_dir=out_dir,
+                    registry=registry,
+                    shots_dir=shots_dir,
+                    save_shot=True,
+                )
+
+            self.assertEqual(paths.boards_dir, out_dir)
+            self.assertEqual(paths.board_yaml_path, out_dir / "connection_plate_white_sideA.yaml")
+            self.assertEqual(paths.registry_path, registry)
+            self.assertEqual(paths.shots_dir, shots_dir)
+            self.assertTrue(out_dir.is_dir())
+            self.assertTrue(registry.parent.is_dir())
+            self.assertTrue(shots_dir.is_dir())
+
+    def test_board_yaml_schema_generation_round_trips(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "board.yaml"
+            board = build_board_yaml(
+                object_name="connection_plate_white_sideA",
+                family="tag36h11",
+                tag_size_mm=80.0,
+                origin_id=52,
+                entries=[
+                    {"id": 53, "cx": 0.1, "cy": -0.2, "yaw_deg": 180.0},
+                    {"id": 52, "cx": 0.0, "cy": 0.0, "yaw_deg": 0.0},
+                ],
+            )
+
+            write_board_yaml(path, board)
+            loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+            for key in ("object", "family", "tag_size_m", "origin_id", "tags", "notes"):
+                self.assertIn(key, loaded)
+            self.assertEqual(loaded["object"], "connection_plate_white_sideA")
+            self.assertEqual(loaded["tag_size_m"], 0.08)
+            self.assertEqual([entry["id"] for entry in loaded["tags"]], [52, 53])
+            for entry in loaded["tags"]:
+                for key in ("id", "cx", "cy", "yaw_deg"):
+                    self.assertIn(key, entry)
+
+    def test_tag_registry_creation_and_update(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            registry_path = Path(tmpdir) / "boards" / "tag_registry.yaml"
+            board_path = Path(tmpdir) / "boards" / "connection_plate_white_sideA.yaml"
+            registry = load_registry(registry_path)
+
+            update = update_registry_entries(
+                registry,
+                [{"id": 52}, {"id": 53}],
+                "connection_plate_white_sideA",
+                board_path,
+            )
+            save_registry(registry_path, registry)
+            loaded = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(update.updated, 2)
+            self.assertEqual(update.conflicts, ())
+            self.assertEqual(loaded["version"], 1)
+            self.assertEqual(
+                loaded["tags"]["52"],
+                {"object": "connection_plate_white_sideA", "yaml": str(board_path)},
+            )
+            self.assertIn("updated", loaded)
+
+    def test_tag_registry_conflict_does_not_silently_overwrite(self) -> None:
+        registry = {
+            "version": 1,
+            "updated": None,
+            "tags": {
+                "52": {"object": "old_face", "yaml": "/tmp/old_face.yaml"},
+            },
+        }
+
+        update = update_registry_entries(
+            registry,
+            [{"id": 52}, {"id": 53}],
+            "connection_plate_white_sideA",
+            "/tmp/connection_plate_white_sideA.yaml",
+        )
+
+        self.assertEqual(update.updated, 1)
+        self.assertEqual(len(update.conflicts), 1)
+        self.assertEqual(registry["tags"]["52"]["yaml"], "/tmp/old_face.yaml")
+        self.assertEqual(
+            registry["tags"]["53"]["yaml"],
+            "/tmp/connection_plate_white_sideA.yaml",
+        )
+
+    def test_esc_exits_cleanly_without_writing_board_yaml(self) -> None:
+        class FakeVideoCapture:
+            def __init__(self, _path: str) -> None:
+                pass
+
+            def isOpened(self) -> bool:
+                return True
+
+            def read(self):
+                return True, np.zeros((20, 20, 3), dtype=np.uint8)
+
+            def release(self) -> None:
+                pass
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            video = base / "sample.mp4"
+            video.touch()
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+            stdout = StringIO()
+
+            with patch.dict(os.environ, self.isolated_env(base), clear=False):
+                with patch("make_board._load_detector_class", return_value=FakeDetector):
+                    with patch("make_board.cv2.VideoCapture", FakeVideoCapture):
+                        with patch("make_board.cv2.imshow"):
+                            with patch("make_board.cv2.waitKey", return_value=27):
+                                with patch("make_board.cv2.destroyAllWindows"):
+                                    with redirect_stdout(stdout):
+                                        result = make_board_cli.main(
+                                            [
+                                                "--project_root",
+                                                str(project_root),
+                                                "--object_name",
+                                                "connection_plate_white_sideA",
+                                                "--source",
+                                                "video",
+                                                "--video",
+                                                str(video),
+                                            ]
+                                        )
+
+            self.assertEqual(result, 0)
+            self.assertIn("quit requested", stdout.getvalue())
+            self.assertFalse((project_root / "boards" / "connection_plate_white_sideA.yaml").exists())
+
+    def test_video_eof_exits_without_hanging_or_writing_board_yaml(self) -> None:
+        class FakeVideoCapture:
+            def __init__(self, _path: str) -> None:
+                pass
+
+            def isOpened(self) -> bool:
+                return True
+
+            def read(self):
+                return False, None
+
+            def release(self) -> None:
+                pass
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            video = base / "sample.mp4"
+            video.touch()
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+            stdout = StringIO()
+
+            with patch.dict(os.environ, self.isolated_env(base), clear=False):
+                with patch("make_board._load_detector_class", return_value=FakeDetector):
+                    with patch("make_board.cv2.VideoCapture", FakeVideoCapture):
+                        with patch("make_board.cv2.destroyAllWindows"):
+                            with redirect_stdout(stdout):
+                                result = make_board_cli.main(
+                                    [
+                                        "--project_root",
+                                        str(project_root),
+                                        "--object_name",
+                                        "connection_plate_white_sideA",
+                                        "--source",
+                                        "video",
+                                        "--video",
+                                        str(video),
+                                    ]
+                                )
+
+            self.assertEqual(result, 0)
+            self.assertIn("video ended", stdout.getvalue())
+            self.assertFalse((project_root / "boards" / "connection_plate_white_sideA.yaml").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_step2_make_board.py
+++ b/tests/test_step2_make_board.py
@@ -225,6 +225,66 @@ class MakeBoardStep2Tests(unittest.TestCase):
             self.assertIn("Malformed calibration YAML", str(ctx.exception))
             self.assertFalse((project_root / "boards").exists())
 
+    def test_non_numeric_distortion_coefficients_fail_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib = project_root / "calib" / "calib_color.yaml"
+            _write_calibration(calib)
+            data = yaml.safe_load(calib.read_text(encoding="utf-8"))
+            data["distortion_coefficients"]["k1"] = "not-a-number"
+            calib.write_text(yaml.safe_dump(data), encoding="utf-8")
+
+            with self.assertRaises(SystemExit) as ctx:
+                make_board_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--object_name",
+                        "connection_plate_white_sideA",
+                    ]
+                )
+
+            self.assertIn("Malformed calibration YAML", str(ctx.exception))
+            self.assertIn("distortion_coefficients.k1", str(ctx.exception))
+            self.assertFalse((project_root / "boards").exists())
+
+    def test_detector_initialization_failure_does_not_open_source(self) -> None:
+        class RaisingDetector:
+            def __init__(self, *args, **kwargs) -> None:
+                raise RuntimeError("unsupported family")
+
+        class SourceShouldNotOpen:
+            def __init__(self, _path: str) -> None:
+                raise AssertionError("source opened before detector initialized")
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            video = base / "sample.mp4"
+            video.touch()
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+
+            with patch.dict(os.environ, self.isolated_env(base), clear=False):
+                with patch("make_board._load_detector_class", return_value=RaisingDetector):
+                    with patch("make_board.cv2.VideoCapture", SourceShouldNotOpen):
+                        with self.assertRaises(SystemExit) as ctx:
+                            make_board_cli.main(
+                                [
+                                    "--project_root",
+                                    str(project_root),
+                                    "--object_name",
+                                    "connection_plate_white_sideA",
+                                    "--source",
+                                    "video",
+                                    "--video",
+                                    str(video),
+                                ]
+                            )
+
+            self.assertIn("Could not initialize AprilTag detector", str(ctx.exception))
+            self.assertIn("unsupported family", str(ctx.exception))
+            self.assertFalse((project_root / "boards").exists())
+
     def test_calibration_resolution_finds_project_calib_color_yaml(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"


### PR DESCRIPTION
@qub-arise, based on issue #32, this PR aims to validate the Step 2 board-building workflow and tag-registry outputs for `posetag-make-board` while preserving the existing board-frame algorithm.

closes #32 

## Summary

- Keeps `posetag-make-board` as a thin public wrapper over the retained legacy interactive loop.
- Adds tested Step 2 helpers for calibration path resolution/loading, output path preparation, board YAML construction, and tag-registry load/update/write behavior.
- Hardens source/calibration failure paths so bad video/source/calibration inputs fail clearly before board YAML or registry artifacts are created.
- Preserves the scientific board-frame contract: origin tag centre, x/y axes from the origin tag, planar z approximately 0, `tag_size_m` in metres, and `yaw_deg` as in-plane yaw around +z.
- Adds hardware-free Step 2 tests covering help resolution, legacy script compatibility, bad source/calibration inputs, path overrides, board YAML schema, registry conflict behavior, ESC exit, and video EOF.
- Updates README Step 2 to match the command behavior.

## Validation

- `python3 -m pytest tests/test_step2_make_board.py -q` -> 17 passed
- `python3 -m pytest -q` -> 55 passed, 6 subtests passed
- `git diff --check` -> passed
- Earlier pre-cleanup validation also included `python3 -m compileall -q src utils tests`, editable install, and installed `posetag-make-board --help` smoke checks.

## Residual Risks

- Hardware behavior still needs manual validation with an actual webcam and RealSense device.
- Video/camera UI behavior is covered with fakes where feasible, but not by end-to-end image fixtures.
- Registry paths remain string paths as produced by the current implementation; portable registry path policy is deferred.

## Remaining Technical Debt

- The full interactive capture loop still lives in `src/make_board.py`; only pure validation/schema/path helpers were moved into `src/posetag/pipelines/make_board.py` for this issue.
- A future package-first architecture issue should migrate the full Step 2 workflow after workflow boundaries through at least Steps 0-3 are validated.
