### PR TITLE
Add PoseTag project status validators

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ packages = [
   "posetag.cli",
   "posetag.pipelines",
   "posetag.utils",
+  "posetag.workflows",
   "gt6dof_atag",
   "gt6dof_atag.cli",
   "gt6dof_atag.utils",

--- a/src/posetag/workflows/__init__.py
+++ b/src/posetag/workflows/__init__.py
@@ -1,0 +1,9 @@
+"""Workflow inspection helpers for PoseTag project dashboards."""
+
+from posetag.workflows.status import (
+    StageSummary,
+    WorkflowStatus,
+    inspect_project,
+)
+
+__all__ = ["StageSummary", "WorkflowStatus", "inspect_project"]

--- a/src/posetag/workflows/status.py
+++ b/src/posetag/workflows/status.py
@@ -1,0 +1,448 @@
+"""Read-only workflow status inspection for PoseTag project directories.
+
+The helpers in this module are GUI-independent.  They report whether the
+validated PoseTag workflow artifacts for Steps 0-2 are present and readable,
+while leaving camera capture, calibration, board construction, annotation, and
+pose-estimation algorithms in their existing pipeline modules.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Union
+
+import yaml
+
+from posetag.pipelines.make_board import (
+    MakeBoardError,
+    load_calibration_yaml,
+    load_registry,
+)
+
+
+class WorkflowStatus(str, Enum):
+    """Workflow-stage status values consumed by frontends."""
+
+    COMPLETE = "complete"
+    MISSING = "missing"
+    NEEDS_ATTENTION = "needs_attention"
+    NOT_APPLICABLE = "not_applicable"
+
+
+@dataclass(frozen=True)
+class StageSummary:
+    """Structured status for one PoseTag workflow stage."""
+
+    stage_id: int
+    key: str
+    name: str
+    status: WorkflowStatus
+    message: str
+    checked_paths: tuple[str, ...]
+    warnings: tuple[str, ...]
+    errors: tuple[str, ...]
+    next_action: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-friendly representation for GUI or CLI renderers."""
+
+        data = asdict(self)
+        data["status"] = self.status.value
+        data["checked_paths"] = list(self.checked_paths)
+        data["warnings"] = list(self.warnings)
+        data["errors"] = list(self.errors)
+        return data
+
+
+_STAGE_NAMES = {
+    0: ("generate_tags", "Generate AprilTag Sheets"),
+    1: ("calibrate_camera", "Calibrate Camera"),
+    2: ("build_boards", "Build Boards"),
+    3: ("capture_face_shots", "Capture Face Shots"),
+    4: ("annotate_faces", "Annotate Faces"),
+    5: ("collect_dataset", "Collect Dataset"),
+    6: ("review_export", "Review and Export"),
+}
+
+_BOARD_REQUIRED_FIELDS = ("object", "family", "tag_size_m", "origin_id", "tags", "notes")
+_BOARD_TAG_REQUIRED_FIELDS = ("id", "cx", "cy", "yaw_deg")
+
+
+def inspect_project(project_root: Union[Path, str]) -> list[StageSummary]:
+    """Inspect a PoseTag project directory and return stage status summaries.
+
+    The function is intentionally read-only: it does not call project-root
+    resolvers, create directories, launch commands, import GUI frameworks, or
+    open cameras.
+    """
+
+    root = Path(project_root).expanduser()
+    summaries = [
+        inspect_step0(root),
+        inspect_step1(root),
+        inspect_step2(root),
+    ]
+    summaries.extend(
+        _placeholder_summaries(
+            step2_complete=summaries[2].status == WorkflowStatus.COMPLETE
+        )
+    )
+    return summaries
+
+
+def inspect_step0(project_root: Union[Path, str]) -> StageSummary:
+    """Inspect Step 0 AprilTag sheet outputs."""
+
+    root = Path(project_root).expanduser()
+    patterns_dir = root / "boards" / "patterns"
+    png_paths = sorted(path for path in patterns_dir.glob("*.png") if path.is_file())
+    checked_paths = _path_tuple([patterns_dir, *png_paths])
+
+    if png_paths:
+        count = len(png_paths)
+        return _stage(
+            stage_id=0,
+            status=WorkflowStatus.COMPLETE,
+            message=f"Found {count} AprilTag sheet PNG file{'s' if count != 1 else ''}.",
+            checked_paths=checked_paths,
+            next_action="Proceed to Step 1 camera calibration.",
+        )
+
+    return _stage(
+        stage_id=0,
+        status=WorkflowStatus.MISSING,
+        message="No generated AprilTag sheet PNG files were found.",
+        checked_paths=checked_paths,
+        next_action="Run posetag-gen-tags to write sheets under boards/patterns/.",
+    )
+
+
+def inspect_step1(project_root: Union[Path, str]) -> StageSummary:
+    """Inspect Step 1 colour-camera calibration output."""
+
+    root = Path(project_root).expanduser()
+    calib_path = root / "calib" / "calib_color.yaml"
+    checked_paths = _path_tuple([calib_path])
+
+    if not calib_path.exists():
+        return _stage(
+            stage_id=1,
+            status=WorkflowStatus.MISSING,
+            message="Colour-camera calibration YAML was not found.",
+            checked_paths=checked_paths,
+            next_action="Run posetag-calib-charuco to create calib/calib_color.yaml.",
+        )
+
+    try:
+        load_calibration_yaml(calib_path)
+    except MakeBoardError as exc:
+        return _stage(
+            stage_id=1,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="Colour-camera calibration YAML exists but did not pass schema checks.",
+            checked_paths=checked_paths,
+            errors=(str(exc),),
+            next_action="Regenerate or repair calib/calib_color.yaml before building boards.",
+        )
+
+    return _stage(
+        stage_id=1,
+        status=WorkflowStatus.COMPLETE,
+        message="Colour-camera calibration YAML exists and passed schema checks.",
+        checked_paths=checked_paths,
+        next_action="Proceed to Step 2 board building.",
+    )
+
+
+def inspect_step2(project_root: Union[Path, str]) -> StageSummary:
+    """Inspect Step 2 board YAML files and tag registry output."""
+
+    root = Path(project_root).expanduser()
+    registry_path = root / "boards" / "tag_registry.yaml"
+    checked_paths: list[Path] = [registry_path]
+
+    if not registry_path.exists():
+        return _stage(
+            stage_id=2,
+            status=WorkflowStatus.MISSING,
+            message="Tag registry YAML was not found.",
+            checked_paths=_path_tuple(checked_paths),
+            next_action="Run posetag-make-board after completing camera calibration.",
+        )
+
+    try:
+        registry = load_registry(registry_path)
+    except MakeBoardError as exc:
+        return _stage(
+            stage_id=2,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="Tag registry YAML exists but did not pass schema checks.",
+            checked_paths=_path_tuple(checked_paths),
+            errors=(str(exc),),
+            next_action="Repair boards/tag_registry.yaml or rerun posetag-make-board.",
+        )
+
+    tags = registry.get("tags", {})
+    if not tags:
+        return _stage(
+            stage_id=2,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="Tag registry YAML has no tag mappings.",
+            checked_paths=_path_tuple(checked_paths),
+            errors=("boards/tag_registry.yaml must contain at least one tag mapping.",),
+            next_action="Run posetag-make-board and select at least one visible tag.",
+        )
+
+    warnings: list[str] = []
+    errors: list[str] = []
+    valid_board_paths: set[Path] = set()
+
+    for tag_id, entry in _sorted_registry_entries(tags):
+        if not isinstance(entry, Mapping):
+            errors.append(f"Registry entry {tag_id!r} must be a mapping.")
+            continue
+
+        yaml_value = entry.get("yaml")
+        if not isinstance(yaml_value, str) or not yaml_value.strip():
+            errors.append(f"Registry entry {tag_id!r} is missing a board YAML path.")
+            continue
+
+        board_path = _resolve_registry_board_path(root, registry_path, yaml_value)
+        checked_paths.append(board_path)
+        if not board_path.exists():
+            errors.append(
+                f"Referenced board YAML for tag {tag_id!r} was not found: {board_path}"
+            )
+            continue
+
+        board_errors = _validate_board_yaml(board_path)
+        if board_errors:
+            errors.extend(f"{board_path}: {message}" for message in board_errors)
+            continue
+
+        valid_board_paths.add(board_path)
+
+    if errors:
+        if valid_board_paths:
+            warnings.append(
+                f"Found {len(valid_board_paths)} valid referenced board YAML file"
+                f"{'s' if len(valid_board_paths) != 1 else ''}, but the registry also has errors."
+            )
+        return _stage(
+            stage_id=2,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="Tag registry or referenced board YAML files need attention.",
+            checked_paths=_path_tuple(checked_paths),
+            warnings=tuple(warnings),
+            errors=tuple(errors),
+            next_action=(
+                "Repair the registry references or rerun posetag-make-board "
+                "for the affected board."
+            ),
+        )
+
+    if not valid_board_paths:
+        return _stage(
+            stage_id=2,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="No referenced board YAML files passed schema checks.",
+            checked_paths=_path_tuple(checked_paths),
+            errors=("At least one referenced board YAML must exist and match the Step 2 schema.",),
+            next_action="Run posetag-make-board to create a board YAML and registry mapping.",
+        )
+
+    count = len(valid_board_paths)
+    return _stage(
+        stage_id=2,
+        status=WorkflowStatus.COMPLETE,
+        message=(
+            f"Tag registry maps tags to {count} valid board YAML "
+            f"file{'s' if count != 1 else ''}."
+        ),
+        checked_paths=_path_tuple(checked_paths),
+        next_action="Proceed to Step 3 face-shot capture.",
+    )
+
+
+def _placeholder_summaries(step2_complete: bool) -> list[StageSummary]:
+    if step2_complete:
+        step3 = _stage(
+            stage_id=3,
+            status=WorkflowStatus.MISSING,
+            message="Face-shot capture status validation is not implemented yet.",
+            checked_paths=(),
+            next_action="Run the Step 3 capture workflow after confirming board coverage.",
+        )
+    else:
+        step3 = _stage(
+            stage_id=3,
+            status=WorkflowStatus.NOT_APPLICABLE,
+            message="Face-shot capture depends on a valid tag registry and board YAML.",
+            checked_paths=(),
+            next_action="Complete Step 2 before checking Step 3.",
+        )
+
+    return [
+        step3,
+        _stage(
+            stage_id=4,
+            status=WorkflowStatus.NOT_APPLICABLE,
+            message="Face annotation depends on captured face shots.",
+            checked_paths=(),
+            next_action="Complete Step 3 before checking Step 4.",
+        ),
+        _stage(
+            stage_id=5,
+            status=WorkflowStatus.NOT_APPLICABLE,
+            message="Dataset collection depends on calibration, boards, and annotations.",
+            checked_paths=(),
+            next_action="Complete Steps 1-4 before checking Step 5.",
+        ),
+        _stage(
+            stage_id=6,
+            status=WorkflowStatus.NOT_APPLICABLE,
+            message="Review and export depends on generated dataset outputs.",
+            checked_paths=(),
+            next_action="Complete Step 5 before checking Step 6.",
+        ),
+    ]
+
+
+def _validate_board_yaml(path: Path) -> tuple[str, ...]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        return (f"Malformed board YAML: {exc}",)
+    except OSError as exc:
+        return (f"Could not read board YAML: {exc}",)
+
+    if not isinstance(data, Mapping):
+        return ("Board YAML must contain a mapping.",)
+
+    errors: list[str] = []
+    for field in _BOARD_REQUIRED_FIELDS:
+        if field not in data:
+            errors.append(f"Board YAML is missing required field {field!r}.")
+
+    if errors:
+        return tuple(errors)
+
+    for field in ("object", "family", "notes"):
+        if not isinstance(data.get(field), str) or not data[field].strip():
+            errors.append(f"Board YAML field {field!r} must be a non-empty string.")
+
+    _require_number(data, "tag_size_m", errors)
+    _require_int(data, "origin_id", errors)
+
+    tags = data.get("tags")
+    if not isinstance(tags, list) or not tags:
+        errors.append("Board YAML field 'tags' must be a non-empty list.")
+    else:
+        for index, tag in enumerate(tags):
+            if not isinstance(tag, Mapping):
+                errors.append(f"Board YAML tag entry {index} must be a mapping.")
+                continue
+            for field in _BOARD_TAG_REQUIRED_FIELDS:
+                if field not in tag:
+                    errors.append(
+                        f"Board YAML tag entry {index} is missing field {field!r}."
+                    )
+            _require_int(tag, "id", errors, prefix=f"Board YAML tag entry {index}")
+            for field in ("cx", "cy", "yaw_deg"):
+                _require_number(tag, field, errors, prefix=f"Board YAML tag entry {index}")
+
+    return tuple(errors)
+
+
+def _resolve_registry_board_path(
+    project_root: Path,
+    registry_path: Path,
+    yaml_value: str,
+) -> Path:
+    raw = Path(yaml_value).expanduser()
+    if raw.is_absolute():
+        return raw
+
+    candidates = [
+        project_root / raw,
+        registry_path.parent / raw,
+    ]
+    if raw.parts and raw.parts[0] == project_root.name:
+        candidates.append(project_root.parent / raw)
+    candidates.append(raw)
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def _sorted_registry_entries(tags: Mapping[Any, Any]) -> Iterable[tuple[str, Any]]:
+    return sorted(
+        ((str(tag_id), entry) for tag_id, entry in tags.items()),
+        key=lambda item: item[0],
+    )
+
+
+def _stage(
+    stage_id: int,
+    status: WorkflowStatus,
+    message: str,
+    checked_paths: Iterable[Union[Path, str]],
+    next_action: str,
+    warnings: tuple[str, ...] = (),
+    errors: tuple[str, ...] = (),
+) -> StageSummary:
+    key, name = _STAGE_NAMES[stage_id]
+    return StageSummary(
+        stage_id=stage_id,
+        key=key,
+        name=name,
+        status=status,
+        message=message,
+        checked_paths=tuple(str(path) for path in checked_paths),
+        warnings=warnings,
+        errors=errors,
+        next_action=next_action,
+    )
+
+
+def _path_tuple(paths: Iterable[Union[Path, str]]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(str(path) for path in paths))
+
+
+def _require_number(
+    data: Mapping[str, Any],
+    field: str,
+    errors: list[str],
+    prefix: Optional[str] = None,
+) -> None:
+    label = f"{prefix} field {field!r}" if prefix else f"Board YAML field {field!r}"
+    try:
+        value = float(data[field])
+    except (KeyError, TypeError, ValueError):
+        errors.append(f"{label} must be numeric.")
+        return
+    if not math.isfinite(value):
+        errors.append(f"{label} must be finite.")
+
+
+def _require_int(
+    data: Mapping[str, Any],
+    field: str,
+    errors: list[str],
+    prefix: Optional[str] = None,
+) -> None:
+    label = f"{prefix} field {field!r}" if prefix else f"Board YAML field {field!r}"
+    try:
+        value = data[field]
+        int(value)
+    except (KeyError, TypeError, ValueError):
+        errors.append(f"{label} must be an integer.")
+        return
+    if isinstance(value, bool) or (isinstance(value, float) and not value.is_integer()):
+        errors.append(f"{label} must be an integer.")

--- a/src/posetag/workflows/status.py
+++ b/src/posetag/workflows/status.py
@@ -57,6 +57,12 @@ class StageSummary:
         return data
 
 
+@dataclass(frozen=True)
+class _BoardSchema:
+    object_name: str
+    tag_ids: frozenset[int]
+
+
 _STAGE_NAMES = {
     0: ("generate_tags", "Generate AprilTag Sheets"),
     1: ("calibrate_camera", "Calibrate Camera"),
@@ -67,6 +73,17 @@ _STAGE_NAMES = {
     6: ("review_export", "Review and Export"),
 }
 
+_CALIBRATION_REQUIRED_FIELDS = (
+    "image_width",
+    "image_height",
+    "camera_matrix",
+    "distortion_coefficients",
+    "reproj_rms",
+    "model",
+    "notes",
+)
+_CALIBRATION_CAMERA_MATRIX_FIELDS = ("fx", "fy", "cx", "cy", "data")
+_CALIBRATION_DISTORTION_FIELDS = ("k1", "k2", "p1", "p2", "k3", "data")
 _BOARD_REQUIRED_FIELDS = ("object", "family", "tag_size_m", "origin_id", "tags", "notes")
 _BOARD_TAG_REQUIRED_FIELDS = ("id", "cx", "cy", "yaw_deg")
 
@@ -148,6 +165,17 @@ def inspect_step1(project_root: Union[Path, str]) -> StageSummary:
             next_action="Regenerate or repair calib/calib_color.yaml before building boards.",
         )
 
+    workflow_errors = _validate_calibration_workflow_schema(calib_path)
+    if workflow_errors:
+        return _stage(
+            stage_id=1,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="Colour-camera calibration YAML exists but is incomplete.",
+            checked_paths=checked_paths,
+            errors=workflow_errors,
+            next_action="Regenerate or repair calib/calib_color.yaml before building boards.",
+        )
+
     return _stage(
         stage_id=1,
         status=WorkflowStatus.COMPLETE,
@@ -199,10 +227,21 @@ def inspect_step2(project_root: Union[Path, str]) -> StageSummary:
     warnings: list[str] = []
     errors: list[str] = []
     valid_board_paths: set[Path] = set()
+    board_cache: dict[Path, _BoardSchema] = {}
 
     for tag_id, entry in _sorted_registry_entries(tags):
         if not isinstance(entry, Mapping):
             errors.append(f"Registry entry {tag_id!r} must be a mapping.")
+            continue
+
+        registry_tag_id = _parse_int(tag_id)
+        if registry_tag_id is None:
+            errors.append(f"Registry tag key {tag_id!r} must be an integer tag ID.")
+            continue
+
+        registry_object = entry.get("object")
+        if not isinstance(registry_object, str) or not registry_object.strip():
+            errors.append(f"Registry entry {tag_id!r} is missing an object name.")
             continue
 
         yaml_value = entry.get("yaml")
@@ -218,12 +257,29 @@ def inspect_step2(project_root: Union[Path, str]) -> StageSummary:
             )
             continue
 
-        board_errors = _validate_board_yaml(board_path)
+        board_schema = board_cache.get(board_path)
+        board_errors: tuple[str, ...] = ()
+        if board_schema is None:
+            board_schema, board_errors = _load_board_schema(board_path)
+            if board_schema is not None:
+                board_cache[board_path] = board_schema
         if board_errors:
             errors.extend(f"{board_path}: {message}" for message in board_errors)
             continue
 
         valid_board_paths.add(board_path)
+        if board_schema is None:
+            continue
+        if registry_tag_id not in board_schema.tag_ids:
+            errors.append(
+                f"Registry tag {tag_id!r} is not present in referenced board YAML: "
+                f"{board_path}"
+            )
+        if registry_object != board_schema.object_name:
+            errors.append(
+                f"Registry entry {tag_id!r} maps object {registry_object!r}, "
+                f"but {board_path} declares object {board_schema.object_name!r}."
+            )
 
     if errors:
         if valid_board_paths:
@@ -250,7 +306,10 @@ def inspect_step2(project_root: Union[Path, str]) -> StageSummary:
             status=WorkflowStatus.NEEDS_ATTENTION,
             message="No referenced board YAML files passed schema checks.",
             checked_paths=_path_tuple(checked_paths),
-            errors=("At least one referenced board YAML must exist and match the Step 2 schema.",),
+            errors=(
+                "At least one referenced board YAML must exist and match the "
+                "Step 2 schema.",
+            ),
             next_action="Run posetag-make-board to create a board YAML and registry mapping.",
         )
 
