### PR TITLE
Build workflow dashboard MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Optional extras:
 
 ```bash
 python3 -m pip install -e ".[apriltags]"
+python3 -m pip install -e ".[gui]"
 python3 -m pip install -e ".[realsense]"
 python3 -m pip install -e ".[scipy]"
 ```
@@ -93,6 +94,20 @@ posetag project home
 By default PoseTag uses `~/posetag` as the projects home. During the migration
 it still discovers legacy project homes under `~/gt-6dof` and still accepts the
 legacy `GTAT_PROJECT` / `GTAT_PROJECTS_DIR` environment variables.
+
+## Workflow Dashboard
+
+PoseTag includes an optional read-only PySide6 dashboard for inspecting workflow
+status from the same package helpers used by tests and command-line tools:
+
+```bash
+python3 -m pip install -e ".[gui]"
+posetag-gui --project_root my_project
+```
+
+The MVP dashboard shows the project root, stages 0-6, checked paths, warnings,
+errors, next recommended action, and copyable command previews. It does not
+launch camera, calibration, board-building, annotation, or dataset workflows.
 
 ## Scientific Contract
 
@@ -793,6 +808,7 @@ are:
 - `posetag-capture-face` -> face-shot capture
 - `posetag-annotate` -> single, batch, and browse annotation flows
 - `posetag-collect` -> dataset capture
+- `posetag-gui` -> optional read-only workflow status dashboard
 - `python3 -m gen_keypoints` -> canonical keypoint generation
 - `python3 -m view_keypoints` -> mesh/keypoint visualisation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = ["numpy", "opencv-python>=4.5", "PyYAML"]
 
 [project.optional-dependencies]
 apriltags = ["pupil-apriltags"]
+gui = ["PySide6"]
 realsense = ["pyrealsense2"]
 scipy = ["scipy"]
 
@@ -25,6 +26,7 @@ posetag-make-board = "posetag.cli.make_board:main"
 posetag-capture-face = "posetag.cli.capture_face:main"
 posetag-annotate = "posetag.cli.annotate:main"
 posetag-collect = "posetag.cli.collect:main"
+posetag-gui = "posetag.gui.app:main"
 gtat = "gt6dof_atag.cli.gtat:main"
 gtat-gen-tags = "gt6dof_atag.cli.gen_tags:main"
 gtat-calib-charuco = "gt6dof_atag.cli.charuco:main"
@@ -41,6 +43,7 @@ packages = [
   "posetag.pipelines",
   "posetag.utils",
   "posetag.workflows",
+  "posetag.gui",
   "gt6dof_atag",
   "gt6dof_atag.cli",
   "gt6dof_atag.utils",

--- a/src/posetag/gui/__init__.py
+++ b/src/posetag/gui/__init__.py
@@ -1,2 +1,1 @@
 """Optional PySide6 presentation layer for PoseTag workflow status."""
-

--- a/src/posetag/gui/__init__.py
+++ b/src/posetag/gui/__init__.py
@@ -1,0 +1,2 @@
+"""Optional PySide6 presentation layer for PoseTag workflow status."""
+

--- a/src/posetag/gui/app.py
+++ b/src/posetag/gui/app.py
@@ -97,4 +97,3 @@ def _load_qt_modules() -> QtModules:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/src/posetag/gui/app.py
+++ b/src/posetag/gui/app.py
@@ -1,0 +1,100 @@
+"""Command-line entry point for the optional PoseTag workflow dashboard."""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+
+INSTALL_HINT = 'pip install -e ".[gui]"'
+
+
+class MissingGuiDependency(RuntimeError):
+    """Raised when the optional PySide6 GUI dependency is unavailable."""
+
+
+@dataclass(frozen=True)
+class QtModules:
+    """Container for lazily imported PySide6 modules."""
+
+    QtCore: Any
+    QtGui: Any
+    QtWidgets: Any
+
+
+class _Formatter(argparse.ArgumentDefaultsHelpFormatter):
+    pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``posetag-gui`` argument parser without importing PySide6."""
+
+    parser = argparse.ArgumentParser(
+        prog="posetag-gui",
+        formatter_class=_Formatter,
+        description="Open the optional PoseTag workflow status dashboard.",
+    )
+    parser.add_argument(
+        "--project_root",
+        "--project-root",
+        dest="project_root",
+        default=".",
+        help="PoseTag project root to inspect.",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Launch the optional PySide6 workflow dashboard."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        return run_gui(args.project_root)
+    except MissingGuiDependency as exc:
+        print(str(exc), file=sys.stderr)
+        print(f'Install the GUI extra with: {INSTALL_HINT}', file=sys.stderr)
+        return 2
+
+
+def run_gui(project_root: str | Path, qt_modules: QtModules | None = None) -> int:
+    """Run the Qt application and return the Qt event-loop exit code."""
+
+    qt = qt_modules or _load_qt_modules()
+    argv = [sys.argv[0] if sys.argv else "posetag-gui"]
+    app = qt.QtWidgets.QApplication.instance()
+    if app is None:
+        app = qt.QtWidgets.QApplication(argv)
+
+    app.setApplicationName("PoseTag")
+    app.setOrganizationName("PoseTag")
+
+    from posetag.gui.main_window import build_main_window
+
+    window = build_main_window(qt, Path(project_root).expanduser())
+    window.resize(1180, 740)
+    window.show()
+    return int(app.exec())
+
+
+def _load_qt_modules() -> QtModules:
+    try:
+        return QtModules(
+            QtCore=importlib.import_module("PySide6.QtCore"),
+            QtGui=importlib.import_module("PySide6.QtGui"),
+            QtWidgets=importlib.import_module("PySide6.QtWidgets"),
+        )
+    except ImportError as exc:
+        raise MissingGuiDependency(
+            "PySide6 is required to launch the PoseTag GUI."
+        ) from exc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/src/posetag/gui/main_window.py
+++ b/src/posetag/gui/main_window.py
@@ -1,0 +1,311 @@
+"""Main window construction for the optional PoseTag workflow dashboard."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Optional
+
+from posetag.gui.models import StageViewModel, inspect_project_view
+
+
+def build_main_window(qt: Any, project_root: Path) -> Any:
+    """Build the PySide6 main window without importing Qt at module import time."""
+
+    QtCore = qt.QtCore
+    QtGui = qt.QtGui
+    QtWidgets = qt.QtWidgets
+
+    class PoseTagMainWindow(QtWidgets.QMainWindow):
+        def __init__(self, initial_project_root: Path) -> None:
+            super().__init__()
+            self._models: tuple[StageViewModel, ...] = ()
+            self._selected_stage_id = 0
+
+            self.setWindowTitle("PoseTag Workflow Dashboard")
+            self._root_input = QtWidgets.QLineEdit(str(initial_project_root))
+            self._root_input.setMinimumWidth(360)
+            self._root_input.returnPressed.connect(self._refresh)
+
+            browse_button = QtWidgets.QPushButton("Browse")
+            browse_button.clicked.connect(self._browse_project_root)
+
+            refresh_button = QtWidgets.QPushButton("Refresh")
+            refresh_button.clicked.connect(self._refresh)
+
+            root_bar = QtWidgets.QHBoxLayout()
+            root_bar.addWidget(QtWidgets.QLabel("Project root"))
+            root_bar.addWidget(self._root_input, 1)
+            root_bar.addWidget(browse_button)
+            root_bar.addWidget(refresh_button)
+
+            self._stage_list = QtWidgets.QListWidget()
+            self._stage_list.setMinimumWidth(260)
+            self._stage_list.setMaximumWidth(330)
+            self._stage_list.currentRowChanged.connect(self._select_stage_by_row)
+
+            self._stage_title = QtWidgets.QLabel()
+            self._stage_title.setObjectName("StageTitle")
+
+            self._status_label = QtWidgets.QLabel()
+            self._status_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+            self._status_label.setMinimumWidth(128)
+            self._status_label.setObjectName("StatusPill")
+
+            title_row = QtWidgets.QHBoxLayout()
+            title_row.addWidget(self._stage_title, 1)
+            title_row.addWidget(self._status_label)
+
+            self._message_label = QtWidgets.QLabel()
+            self._message_label.setWordWrap(True)
+            self._message_label.setObjectName("StageMessage")
+
+            self._details_text = QtWidgets.QPlainTextEdit()
+            self._details_text.setReadOnly(True)
+            self._details_text.setMinimumHeight(320)
+
+            self._command_preview = QtWidgets.QLineEdit()
+            self._command_preview.setReadOnly(True)
+            self._copy_button = QtWidgets.QPushButton("Copy")
+            self._copy_button.clicked.connect(self._copy_command)
+
+            command_row = QtWidgets.QHBoxLayout()
+            command_row.addWidget(QtWidgets.QLabel("Command preview"))
+            command_row.addWidget(self._command_preview, 1)
+            command_row.addWidget(self._copy_button)
+
+            detail_panel = QtWidgets.QWidget()
+            detail_layout = QtWidgets.QVBoxLayout(detail_panel)
+            detail_layout.addLayout(title_row)
+            detail_layout.addWidget(self._message_label)
+            detail_layout.addWidget(self._details_text, 1)
+            detail_layout.addLayout(command_row)
+
+            self._health_text = QtWidgets.QPlainTextEdit()
+            self._health_text.setReadOnly(True)
+            self._health_text.setMinimumWidth(260)
+            self._health_text.setMaximumWidth(380)
+
+            splitter = QtWidgets.QSplitter(QtCore.Qt.Orientation.Horizontal)
+            splitter.addWidget(self._stage_list)
+            splitter.addWidget(detail_panel)
+            splitter.addWidget(self._health_text)
+            splitter.setStretchFactor(0, 0)
+            splitter.setStretchFactor(1, 1)
+            splitter.setStretchFactor(2, 0)
+
+            central = QtWidgets.QWidget()
+            layout = QtWidgets.QVBoxLayout(central)
+            layout.addLayout(root_bar)
+            layout.addWidget(splitter, 1)
+            self.setCentralWidget(central)
+            self.setStyleSheet(_style_sheet())
+
+            self._refresh()
+
+        def _browse_project_root(self) -> None:
+            selected = QtWidgets.QFileDialog.getExistingDirectory(
+                self,
+                "Select PoseTag project root",
+                self._root_input.text() or str(Path.cwd()),
+            )
+            if selected:
+                self._root_input.setText(selected)
+                self._refresh()
+
+        def _refresh(self) -> None:
+            root = Path(self._root_input.text()).expanduser()
+            try:
+                self._models = inspect_project_view(root)
+            except Exception as exc:  # pragma: no cover - defensive UI boundary
+                self._models = ()
+                self._render_error(root, exc)
+                return
+            self._render_stage_list()
+            self._select_stage(self._selected_stage_id)
+            self._render_health()
+
+        def _render_stage_list(self) -> None:
+            self._stage_list.blockSignals(True)
+            self._stage_list.clear()
+            for model in self._models:
+                item = QtWidgets.QListWidgetItem(
+                    f"{model.stage_id}. {model.name}\n{model.status_label}"
+                )
+                item.setData(QtCore.Qt.ItemDataRole.UserRole, model.stage_id)
+                item.setForeground(QtGui.QBrush(QtGui.QColor("#17202a")))
+                item.setBackground(
+                    QtGui.QBrush(QtGui.QColor(_soft_color(model.status)))
+                )
+                self._stage_list.addItem(item)
+            self._stage_list.blockSignals(False)
+
+        def _select_stage_by_row(self, row: int) -> None:
+            item = self._stage_list.item(row)
+            if item is None:
+                return
+            self._select_stage(int(item.data(QtCore.Qt.ItemDataRole.UserRole)))
+
+        def _select_stage(self, stage_id: int) -> None:
+            model = self._model_by_stage_id(stage_id) or self._first_model()
+            if model is None:
+                return
+
+            self._selected_stage_id = model.stage_id
+            for index in range(self._stage_list.count()):
+                item = self._stage_list.item(index)
+                if item.data(QtCore.Qt.ItemDataRole.UserRole) == model.stage_id:
+                    if self._stage_list.currentRow() != index:
+                        self._stage_list.setCurrentRow(index)
+                    break
+
+            self._stage_title.setText(f"Stage {model.stage_id}: {model.name}")
+            self._status_label.setText(model.status_label)
+            self._status_label.setStyleSheet(
+                f"background: {model.status_color}; color: white; "
+                "border-radius: 4px; padding: 5px 10px;"
+            )
+            self._message_label.setText(model.message)
+            self._details_text.setPlainText(_format_stage_details(model))
+            self._command_preview.setText(model.command_preview)
+            self._copy_button.setEnabled(bool(model.command_preview))
+
+        def _render_health(self) -> None:
+            counts: dict[str, int] = {}
+            for model in self._models:
+                counts[model.status_label] = counts.get(model.status_label, 0) + 1
+
+            next_model = _first_actionable_model(self._models)
+            lines = [
+                "Project Health",
+                "",
+                *(f"{label}: {count}" for label, count in sorted(counts.items())),
+                "",
+                "Next recommended action",
+                "",
+                (
+                    next_model.next_action
+                    if next_model
+                    else "All inspected stages are complete."
+                ),
+            ]
+            self._health_text.setPlainText("\n".join(lines))
+
+        def _render_error(self, root: Path, exc: Exception) -> None:
+            self._stage_list.clear()
+            self._stage_title.setText("Project inspection failed")
+            self._status_label.setText("Needs attention")
+            self._message_label.setText(str(root))
+            self._details_text.setPlainText(str(exc))
+            self._command_preview.clear()
+            self._copy_button.setEnabled(False)
+            self._health_text.setPlainText("Project Health\n\nInspection failed.")
+
+        def _copy_command(self) -> None:
+            command = self._command_preview.text()
+            if command:
+                QtWidgets.QApplication.clipboard().setText(command)
+
+        def _model_by_stage_id(self, stage_id: int) -> Optional[StageViewModel]:
+            for model in self._models:
+                if model.stage_id == stage_id:
+                    return model
+            return None
+
+        def _first_model(self) -> Optional[StageViewModel]:
+            return self._models[0] if self._models else None
+
+    return PoseTagMainWindow(project_root)
+
+
+def _format_stage_details(model: StageViewModel) -> str:
+    lines = [
+        "Status",
+        model.status_label,
+        "",
+        "Checked paths",
+        *(_format_items(model.checked_paths) or ["(none)"]),
+        "",
+        "Warnings",
+        *(_format_items(model.warnings) or ["(none)"]),
+        "",
+        "Errors",
+        *(_format_items(model.errors) or ["(none)"]),
+        "",
+        "Next action",
+        model.next_action,
+    ]
+    return "\n".join(lines)
+
+
+def _format_items(items: tuple[str, ...]) -> list[str]:
+    return [f"- {item}" for item in items]
+
+
+def _first_actionable_model(
+    models: tuple[StageViewModel, ...],
+) -> Optional[StageViewModel]:
+    for model in models:
+        if model.status != "complete" and model.status != "not_applicable":
+            return model
+    for model in models:
+        if model.status != "complete":
+            return model
+    return None
+
+
+def _soft_color(status: str) -> str:
+    return {
+        "complete": "#dceee4",
+        "missing": "#fff0bd",
+        "needs_attention": "#f8d8d0",
+        "not_applicable": "#e6e9ed",
+    }.get(status, "#e6e9ed")
+
+
+def _style_sheet() -> str:
+    return """
+QMainWindow, QWidget {
+    background: #f7f8fa;
+    color: #17202a;
+    font-size: 13px;
+}
+QLineEdit, QPlainTextEdit, QListWidget {
+    background: #ffffff;
+    border: 1px solid #cfd6df;
+    border-radius: 4px;
+    padding: 6px;
+}
+QPushButton {
+    background: #244d7a;
+    color: #ffffff;
+    border: 1px solid #1f4268;
+    border-radius: 4px;
+    padding: 7px 12px;
+}
+QPushButton:disabled {
+    background: #b8c1ca;
+    border-color: #aab4bf;
+}
+QListWidget::item {
+    padding: 10px;
+    border-bottom: 1px solid #d8dee6;
+}
+QListWidget::item:selected {
+    background: #e8f1fb;
+    color: #0b1724;
+    border-left: 4px solid #244d7a;
+}
+QListWidget::item:selected:!active {
+    background: #e8f1fb;
+    color: #0b1724;
+    border-left: 4px solid #244d7a;
+}
+QLabel#StageTitle {
+    font-size: 22px;
+    font-weight: 700;
+}
+QLabel#StageMessage {
+    color: #394653;
+    padding: 4px 0 10px 0;
+}
+"""

--- a/src/posetag/gui/models.py
+++ b/src/posetag/gui/models.py
@@ -1,0 +1,84 @@
+"""Qt-independent view models for the PoseTag workflow dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
+
+from posetag.workflows.commands import command_preview
+from posetag.workflows.status import StageSummary, inspect_project
+
+
+_STATUS_LABELS = {
+    "complete": "Complete",
+    "missing": "Missing",
+    "needs_attention": "Needs attention",
+    "not_applicable": "Not applicable",
+}
+
+_STATUS_COLORS = {
+    "complete": "#2f7d4f",
+    "missing": "#8a6a00",
+    "needs_attention": "#b14a33",
+    "not_applicable": "#69717d",
+}
+
+
+@dataclass(frozen=True)
+class StageViewModel:
+    """Display-ready wrapper around a workflow ``StageSummary``."""
+
+    stage_id: int
+    key: str
+    name: str
+    status: str
+    status_label: str
+    status_color: str
+    message: str
+    checked_paths: tuple[str, ...]
+    warnings: tuple[str, ...]
+    errors: tuple[str, ...]
+    next_action: str
+    command_preview: str
+
+    @property
+    def has_issues(self) -> bool:
+        """Return true when the stage has warnings or errors to display."""
+
+        return bool(self.warnings or self.errors)
+
+    @classmethod
+    def from_summary(
+        cls,
+        summary: StageSummary,
+        project_root: Union[Path, str],
+    ) -> "StageViewModel":
+        status = str(summary.status.value)
+        return cls(
+            stage_id=summary.stage_id,
+            key=summary.key,
+            name=summary.name,
+            status=status,
+            status_label=_STATUS_LABELS.get(
+                status,
+                status.replace("_", " ").title(),
+            ),
+            status_color=_STATUS_COLORS.get(status, "#69717d"),
+            message=summary.message,
+            checked_paths=tuple(summary.checked_paths),
+            warnings=tuple(summary.warnings),
+            errors=tuple(summary.errors),
+            next_action=summary.next_action,
+            command_preview=command_preview(summary.key, project_root),
+        )
+
+
+def inspect_project_view(project_root: Union[Path, str]) -> tuple[StageViewModel, ...]:
+    """Inspect a project and return display models for all workflow stages."""
+
+    root = Path(project_root).expanduser()
+    return tuple(
+        StageViewModel.from_summary(summary, root)
+        for summary in inspect_project(root)
+    )

--- a/src/posetag/workflows/__init__.py
+++ b/src/posetag/workflows/__init__.py
@@ -1,9 +1,10 @@
 """Workflow inspection helpers for PoseTag project dashboards."""
 
+from posetag.workflows.commands import command_preview
 from posetag.workflows.status import (
     StageSummary,
     WorkflowStatus,
     inspect_project,
 )
 
-__all__ = ["StageSummary", "WorkflowStatus", "inspect_project"]
+__all__ = ["StageSummary", "WorkflowStatus", "command_preview", "inspect_project"]

--- a/src/posetag/workflows/commands.py
+++ b/src/posetag/workflows/commands.py
@@ -43,10 +43,14 @@ _COMMAND_TEMPLATES = {
         "OBJECT_NAME",
     ),
     "annotate_faces": (
+        "env",
+        "POSETAG_PROJECT={project_root}",
         "posetag-annotate",
         "--browse",
     ),
     "collect_dataset": (
+        "env",
+        "POSETAG_PROJECT={project_root}",
         "posetag-collect",
         "--mode",
         "live",
@@ -67,12 +71,15 @@ def command_preview(stage_key: str, project_root: Union[Path, str]) -> str:
 
     root = str(Path(project_root).expanduser())
     parts = (
-        root if part == "{project_root}" else part
+        _format_part(part, root)
         for part in template
     )
     return _join_command(parts)
 
 
+def _format_part(part: str, project_root: str) -> str:
+    return part.replace("{project_root}", project_root)
+
+
 def _join_command(parts: Iterable[str]) -> str:
     return shlex.join(tuple(parts))
-

--- a/src/posetag/workflows/commands.py
+++ b/src/posetag/workflows/commands.py
@@ -1,0 +1,78 @@
+"""Read-only command previews for PoseTag workflow stages."""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+from typing import Iterable, Union
+
+
+_COMMAND_TEMPLATES = {
+    "generate_tags": (
+        "posetag-gen-tags",
+        "--project_root",
+        "{project_root}",
+        "--tag-size-mm",
+        "TAG_SIZE_MM",
+        "--ids",
+        "TAG_IDS",
+    ),
+    "calibrate_camera": (
+        "posetag-calib-charuco",
+        "--project_root",
+        "{project_root}",
+        "--source",
+        "opencv",
+        "--cam",
+        "0",
+    ),
+    "build_boards": (
+        "posetag-make-board",
+        "--project_root",
+        "{project_root}",
+        "--object_name",
+        "OBJECT_FACE",
+        "--calib",
+        "calib_color.yaml",
+    ),
+    "capture_face_shots": (
+        "posetag-capture-face",
+        "--project_root",
+        "{project_root}",
+        "--object_name",
+        "OBJECT_NAME",
+    ),
+    "annotate_faces": (
+        "posetag-annotate",
+        "--browse",
+    ),
+    "collect_dataset": (
+        "posetag-collect",
+        "--mode",
+        "live",
+        "--session",
+        "SESSION",
+        "--calib",
+        "calib_color.yaml",
+    ),
+}
+
+
+def command_preview(stage_key: str, project_root: Union[Path, str]) -> str:
+    """Return a copyable command preview for a workflow stage, if known."""
+
+    template = _COMMAND_TEMPLATES.get(stage_key)
+    if template is None:
+        return ""
+
+    root = str(Path(project_root).expanduser())
+    parts = (
+        root if part == "{project_root}" else part
+        for part in template
+    )
+    return _join_command(parts)
+
+
+def _join_command(parts: Iterable[str]) -> str:
+    return shlex.join(tuple(parts))
+

--- a/tests/test_rename_phase0.py
+++ b/tests/test_rename_phase0.py
@@ -29,6 +29,7 @@ class RenamePhase0Tests(unittest.TestCase):
         self.assertEqual(project["readme"], "README.md")
         self.assertEqual(scripts["posetag"], "posetag.cli.posetag:main")
         self.assertEqual(scripts["posetag-gen-tags"], "posetag.cli.gen_tags:main")
+        self.assertEqual(scripts["posetag-gui"], "posetag.gui.app:main")
         self.assertEqual(scripts["gtat"], "gt6dof_atag.cli.gtat:main")
 
     def test_script_targets_are_importable(self) -> None:
@@ -41,6 +42,7 @@ class RenamePhase0Tests(unittest.TestCase):
             "posetag-capture-face",
             "posetag-annotate",
             "posetag-collect",
+            "posetag-gui",
             "gtat",
             "gtat-gen-tags",
             "gtat-calib-charuco",

--- a/tests/test_workflow_gui.py
+++ b/tests/test_workflow_gui.py
@@ -100,6 +100,17 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertIn("'/tmp/PoseTag project'", preview)
         self.assertIn("OBJECT_FACE", preview)
 
+    def test_legacy_command_previews_use_selected_project_env(self) -> None:
+        project_root = Path("/tmp/PoseTag project")
+
+        annotate_preview = command_preview("annotate_faces", project_root)
+        collect_preview = command_preview("collect_dataset", project_root)
+
+        self.assertIn("env 'POSETAG_PROJECT=/tmp/PoseTag project'", annotate_preview)
+        self.assertIn("posetag-annotate --browse", annotate_preview)
+        self.assertIn("env 'POSETAG_PROJECT=/tmp/PoseTag project'", collect_preview)
+        self.assertIn("posetag-collect --mode live", collect_preview)
+
     def test_selected_stage_row_keeps_readable_text_style(self) -> None:
         style = _style_sheet()
 

--- a/tests/test_workflow_gui.py
+++ b/tests/test_workflow_gui.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+import tomllib
+import unittest
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from posetag.gui import app as gui_app
+from posetag.gui.main_window import _style_sheet
+from posetag.gui.models import inspect_project_view
+from posetag.workflows.commands import command_preview
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = REPO_ROOT / "src"
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+
+class WorkflowGuiTests(unittest.TestCase):
+    def test_pyproject_declares_optional_gui_extra_and_entry_point(self) -> None:
+        with PYPROJECT_PATH.open("rb") as handle:
+            pyproject = tomllib.load(handle)
+
+        self.assertEqual(
+            pyproject["project"]["optional-dependencies"]["gui"],
+            ["PySide6"],
+        )
+        self.assertEqual(
+            pyproject["project"]["scripts"]["posetag-gui"],
+            "posetag.gui.app:main",
+        )
+        self.assertIn("posetag.gui", pyproject["tool"]["setuptools"]["packages"])
+
+    def test_posetag_gui_help_does_not_require_pyside6(self) -> None:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _pythonpath_with_src(env)
+        result = subprocess.run(
+            [sys.executable, "-m", "posetag.gui.app", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("posetag-gui", result.stdout)
+        self.assertIn("--project_root", result.stdout)
+        self.assertNotIn("PySide6 is required", result.stderr)
+
+    def test_app_accepts_project_root_aliases(self) -> None:
+        parser = gui_app.build_parser()
+
+        underscore = parser.parse_args(["--project_root", "project_a"])
+        hyphen = parser.parse_args(["--project-root", "project_b"])
+
+        self.assertEqual(underscore.project_root, "project_a")
+        self.assertEqual(hyphen.project_root, "project_b")
+
+    def test_missing_pyside6_error_is_clear(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            stderr = StringIO()
+            with patch.object(
+                gui_app,
+                "_load_qt_modules",
+                side_effect=gui_app.MissingGuiDependency("PySide6 is required."),
+            ):
+                with redirect_stderr(stderr):
+                    rc = gui_app.main(["--project_root", tmpdir])
+
+        self.assertEqual(rc, 2)
+        self.assertIn("PySide6 is required", stderr.getvalue())
+        self.assertIn('pip install -e ".[gui]"', stderr.getvalue())
+
+    def test_view_models_are_built_from_workflow_status_helpers(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project with spaces"
+            models = inspect_project_view(project_root)
+
+        self.assertEqual(len(models), 7)
+        self.assertEqual(models[0].stage_id, 0)
+        self.assertEqual(models[0].status, "missing")
+        self.assertIn("posetag-gen-tags", models[0].command_preview)
+        self.assertIn("--project_root", models[0].command_preview)
+        self.assertEqual(models[6].command_preview, "")
+
+    def test_command_preview_quotes_project_paths(self) -> None:
+        preview = command_preview(
+            "build_boards",
+            Path("/tmp/PoseTag project"),
+        )
+
+        self.assertIn("posetag-make-board", preview)
+        self.assertIn("'/tmp/PoseTag project'", preview)
+        self.assertIn("OBJECT_FACE", preview)
+
+    def test_selected_stage_row_keeps_readable_text_style(self) -> None:
+        style = _style_sheet()
+
+        self.assertIn("QListWidget::item:selected", style)
+        self.assertIn("background: #e8f1fb", style)
+        self.assertIn("color: #0b1724", style)
+        self.assertIn("QListWidget::item:selected:!active", style)
+
+    def test_backend_workflow_modules_do_not_import_gui(self) -> None:
+        backend_files = list((SRC_ROOT / "posetag" / "workflows").glob("*.py"))
+        backend_files.extend((SRC_ROOT / "posetag" / "pipelines").glob("*.py"))
+
+        offenders: list[str] = []
+        for path in backend_files:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom):
+                    module = node.module or ""
+                    if module == "posetag.gui" or module.startswith("posetag.gui."):
+                        offenders.append(str(path.relative_to(REPO_ROOT)))
+                elif isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name == "posetag.gui" or alias.name.startswith(
+                            "posetag.gui."
+                        ):
+                            offenders.append(str(path.relative_to(REPO_ROOT)))
+
+        self.assertEqual(offenders, [])
+
+    def test_workflow_status_import_does_not_import_gui_or_pyside6(self) -> None:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = _pythonpath_with_src(env)
+        code = (
+            "from posetag.workflows.status import inspect_project\n"
+            "import sys\n"
+            "bad = [name for name in sys.modules "
+            "if name.startswith('posetag.gui') or name.startswith('PySide6')]\n"
+            "raise SystemExit(1 if bad else 0)\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+
+
+def _pythonpath_with_src(env: dict[str, str]) -> str:
+    existing = env.get("PYTHONPATH")
+    if existing:
+        return f"{SRC_ROOT}{os.pathsep}{existing}"
+    return str(SRC_ROOT)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
@qub-arise, based on issue #36, this PR adds the read-only PoseTag workflow dashboard MVP and requests review.

Summary:
- Add optional PySide6 GUI extra and the `posetag-gui` entry point.
- Add a read-only workflow dashboard that consumes `posetag.workflows.status.inspect_project()` for stages 0-6.
- Add workflow-level command previews, Qt-independent GUI view models, README usage docs, and hardware-free GUI tests.
- Keep workflow and pipeline modules free of GUI imports, with a regression test for the dependency direction.

How to run and use:
1. Install the optional GUI extra with `python3 -m pip install -e ".[gui]"`.
2. Launch with `posetag-gui --project_root my_project`.
3. Use the project-root field, Browse, or Refresh to inspect a project.
4. Select stages in the left rail to view status, checked paths, warnings, errors, next action, and copyable command previews.

Validation:
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q src utils tests`
- `git diff --check`
- `python3 -m posetag.gui.app --project_root .` was checked in the no-PySide6 environment and exits with the expected install hint.

Residual risks / current limitations:
- The MVP is intentionally read-only and does not launch camera, calibration, board-building, annotation, or dataset workflows.
- Automated tests cover CLI/help/import/model/style behavior without requiring PySide6. Visual desktop behavior still benefits from manual review on a machine with the GUI extra installed.

Closes #36.