@@ -311,17 +370,89 @@ def _placeholder_summaries(step2_complete: bool) -> list[StageSummary]:
     ]
 
 
-def _validate_board_yaml(path: Path) -> tuple[str, ...]:
+def _validate_calibration_workflow_schema(path: Path) -> tuple[str, ...]:
     try:
         with path.open("r", encoding="utf-8") as handle:
             data = yaml.safe_load(handle)
     except yaml.YAMLError as exc:
-        return (f"Malformed board YAML: {exc}",)
+        return (f"Malformed calibration YAML: {exc}",)
     except OSError as exc:
-        return (f"Could not read board YAML: {exc}",)
+        return (f"Could not read calibration YAML: {exc}",)
 
     if not isinstance(data, Mapping):
-        return ("Board YAML must contain a mapping.",)
+        return ("Calibration YAML must contain a mapping.",)
+
+    errors: list[str] = []
+    for field in _CALIBRATION_REQUIRED_FIELDS:
+        if field not in data:
+            errors.append(f"Calibration YAML is missing required field {field!r}.")
+
+    if errors:
+        return tuple(errors)
+
+    _require_positive_int(data, "image_width", errors, prefix="Calibration YAML")
+    _require_positive_int(data, "image_height", errors, prefix="Calibration YAML")
+    _require_number(data, "reproj_rms", errors, prefix="Calibration YAML")
+
+    for field in ("model", "notes"):
+        if not isinstance(data.get(field), str) or not data[field].strip():
+            errors.append(
+                f"Calibration YAML field {field!r} must be a non-empty string."
+            )
+
+    camera_matrix = data.get("camera_matrix")
+    if not isinstance(camera_matrix, Mapping):
+        errors.append("Calibration YAML field 'camera_matrix' must be a mapping.")
+    else:
+        for field in _CALIBRATION_CAMERA_MATRIX_FIELDS:
+            if field not in camera_matrix:
+                errors.append(
+                    f"Calibration YAML camera_matrix is missing field {field!r}."
+                )
+        if "data" in camera_matrix:
+            _require_numeric_matrix(
+                camera_matrix["data"],
+                "Calibration YAML camera_matrix.data",
+                rows=3,
+                cols=3,
+                errors=errors,
+            )
+
+    distortion = data.get("distortion_coefficients")
+    if not isinstance(distortion, Mapping):
+        errors.append(
+            "Calibration YAML field 'distortion_coefficients' must be a mapping."
+        )
+    else:
+        for field in _CALIBRATION_DISTORTION_FIELDS:
+            if field not in distortion:
+                errors.append(
+                    "Calibration YAML distortion_coefficients is missing "
+                    f"field {field!r}."
+                )
+        if "data" in distortion:
+            _require_numeric_matrix(
+                distortion["data"],
+                "Calibration YAML distortion_coefficients.data",
+                rows=1,
+                min_cols=5,
+                errors=errors,
+            )
+
+    return tuple(errors)
+
+
+def _load_board_schema(path: Path) -> tuple[Optional[_BoardSchema], tuple[str, ...]]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        return None, (f"Malformed board YAML: {exc}",)
+    except OSError as exc:
+        return None, (f"Could not read board YAML: {exc}",)
+
+    if not isinstance(data, Mapping):
+        return None, ("Board YAML must contain a mapping.",)
 
     errors: list[str] = []
     for field in _BOARD_REQUIRED_FIELDS:
@@ -329,7 +460,7 @@ def _validate_board_yaml(path: Path) -> tuple[str, ...]:
             errors.append(f"Board YAML is missing required field {field!r}.")
 
     if errors:
-        return tuple(errors)
+        return None, tuple(errors)
 
     for field in ("object", "family", "notes"):
         if not isinstance(data.get(field), str) or not data[field].strip():
@@ -339,6 +470,7 @@ def _validate_board_yaml(path: Path) -> tuple[str, ...]:
     _require_int(data, "origin_id", errors)
 
     tags = data.get("tags")
+    tag_ids: set[int] = set()
     if not isinstance(tags, list) or not tags:
         errors.append("Board YAML field 'tags' must be a non-empty list.")
     else:
@@ -352,10 +484,19 @@ def _validate_board_yaml(path: Path) -> tuple[str, ...]:
                         f"Board YAML tag entry {index} is missing field {field!r}."
                     )
             _require_int(tag, "id", errors, prefix=f"Board YAML tag entry {index}")
+            tag_id = _parse_int(tag.get("id"))
+            if tag_id is not None:
+                tag_ids.add(tag_id)
             for field in ("cx", "cy", "yaw_deg"):
                 _require_number(tag, field, errors, prefix=f"Board YAML tag entry {index}")
 
-    return tuple(errors)
+    if errors:
+        return None, tuple(errors)
+
+    return _BoardSchema(
+        object_name=str(data["object"]),
+        tag_ids=frozenset(tag_ids),
+    ), ()
 
 
 def _resolve_registry_board_path(
@@ -415,6 +556,18 @@ def _path_tuple(paths: Iterable[Union[Path, str]]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(str(path) for path in paths))
 
 
+def _parse_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if isinstance(value, float) and not value.is_integer():
+        return None
+    return parsed
+
+
 def _require_number(
     data: Mapping[str, Any],
     field: str,
@@ -422,6 +575,9 @@ def _require_number(
     prefix: Optional[str] = None,
 ) -> None:
     label = f"{prefix} field {field!r}" if prefix else f"Board YAML field {field!r}"
+    if isinstance(data.get(field), bool):
+        errors.append(f"{label} must be numeric.")
+        return
     try:
         value = float(data[field])
     except (KeyError, TypeError, ValueError):
@@ -438,11 +594,59 @@ def _require_int(
     prefix: Optional[str] = None,
 ) -> None:
     label = f"{prefix} field {field!r}" if prefix else f"Board YAML field {field!r}"
-    try:
-        value = data[field]
-        int(value)
-    except (KeyError, TypeError, ValueError):
+    parsed = _parse_int(data.get(field))
+    if parsed is None:
         errors.append(f"{label} must be an integer.")
         return
-    if isinstance(value, bool) or (isinstance(value, float) and not value.is_integer()):
+
+
+def _require_positive_int(
+    data: Mapping[str, Any],
+    field: str,
+    errors: list[str],
+    prefix: str,
+) -> None:
+    label = f"{prefix} field {field!r}"
+    parsed = _parse_int(data.get(field))
+    if parsed is None:
         errors.append(f"{label} must be an integer.")
+        return
+    if parsed <= 0:
+        errors.append(f"{label} must be positive.")
+
+
+def _require_numeric_matrix(
+    value: Any,
+    label: str,
+    rows: int,
+    errors: list[str],
+    cols: Optional[int] = None,
+    min_cols: Optional[int] = None,
+) -> None:
+    expected = f"{rows}x{cols}" if cols is not None else f"{rows}x>={min_cols}"
+    if not isinstance(value, list) or len(value) != rows:
+        errors.append(f"{label} must be a {expected} numeric list.")
+        return
+    for row in value:
+        wrong_width = False
+        if not isinstance(row, list):
+            wrong_width = True
+        elif cols is not None and len(row) != cols:
+            wrong_width = True
+        elif min_cols is not None and len(row) < min_cols:
+            wrong_width = True
+        if wrong_width:
+            errors.append(f"{label} must be a {expected} numeric list.")
+            return
+        for item in row:
+            if isinstance(item, bool):
+                errors.append(f"{label} must contain only numeric values.")
+                return
+            try:
+                numeric = float(item)
+            except (TypeError, ValueError):
+                errors.append(f"{label} must contain only numeric values.")
+                return
+            if not math.isfinite(numeric):
+                errors.append(f"{label} must contain only finite values.")
+                return

--- a/tests/test_workflow_status.py
+++ b/tests/test_workflow_status.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import yaml
+
+from posetag.pipelines.charuco_calibration import (
+    build_calibration_yaml,
+    write_calibration_yaml,
+)
+from posetag.pipelines.make_board import build_board_yaml, write_board_yaml
+from posetag.workflows.status import WorkflowStatus, inspect_project
+
+
+def _stage_by_id(project_root: Path, stage_id: int):
+    summaries = inspect_project(project_root)
+    return {summary.stage_id: summary for summary in summaries}[stage_id]
+
+
+def _write_valid_calibration(path: Path) -> None:
+    camera_matrix = np.array(
+        [
+            [600.0, 0.0, 320.0],
+            [0.0, 610.0, 240.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    distortion = np.array([[0.0, 0.0, 0.0, 0.0, 0.0]])
+    data = build_calibration_yaml(
+        image_width=640,
+        image_height=480,
+        camera_matrix=camera_matrix,
+        distortion_coefficients=distortion,
+        reproj_rms=0.12,
+        notes="Synthetic calibration for workflow status tests.",
+    )
+    write_calibration_yaml(path, data)
+
+
+def _write_valid_board_and_registry(project_root: Path) -> tuple[Path, Path]:
+    board_path = project_root / "boards" / "connection_plate_white_sideA.yaml"
+    registry_path = project_root / "boards" / "tag_registry.yaml"
+    board = build_board_yaml(
+        object_name="connection_plate_white_sideA",
+        family="tag36h11",
+        tag_size_mm=80.0,
+        origin_id=52,
+        entries=[
+            {"id": 52, "cx": 0.0, "cy": 0.0, "yaw_deg": 0.0},
+            {"id": 53, "cx": 0.1, "cy": -0.2, "yaw_deg": 180.0},
+        ],
+    )
+    write_board_yaml(board_path, board)
+    registry = {
+        "version": 1,
+        "updated": "2026-05-27T12:00:00Z",
+        "tags": {
+            "52": {"object": "connection_plate_white_sideA", "yaml": str(board_path)},
+            "53": {"object": "connection_plate_white_sideA", "yaml": str(board_path)},
+        },
+    }
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(yaml.safe_dump(registry), encoding="utf-8")
+    return board_path, registry_path
+
+
+class WorkflowStatusTests(unittest.TestCase):
+    def test_empty_project_reports_steps_0_to_2_missing(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            summaries = inspect_project(project_root)
+            by_id = {summary.stage_id: summary for summary in summaries}
+
+            self.assertEqual(by_id[0].status, WorkflowStatus.MISSING)
+            self.assertEqual(by_id[1].status, WorkflowStatus.MISSING)
+            self.assertEqual(by_id[2].status, WorkflowStatus.MISSING)
+            self.assertEqual(len(summaries), 7)
+            for summary in summaries:
+                rendered = summary.to_dict()
+                for key in (
+                    "stage_id",
+                    "key",
+                    "name",
+                    "status",
+                    "message",
+                    "checked_paths",
+                    "warnings",
+                    "errors",
+                    "next_action",
+                ):
+                    self.assertIn(key, rendered)
+
+    def test_patterns_png_marks_step0_complete(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            patterns_dir = project_root / "boards" / "patterns"
+            patterns_dir.mkdir(parents=True)
+            (patterns_dir / "apriltag_sheet.png").write_bytes(
+                b"not-an-image-but-a-png-path"
+            )
+
+            stage = _stage_by_id(project_root, 0)
+
+            self.assertEqual(stage.status, WorkflowStatus.COMPLETE)
+            self.assertIn(str(patterns_dir / "apriltag_sheet.png"), stage.checked_paths)
+
+    def test_valid_calib_color_yaml_marks_step1_complete(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_valid_calibration(project_root / "calib" / "calib_color.yaml")
+
+            stage = _stage_by_id(project_root, 1)
+
+            self.assertEqual(stage.status, WorkflowStatus.COMPLETE)
+            self.assertEqual(stage.errors, ())
+
+    def test_malformed_calib_color_yaml_needs_attention(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib_path = project_root / "calib" / "calib_color.yaml"
+            calib_path.parent.mkdir(parents=True)
+            calib_path.write_text("not_camera_matrix: true\n", encoding="utf-8")
+
+            stage = _stage_by_id(project_root, 1)
+
+            self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
+            self.assertTrue(stage.errors)
+            self.assertIn("Malformed calibration YAML", stage.errors[0])
+
+    def test_valid_board_yaml_and_registry_mark_step2_complete(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            board_path, registry_path = _write_valid_board_and_registry(project_root)
+
+            stage = _stage_by_id(project_root, 2)
+
+            self.assertEqual(stage.status, WorkflowStatus.COMPLETE)
+            self.assertEqual(stage.errors, ())
+            self.assertIn(str(registry_path), stage.checked_paths)
+            self.assertIn(str(board_path), stage.checked_paths)
+
+    def test_registry_referencing_missing_board_yaml_needs_attention(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            registry_path = project_root / "boards" / "tag_registry.yaml"
+            missing_board = project_root / "boards" / "missing_board.yaml"
+            registry_path.parent.mkdir(parents=True)
+            registry_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "version": 1,
+                        "updated": "2026-05-27T12:00:00Z",
+                        "tags": {
+                            "52": {
+                                "object": "connection_plate_white_sideA",
+                                "yaml": str(missing_board),
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            stage = _stage_by_id(project_root, 2)
+
+            self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
+            self.assertTrue(stage.errors)
+            self.assertIn("was not found", stage.errors[0])
+
+    def test_workflow_helpers_import_without_gui_dependency(self) -> None:
+        code = (
+            "from posetag.workflows.status import inspect_project\n"
+            "import sys\n"
+            "raise SystemExit(1 if 'PySide6' in sys.modules else 0)\n"
+        )
+
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_status.py
+++ b/tests/test_workflow_status.py
@@ -132,6 +132,38 @@ class WorkflowStatusTests(unittest.TestCase):
             self.assertTrue(stage.errors)
             self.assertIn("Malformed calibration YAML", stage.errors[0])
 
+    def test_calib_color_yaml_missing_workflow_fields_needs_attention(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib_path = project_root / "calib" / "calib_color.yaml"
+            calib_path.parent.mkdir(parents=True)
+            calib_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "camera_matrix": {
+                            "fx": 600.0,
+                            "fy": 610.0,
+                            "cx": 320.0,
+                            "cy": 240.0,
+                        },
+                        "distortion_coefficients": {
+                            "k1": 0.0,
+                            "k2": 0.0,
+                            "p1": 0.0,
+                            "p2": 0.0,
+                            "k3": 0.0,
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            stage = _stage_by_id(project_root, 1)
+
+            self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
+            self.assertTrue(any("image_width" in error for error in stage.errors))
+            self.assertTrue(any("reproj_rms" in error for error in stage.errors))
+
     def test_valid_board_yaml_and_registry_mark_step2_complete(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
@@ -171,6 +203,54 @@ class WorkflowStatusTests(unittest.TestCase):
             self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
             self.assertTrue(stage.errors)
             self.assertIn("was not found", stage.errors[0])
+
+    def test_registry_tag_missing_from_board_yaml_needs_attention(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            board_path = project_root / "boards" / "connection_plate_white_sideA.yaml"
+            registry_path = project_root / "boards" / "tag_registry.yaml"
+            board = build_board_yaml(
+                object_name="connection_plate_white_sideA",
+                family="tag36h11",
+                tag_size_mm=80.0,
+                origin_id=52,
+                entries=[{"id": 52, "cx": 0.0, "cy": 0.0, "yaw_deg": 0.0}],
+            )
+            write_board_yaml(board_path, board)
+            registry_path.write_text(
+                yaml.safe_dump(
+                    {
+                        "version": 1,
+                        "updated": "2026-05-27T12:00:00Z",
+                        "tags": {
+                            "99": {
+                                "object": "connection_plate_white_sideA",
+                                "yaml": str(board_path),
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            stage = _stage_by_id(project_root, 2)
+
+            self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
+            self.assertTrue(any("not present" in error for error in stage.errors))
+
+    def test_registry_object_mismatch_needs_attention(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            board_path, registry_path = _write_valid_board_and_registry(project_root)
+            registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+            registry["tags"]["52"]["object"] = "different_object"
+            registry_path.write_text(yaml.safe_dump(registry), encoding="utf-8")
+
+            stage = _stage_by_id(project_root, 2)
+
+            self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
+            self.assertTrue(any("different_object" in error for error in stage.errors))
+            self.assertTrue(any(str(board_path) in error for error in stage.errors))
 
     def test_workflow_helpers_import_without_gui_dependency(self) -> None:
         code = (


### PR DESCRIPTION
Based on issue #35, this PR aims to add a GUI-independent workflow status layer that a future PoseTag dashboard can consume without duplicating scientific workflow logic.

## Summary
- Adds `posetag.workflows.status.inspect_project(project_root)` returning structured `StageSummary` objects for Steps 0-6.
- Defines the workflow statuses `complete`, `missing`, `needs_attention`, and `not_applicable`.
- Checks Step 0 generated AprilTag sheet PNGs under `boards/patterns/`.
- Checks Step 1 `calib/calib_color.yaml` using the existing calibration YAML loader/schema checks.
- Checks Step 2 `boards/tag_registry.yaml`, tag mappings, referenced board YAML existence, and expected board YAML schema.
- Adds placeholder statuses for Steps 3-6 without adding GUI code, command launching, camera access, or workflow orchestration.
- Adds hardware-free tests using temporary project folders and synthetic YAML/PNG files.

## Validation
- `python3 -m unittest tests.test_workflow_status -v`
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q src utils tests`
- `git diff --check`

## Residual Risks
- Step 2 board YAML validation is intentionally local to the status layer because PoseTag does not yet have a canonical `posetag.io` board-schema loader.
- Steps 3-6 remain placeholders until their workflows and output schemas are validated.

## Remaining Technical Debt
- Move board/registry schema validation into package-first IO helpers during a later architecture pass.
- Extend status checks for capture, annotation, dataset collection, and review/export after those workflow stages are hardened.
