### PR TITLE
Add guided ChArUco board setup to GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ legacy `GTAT_PROJECT` / `GTAT_PROJECTS_DIR` environment variables.
 
 ## Workflow Dashboard
 
-PoseTag includes an optional read-only PySide6 dashboard for inspecting workflow
-status from the same package helpers used by tests and command-line tools:
+PoseTag includes an optional PySide6 dashboard for inspecting workflow status
+from the same package helpers used by tests and command-line tools:
 
 ```bash
 python3 -m pip install -e ".[gui]"
@@ -107,9 +107,11 @@ posetag-gui --project_root my_project
 
 The dashboard shows the selected project root, stages 0-6, a project-health
 summary, checked paths, warnings, errors, next recommended action, and copyable
-command previews. It can open the selected project folder in the system file
-manager, but it does not launch camera, calibration, board-building,
-annotation, or dataset workflows.
+command previews. In Step 1 it can generate the ChArUco board PNG, PDF, and
+metadata YAML using the same package helper as `posetag-gen-charuco`.
+It can open selected folders in the system file manager, but it does not launch
+camera capture, calibration solving, board-building, annotation, or dataset
+workflows.
 
 ## Scientific Contract
 
@@ -184,8 +186,7 @@ posetag-gen-tags --project_root my_project --tag-size-mm 40 --paper-mm 80x80 --i
 Options you might tweak later: `--paper {A4,LETTER,LEGAL}`, `--paper-mm WxH`,
 `--orientation`, `--dpi`, and `--out_dir`.
 
-PNG output is guaranteed. If Pillow is installed, PoseTag also writes PDF
-output; otherwise it reports that PDF output is optional and continues.
+Standard PoseTag installs write both PNG and PDF sheets.
 
 ---
 
@@ -202,7 +203,7 @@ posetag-gen-charuco --project_root my_project \
   --paper A4 --dpi 300
 ```
 
-This writes a printable PNG, optional PDF, and metadata YAML under:
+This writes a printable PNG, PDF, and metadata YAML under:
 
 ```text
 my_project/calib/boards/
@@ -210,6 +211,9 @@ my_project/calib/boards/
 
 Print at **100%** / **Actual Size** and do not use “Fit to page”. Verify the
 printed square edge with a ruler before calibration.
+
+The optional `posetag-gui` dashboard provides the same ChArUco board setup from
+the Step 1 panel and refreshes project status after writing the files.
 
 Then calibrate with the same board parameters. Press `SPACE` to capture a
 sample and `ENTER` to solve. The calibration command outputs

--- a/docs/workflows/step0_generate_tags.md
+++ b/docs/workflows/step0_generate_tags.md
@@ -10,9 +10,8 @@ posetag-gen-tags --project_root <path> --tag-size-mm <N> --ids <ids>
 
 - Resolves or initializes a PoseTag project when `--project_root` is supplied.
 - Writes printable AprilTag 36h11 sheets.
-- Always writes PNG sheets.
+- Writes PNG and PDF sheets in standard PoseTag installs.
 - Splits output across multiple sheets when the requested IDs do not fit on one page.
-- Also writes PDF sheets when Pillow is installed.
 
 ## Inputs
 
@@ -73,17 +72,14 @@ Explicit output override:
 posetag-gen-tags --project_root my_project --tag-size-mm 40 --ids 1-3,7,9-10 --out_dir exported_patterns
 ```
 
-## Guaranteed Vs Optional Outputs
+## Outputs
 
-- Guaranteed: PNG output.
+- PNG output.
   PNG files include the requested DPI metadata.
-- Optional: PDF output when Pillow is installed.
+- PDF output.
 - Multiple pages: when the requested IDs exceed one sheet, PoseTag writes
   deterministic page-numbered outputs such as `page01of03`, `page02of03`, and
   `page03of03`.
-
-If Pillow is missing, PoseTag still completes the run and reports that the PDF
-was skipped.
 
 ## Failure Modes
 

--- a/docs/workflows/step1_calibrate_charuco.md
+++ b/docs/workflows/step1_calibrate_charuco.md
@@ -49,11 +49,11 @@ Default project-root outputs:
 <project_root>/calib/boards/
   charuco_3x5_square50mm_marker37mm_7X7_50_A4_300dpi.png
   charuco_3x5_square50mm_marker37mm_7X7_50_A4_300dpi.yaml
-  charuco_3x5_square50mm_marker37mm_7X7_50_A4_300dpi.pdf  # when Pillow is installed
+  charuco_3x5_square50mm_marker37mm_7X7_50_A4_300dpi.pdf
 ```
 
-The PNG is guaranteed. PDF output is optional and is written when Pillow is
-available. The metadata YAML round-trips with `yaml.safe_load` and records:
+Standard PoseTag installs write both PNG and PDF output. The metadata YAML
+round-trips with `yaml.safe_load` and records:
 
 ```yaml
 squares_x: 3
@@ -80,6 +80,11 @@ scaled, reprint before calibration.
 Use `--out_dir <path>` to write the PNG/PDF/YAML somewhere other than
 `<project_root>/calib/boards/`. Custom paper can be supplied with
 `--paper-mm WxH`, for example `--paper-mm 210x297`.
+
+The optional `posetag-gui` dashboard exposes this setup as a guided Step 1
+panel. It calls the same package generator as `posetag-gen-charuco`, displays
+the generated PNG/YAML/PDF paths, and refreshes workflow status. It does not
+start camera capture or run `posetag-calib-charuco`.
 
 ## Command Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Samuel Adebayo" }]
 requires-python = ">=3.9"
-dependencies = ["numpy", "opencv-python>=4.5", "PyYAML"]
+dependencies = ["numpy", "opencv-python>=4.5", "Pillow", "PyYAML"]
 
 [project.optional-dependencies]
 apriltags = ["pupil-apriltags"]

--- a/src/posetag/gui/app.py
+++ b/src/posetag/gui/app.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import signal
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -73,11 +74,12 @@ def run_gui(project_root: str | Path, qt_modules: QtModules | None = None) -> in
 
     app.setApplicationName("PoseTag")
     app.setOrganizationName("PoseTag")
+    _install_terminal_shutdown_handlers(app, qt.QtCore)
 
     from posetag.gui.main_window import build_main_window
 
     window = build_main_window(qt, Path(project_root).expanduser())
-    window.resize(1180, 740)
+    window.resize(1280, 800)
     window.show()
     return int(app.exec())
 
@@ -93,6 +95,30 @@ def _load_qt_modules() -> QtModules:
         raise MissingGuiDependency(
             "PySide6 is required to launch the PoseTag GUI."
         ) from exc
+
+
+def _install_terminal_shutdown_handlers(app: Any, qt_core: Any) -> None:
+    """Ask Qt to quit when the launching terminal sends a shutdown signal."""
+
+    def quit_from_signal(_signum: int, _frame: Any) -> None:
+        app.quit()
+
+    signals = [signal.SIGINT, signal.SIGTERM]
+    sighup = getattr(signal, "SIGHUP", None)
+    if sighup is not None:
+        signals.append(sighup)
+
+    for signum in signals:
+        try:
+            signal.signal(signum, quit_from_signal)
+        except (OSError, RuntimeError, ValueError):
+            continue
+
+    timer = qt_core.QTimer()
+    timer.setInterval(200)
+    timer.timeout.connect(lambda: None)
+    timer.start()
+    app._posetag_signal_timer = timer
 
 
 if __name__ == "__main__":

--- a/src/posetag/gui/main_window.py
+++ b/src/posetag/gui/main_window.py
@@ -11,6 +11,24 @@ from posetag.gui.models import (
     inspect_project_view,
     project_health_view,
 )
+from posetag.workflows.charuco_setup import (
+    DEFAULT_DICTIONARY,
+    DEFAULT_DPI,
+    DEFAULT_MARKER_LENGTH_MM,
+    DEFAULT_OUTPUT_FORMAT,
+    DEFAULT_SQUARE_LENGTH_MM,
+    DEFAULT_SQUARES_X,
+    DEFAULT_SQUARES_Y,
+    ORIENTATION_CHOICES,
+    OUTPUT_FORMAT_CHOICES,
+    PAPER_CHOICES,
+    PRINT_GUIDANCE,
+    CharucoBoardSetupConfig,
+    CharucoBoardSetupError,
+    default_output_dir,
+    dictionary_choices,
+    generate_charuco_board_setup,
+)
 
 
 def build_main_window(qt: Any, project_root: Path) -> Any:
@@ -51,11 +69,148 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
         line.setFrameShadow(widgets.QFrame.Shadow.Plain)
         return line
 
+    def _make_int_spin(
+        minimum: int,
+        maximum: int,
+        value: int,
+        suffix: str = "",
+    ) -> Any:
+        spin = QtWidgets.QSpinBox()
+        spin.setRange(minimum, maximum)
+        spin.setValue(value)
+        if suffix:
+            spin.setSuffix(suffix)
+        spin.setMinimumWidth(120)
+        return spin
+
+    def _make_float_spin(
+        minimum: float,
+        maximum: float,
+        value: float,
+        suffix: str = "",
+    ) -> Any:
+        spin = QtWidgets.QDoubleSpinBox()
+        spin.setDecimals(3)
+        spin.setRange(minimum, maximum)
+        spin.setValue(value)
+        spin.setSingleStep(1.0)
+        if suffix:
+            spin.setSuffix(suffix)
+        spin.setMinimumWidth(150)
+        return spin
+
+    def _make_field(label_text: str, field: Any) -> Any:
+        wrapper = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(wrapper)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(4)
+
+        label = QtWidgets.QLabel(label_text)
+        label.setObjectName("FieldLabel")
+        layout.addWidget(label)
+        layout.addWidget(field)
+        return wrapper
+
+    def _safe_dictionary_choices() -> tuple[str, ...]:
+        try:
+            names = dictionary_choices()
+        except Exception:  # pragma: no cover - defensive UI boundary
+            return (DEFAULT_DICTIONARY,)
+        return names or (DEFAULT_DICTIONARY,)
+
+    def _make_stage_rail_entry(model: StageViewModel, selected: bool) -> Any:
+        entry = QtWidgets.QFrame()
+        entry.setObjectName("RailStageEntry")
+        entry.setStyleSheet(_stage_rail_entry_style(model, selected=selected))
+        entry.setAttribute(
+            QtCore.Qt.WidgetAttribute.WA_TransparentForMouseEvents,
+            True,
+        )
+
+        layout = QtWidgets.QHBoxLayout(entry)
+        layout.setContentsMargins(6, 4, 6, 4)
+        layout.setSpacing(5)
+
+        number = QtWidgets.QLabel(str(model.stage_id))
+        number.setObjectName("RailStageNumber")
+        number.setAlignment(
+            QtCore.Qt.AlignmentFlag.AlignLeft | QtCore.Qt.AlignmentFlag.AlignTop
+        )
+        number.setFixedWidth(12)
+        number.setStyleSheet(_stage_rail_number_style(model))
+
+        dot = QtWidgets.QLabel()
+        dot.setObjectName("RailStageDot")
+        dot.setFixedSize(7, 7)
+        dot.setStyleSheet(_stage_rail_dot_style(model))
+
+        copy = QtWidgets.QVBoxLayout()
+        copy.setContentsMargins(0, 0, 0, 0)
+        copy.setSpacing(1)
+
+        name = QtWidgets.QLabel(_stage_rail_name(model))
+        name.setObjectName("RailStageName")
+        name.setWordWrap(True)
+
+        status = QtWidgets.QLabel(_stage_rail_status_label(model))
+        status.setObjectName("RailStageStatus")
+        status.setStyleSheet(_stage_status_chip_style(model))
+
+        copy.addWidget(name)
+        copy.addWidget(status, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
+        layout.addWidget(number, 0, QtCore.Qt.AlignmentFlag.AlignTop)
+        layout.addWidget(dot, 0, QtCore.Qt.AlignmentFlag.AlignTop)
+        layout.addLayout(copy, 1)
+        return entry
+
+    class _CharucoPreviewCanvas(QtWidgets.QLabel):
+        def __init__(self) -> None:
+            super().__init__("No generated board yet.")
+            self._source_pixmap: Any = None
+            self.setObjectName("CharucoPreviewCanvas")
+            self.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+            self.setMinimumSize(300, 300)
+            self.setMaximumHeight(330)
+            self.setWordWrap(True)
+
+        def clear_preview(self, message: str = "No generated board yet.") -> None:
+            self._source_pixmap = None
+            self.clear()
+            self.setText(message)
+
+        def show_preview(self, path: Path) -> bool:
+            pixmap = QtGui.QPixmap(str(path))
+            if pixmap.isNull():
+                self.clear_preview("Preview unavailable.")
+                return False
+            self._source_pixmap = pixmap
+            self.setText("")
+            self._refresh_pixmap()
+            return True
+
+        def resizeEvent(self, event: Any) -> None:
+            super().resizeEvent(event)
+            self._refresh_pixmap()
+
+        def _refresh_pixmap(self) -> None:
+            if self._source_pixmap is None or self._source_pixmap.isNull():
+                return
+            size = self.contentsRect().size()
+            if size.width() <= 0 or size.height() <= 0:
+                return
+            scaled = self._source_pixmap.scaled(
+                size,
+                QtCore.Qt.AspectRatioMode.KeepAspectRatio,
+                QtCore.Qt.TransformationMode.SmoothTransformation,
+            )
+            self.setPixmap(scaled)
+
     class PoseTagMainWindow(QtWidgets.QMainWindow):
         def __init__(self, initial_project_root: Path) -> None:
             super().__init__()
             self._models: tuple[StageViewModel, ...] = ()
             self._selected_stage_id = 0
+            self._stage_widgets: dict[int, Any] = {}
 
             self.setWindowTitle("PoseTag Workflow Dashboard")
 
@@ -79,32 +234,48 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._root_status_label.setObjectName("MutedText")
             self._root_status_label.setWordWrap(True)
 
+            project_root_label = QtWidgets.QLabel("Project root")
+            project_root_label.setObjectName("FieldLabel")
+
             root_bar = QtWidgets.QHBoxLayout()
-            root_bar.addWidget(QtWidgets.QLabel("Project root"))
+            root_bar.addWidget(project_root_label)
             root_bar.addWidget(self._root_input, 1)
             root_bar.addWidget(browse_button)
             root_bar.addWidget(self._open_folder_button)
             root_bar.addWidget(refresh_button)
 
             header_layout = QtWidgets.QVBoxLayout()
-            header_layout.setSpacing(6)
+            header_layout.setSpacing(5)
             header_layout.addWidget(self._project_title)
             header_layout.addLayout(root_bar)
             header_layout.addWidget(self._root_status_label)
 
+            header_panel = QtWidgets.QFrame()
+            header_panel.setObjectName("HeaderPanel")
+            header_panel_layout = QtWidgets.QVBoxLayout(header_panel)
+            header_panel_layout.setContentsMargins(16, 12, 16, 12)
+            header_panel_layout.addLayout(header_layout)
+
             rail_title = QtWidgets.QLabel("Workflow")
             rail_title.setObjectName("PanelTitle")
+
             self._stage_list = QtWidgets.QListWidget()
             self._stage_list.setObjectName("WorkflowRail")
-            self._stage_list.setMinimumWidth(260)
-            self._stage_list.setMaximumWidth(330)
-            self._stage_list.setSpacing(6)
+            self._stage_list.setMinimumWidth(126)
+            self._stage_list.setMaximumWidth(134)
+            self._stage_list.setSpacing(4)
+            self._stage_list.setHorizontalScrollBarPolicy(
+                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            )
             self._stage_list.currentRowChanged.connect(self._select_stage_by_row)
 
-            rail_panel = QtWidgets.QWidget()
+            rail_panel = QtWidgets.QFrame()
+            rail_panel.setObjectName("RailPanel")
+            rail_panel.setMinimumWidth(150)
+            rail_panel.setMaximumWidth(158)
             rail_layout = QtWidgets.QVBoxLayout(rail_panel)
-            rail_layout.setContentsMargins(0, 0, 0, 0)
-            rail_layout.setSpacing(10)
+            rail_layout.setContentsMargins(10, 12, 10, 12)
+            rail_layout.setSpacing(8)
             rail_layout.addWidget(rail_title)
             rail_layout.addWidget(self._stage_list, 1)
 
@@ -129,6 +300,8 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             warnings_card, self._warnings_label = _make_card("Warnings")
             errors_card, self._errors_label = _make_card("Errors")
             next_card, self._next_action_label = _make_card("Next action")
+            self._warnings_card = warnings_card
+            self._errors_card = errors_card
 
             cards_grid = QtWidgets.QGridLayout()
             cards_grid.setSpacing(12)
@@ -141,6 +314,7 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             cards_grid.setColumnStretch(1, 1)
 
             self._command_preview = QtWidgets.QLineEdit()
+            self._command_preview.setObjectName("CommandPreview")
             self._command_preview.setReadOnly(True)
             self._command_preview.setPlaceholderText(
                 "No command preview is defined for this stage."
@@ -152,15 +326,16 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._copy_feedback.setWordWrap(True)
 
             command_card = QtWidgets.QFrame()
-            command_card.setObjectName("Card")
+            command_card.setObjectName("CommandCard")
             command_layout = QtWidgets.QVBoxLayout(command_card)
             command_layout.setContentsMargins(14, 12, 14, 12)
             command_layout.setSpacing(8)
             command_title = QtWidgets.QLabel("Command preview")
             command_title.setObjectName("CardTitle")
             command_note = QtWidgets.QLabel(
-                "Copy the preview into a terminal. The dashboard stays read-only "
-                "and does not run workflow commands."
+                "Copy the preview into a terminal. Camera, calibration, "
+                "board-building, annotation, and dataset workflows are not "
+                "executed by the dashboard."
             )
             command_note.setObjectName("MutedText")
             command_note.setWordWrap(True)
@@ -172,13 +347,230 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             command_layout.addLayout(command_row)
             command_layout.addWidget(self._copy_feedback)
 
+            self._last_charuco_output_dir: Optional[Path] = None
+            self._last_charuco_board_file: Optional[Path] = None
+            self._charuco_card = QtWidgets.QFrame()
+            self._charuco_card.setObjectName("ActionCard")
+            charuco_layout = QtWidgets.QVBoxLayout(self._charuco_card)
+            charuco_layout.setContentsMargins(14, 12, 14, 12)
+            charuco_layout.setSpacing(9)
+
+            charuco_title = QtWidgets.QLabel("ChArUco board setup")
+            charuco_title.setObjectName("CardTitle")
+            charuco_note = QtWidgets.QLabel(
+                "Generate the printed board for Step 1. Calibration capture "
+                "and solve stay in posetag-calib-charuco."
+            )
+            charuco_note.setObjectName("MutedText")
+            charuco_note.setWordWrap(True)
+
+            self._charuco_squares_x = _make_int_spin(
+                2,
+                99,
+                DEFAULT_SQUARES_X,
+            )
+            self._charuco_squares_y = _make_int_spin(
+                2,
+                99,
+                DEFAULT_SQUARES_Y,
+            )
+            self._charuco_square_length = _make_float_spin(
+                0.1,
+                1000.0,
+                DEFAULT_SQUARE_LENGTH_MM,
+                " mm",
+            )
+            self._charuco_marker_length = _make_float_spin(
+                0.1,
+                1000.0,
+                DEFAULT_MARKER_LENGTH_MM,
+                " mm",
+            )
+            self._charuco_dictionary = QtWidgets.QComboBox()
+            self._charuco_dictionary.addItems(list(_safe_dictionary_choices()))
+            self._charuco_dictionary.setCurrentText(DEFAULT_DICTIONARY)
+            self._charuco_dictionary.setMinimumWidth(180)
+            self._charuco_paper = QtWidgets.QComboBox()
+            self._charuco_paper.addItems(list(PAPER_CHOICES))
+            self._charuco_paper.setCurrentText("A4")
+            self._charuco_paper.setMinimumWidth(180)
+            self._charuco_orientation = QtWidgets.QComboBox()
+            self._charuco_orientation.addItems(list(ORIENTATION_CHOICES))
+            self._charuco_orientation.setCurrentText("portrait")
+            self._charuco_orientation.setMinimumWidth(180)
+            self._charuco_dpi = _make_int_spin(1, 2400, DEFAULT_DPI)
+            self._charuco_output_format = QtWidgets.QComboBox()
+            self._charuco_output_format.addItems(list(OUTPUT_FORMAT_CHOICES))
+            self._charuco_output_format.setCurrentText(DEFAULT_OUTPUT_FORMAT)
+            self._charuco_output_format.setMinimumWidth(180)
+
+            self._charuco_out_dir = QtWidgets.QLineEdit()
+            self._charuco_out_dir.setPlaceholderText(
+                "Default: <project_root>/calib/boards/"
+            )
+            charuco_browse_button = QtWidgets.QPushButton("Browse")
+            charuco_browse_button.clicked.connect(self._browse_charuco_output_dir)
+            charuco_out_row = QtWidgets.QHBoxLayout()
+            charuco_out_row.setContentsMargins(0, 0, 0, 0)
+            charuco_out_row.addWidget(self._charuco_out_dir, 1)
+            charuco_out_row.addWidget(charuco_browse_button)
+            charuco_out_widget = QtWidgets.QWidget()
+            charuco_out_widget.setLayout(charuco_out_row)
+
+            charuco_grid = QtWidgets.QGridLayout()
+            charuco_grid.setContentsMargins(0, 0, 0, 0)
+            charuco_grid.setHorizontalSpacing(14)
+            charuco_grid.setVerticalSpacing(10)
+            charuco_grid.addWidget(
+                _make_field("Squares X", self._charuco_squares_x),
+                0,
+                0,
+            )
+            charuco_grid.addWidget(
+                _make_field("Squares Y", self._charuco_squares_y),
+                0,
+                1,
+            )
+            charuco_grid.addWidget(
+                _make_field("Square length", self._charuco_square_length),
+                1,
+                0,
+            )
+            charuco_grid.addWidget(
+                _make_field("Marker length", self._charuco_marker_length),
+                1,
+                1,
+            )
+            charuco_grid.addWidget(
+                _make_field("Dictionary", self._charuco_dictionary),
+                2,
+                0,
+            )
+            charuco_grid.addWidget(
+                _make_field("Paper size", self._charuco_paper),
+                2,
+                1,
+            )
+            charuco_grid.addWidget(
+                _make_field("Orientation", self._charuco_orientation),
+                3,
+                0,
+            )
+            charuco_grid.addWidget(_make_field("DPI", self._charuco_dpi), 3, 1)
+            charuco_grid.addWidget(
+                _make_field("Output format", self._charuco_output_format),
+                4,
+                0,
+            )
+            charuco_grid.addWidget(
+                _make_field("Output folder", charuco_out_widget),
+                5,
+                0,
+                1,
+                2,
+            )
+            charuco_grid.setColumnStretch(0, 1)
+            charuco_grid.setColumnStretch(1, 1)
+
+            self._charuco_generate_button = QtWidgets.QPushButton("Generate Board")
+            self._charuco_generate_button.setObjectName("PrimaryActionButton")
+            self._charuco_generate_button.clicked.connect(self._generate_charuco_board)
+            self._charuco_open_folder_button = QtWidgets.QPushButton(
+                "Open Output Folder"
+            )
+            self._charuco_open_folder_button.setObjectName("SecondaryActionButton")
+            self._charuco_open_folder_button.setEnabled(False)
+            self._charuco_open_folder_button.clicked.connect(
+                self._open_charuco_output_folder
+            )
+            self._charuco_open_file_button = QtWidgets.QPushButton("Open Board File")
+            self._charuco_open_file_button.setObjectName("SecondaryActionButton")
+            self._charuco_open_file_button.setEnabled(False)
+            self._charuco_open_file_button.clicked.connect(
+                self._open_charuco_board_file
+            )
+            charuco_primary_action_row = QtWidgets.QHBoxLayout()
+            charuco_primary_action_row.addWidget(self._charuco_generate_button)
+            charuco_primary_action_row.addStretch(1)
+
+            charuco_file_action_row = QtWidgets.QHBoxLayout()
+            charuco_file_action_row.addWidget(self._charuco_open_file_button)
+            charuco_file_action_row.addWidget(self._charuco_open_folder_button)
+            charuco_file_action_row.addStretch(1)
+
+            self._charuco_guidance = QtWidgets.QLabel(PRINT_GUIDANCE)
+            self._charuco_guidance.setObjectName("GuidanceText")
+            self._charuco_guidance.setWordWrap(True)
+
+            self._charuco_outputs = QtWidgets.QLabel(
+                "No generated files yet."
+            )
+            self._charuco_outputs.setObjectName("OutputText")
+            self._charuco_outputs.setWordWrap(True)
+            self._charuco_outputs.setAlignment(
+                QtCore.Qt.AlignmentFlag.AlignLeft
+                | QtCore.Qt.AlignmentFlag.AlignTop
+            )
+            self._charuco_outputs.setMinimumHeight(78)
+            self._charuco_outputs.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+
+            self._charuco_preview = _CharucoPreviewCanvas()
+            charuco_preview_title = QtWidgets.QLabel("Preview")
+            charuco_preview_title.setObjectName("FieldLabel")
+            charuco_outputs_title = QtWidgets.QLabel("Generated files")
+            charuco_outputs_title.setObjectName("FieldLabel")
+
+            charuco_preview_column = QtWidgets.QFrame()
+            charuco_preview_column.setObjectName("CharucoPreviewColumn")
+            charuco_preview_layout = QtWidgets.QVBoxLayout(charuco_preview_column)
+            charuco_preview_layout.setContentsMargins(10, 10, 10, 10)
+            charuco_preview_layout.setSpacing(7)
+            charuco_preview_layout.addWidget(charuco_preview_title)
+            charuco_preview_layout.addWidget(self._charuco_preview)
+            charuco_preview_layout.addWidget(charuco_outputs_title)
+            charuco_preview_layout.addWidget(self._charuco_outputs)
+            charuco_preview_layout.addLayout(charuco_file_action_row)
+            charuco_preview_layout.addStretch(1)
+            charuco_preview_column.setMinimumWidth(320)
+
+            charuco_controls = QtWidgets.QWidget()
+            charuco_controls.setObjectName("CharucoControls")
+            charuco_controls_layout = QtWidgets.QVBoxLayout(charuco_controls)
+            charuco_controls_layout.setContentsMargins(0, 0, 0, 0)
+            charuco_controls_layout.setSpacing(9)
+            charuco_controls_layout.addLayout(charuco_grid)
+            charuco_controls_layout.addWidget(self._charuco_guidance)
+            charuco_controls_layout.addLayout(charuco_primary_action_row)
+            charuco_controls_layout.addStretch(1)
+
+            charuco_body = QtWidgets.QHBoxLayout()
+            charuco_body.setContentsMargins(0, 0, 0, 0)
+            charuco_body.setSpacing(12)
+            charuco_body.addWidget(
+                charuco_controls,
+                3,
+                QtCore.Qt.AlignmentFlag.AlignTop,
+            )
+            charuco_body.addWidget(
+                charuco_preview_column,
+                2,
+                QtCore.Qt.AlignmentFlag.AlignTop,
+            )
+
+            charuco_layout.addWidget(charuco_title)
+            charuco_layout.addWidget(charuco_note)
+            charuco_layout.addLayout(charuco_body)
+
             detail_content = QtWidgets.QWidget()
             detail_content_layout = QtWidgets.QVBoxLayout(detail_content)
             detail_content_layout.setContentsMargins(0, 0, 0, 0)
-            detail_content_layout.setSpacing(12)
+            detail_content_layout.setSpacing(10)
             detail_content_layout.addLayout(title_row)
             detail_content_layout.addWidget(self._message_label)
             detail_content_layout.addLayout(cards_grid)
+            detail_content_layout.addWidget(self._charuco_card)
             detail_content_layout.addWidget(command_card)
             detail_content_layout.addStretch(1)
 
@@ -186,11 +578,14 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             detail_scroll.setObjectName("DetailScroll")
             detail_scroll.setWidgetResizable(True)
             detail_scroll.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+            detail_scroll.setHorizontalScrollBarPolicy(
+                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            )
             detail_scroll.setWidget(detail_content)
 
             detail_panel = QtWidgets.QWidget()
             detail_layout = QtWidgets.QVBoxLayout(detail_panel)
-            detail_layout.setContentsMargins(18, 0, 18, 0)
+            detail_layout.setContentsMargins(14, 0, 14, 0)
             detail_layout.addWidget(detail_scroll, 1)
 
             self._health_status_label = QtWidgets.QLabel()
@@ -198,45 +593,50 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._health_status_label.setWordWrap(True)
 
             self._health_message_label = QtWidgets.QLabel()
-            self._health_message_label.setObjectName("MutedText")
+            self._health_message_label.setObjectName("HealthMessage")
             self._health_message_label.setWordWrap(True)
 
             self._health_counts_label = QtWidgets.QLabel()
             self._health_counts_label.setObjectName("HealthCounts")
+            self._health_counts_label.setTextFormat(
+                QtCore.Qt.TextFormat.RichText
+            )
             self._health_counts_label.setWordWrap(True)
 
             self._health_issues_label = QtWidgets.QLabel()
-            self._health_issues_label.setObjectName("CardBody")
+            self._health_issues_label.setObjectName("HealthSectionBody")
             self._health_issues_label.setWordWrap(True)
 
+            self._health_issues_title = QtWidgets.QLabel("Checks")
+            self._health_issues_title.setObjectName("HealthSectionTitle")
+            self._health_issues_title.setWordWrap(True)
+
             self._health_next_title = QtWidgets.QLabel()
-            self._health_next_title.setObjectName("CardTitle")
+            self._health_next_title.setObjectName("HealthSectionTitle")
             self._health_next_title.setWordWrap(True)
 
             self._health_next_body = QtWidgets.QLabel()
-            self._health_next_body.setObjectName("CardBody")
+            self._health_next_body.setObjectName("HealthSectionBody")
             self._health_next_body.setWordWrap(True)
             self._health_next_body.setTextInteractionFlags(
                 QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
             )
 
-            self._health_panel = QtWidgets.QWidget()
+            self._health_panel = QtWidgets.QFrame()
+            self._health_panel.setObjectName("HealthPanel")
             self._health_panel.setMinimumWidth(280)
-            self._health_panel.setMaximumWidth(390)
+            self._health_panel.setMaximumWidth(340)
             health_layout = QtWidgets.QVBoxLayout(self._health_panel)
-            health_layout.setContentsMargins(0, 0, 0, 0)
-            health_layout.setSpacing(12)
+            health_layout.setContentsMargins(16, 16, 16, 16)
+            health_layout.setSpacing(10)
             health_title = QtWidgets.QLabel("Project Health")
             health_title.setObjectName("PanelTitle")
             health_layout.addWidget(health_title)
             health_layout.addWidget(self._health_status_label)
             health_layout.addWidget(self._health_message_label)
-            health_layout.addWidget(_divider(QtWidgets))
             health_layout.addWidget(self._health_counts_label)
             health_layout.addWidget(_divider(QtWidgets))
-            issues_title = QtWidgets.QLabel("Warnings and errors")
-            issues_title.setObjectName("CardTitle")
-            health_layout.addWidget(issues_title)
+            health_layout.addWidget(self._health_issues_title)
             health_layout.addWidget(self._health_issues_label)
             health_layout.addWidget(_divider(QtWidgets))
             health_layout.addWidget(self._health_next_title)
@@ -254,13 +654,14 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             central = QtWidgets.QWidget()
             layout = QtWidgets.QVBoxLayout(central)
             layout.setContentsMargins(18, 16, 18, 16)
-            layout.setSpacing(16)
-            layout.addLayout(header_layout)
+            layout.setSpacing(12)
+            layout.addWidget(header_panel)
             layout.addWidget(splitter, 1)
             self.setCentralWidget(central)
             self.setStyleSheet(_style_sheet())
             self.statusBar().showMessage(
-                "Read-only dashboard. Command previews are not executed."
+                "Dashboard can generate ChArUco board files; "
+                "camera workflows are not executed."
             )
 
             self._refresh()
@@ -293,6 +694,92 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             )
             self.statusBar().showMessage(message, 4000)
 
+        def _browse_charuco_output_dir(self) -> None:
+            current = self._charuco_out_dir.text().strip()
+            start_dir = current or str(self._current_project_root())
+            selected = QtWidgets.QFileDialog.getExistingDirectory(
+                self,
+                "Select ChArUco board output folder",
+                start_dir,
+            )
+            if selected:
+                self._charuco_out_dir.setText(selected)
+
+        def _generate_charuco_board(self) -> None:
+            self._charuco_generate_button.setEnabled(False)
+            try:
+                result = generate_charuco_board_setup(self._charuco_setup_config())
+            except CharucoBoardSetupError as exc:
+                message = f"ChArUco board generation failed: {exc}"
+                self._charuco_outputs.setText(message)
+                self._last_charuco_output_dir = None
+                self._last_charuco_board_file = None
+                self._charuco_open_folder_button.setEnabled(False)
+                self._charuco_open_file_button.setEnabled(False)
+                self._charuco_preview.clear_preview("Preview unavailable.")
+                self.statusBar().showMessage(message, 6000)
+            except Exception as exc:  # pragma: no cover - defensive UI boundary
+                message = f"ChArUco board generation failed: {exc}"
+                self._charuco_outputs.setText(message)
+                self._last_charuco_output_dir = None
+                self._last_charuco_board_file = None
+                self._charuco_open_folder_button.setEnabled(False)
+                self._charuco_open_file_button.setEnabled(False)
+                self._charuco_preview.clear_preview("Preview unavailable.")
+                self.statusBar().showMessage(message, 6000)
+            else:
+                self._last_charuco_output_dir = result.out_dir
+                self._last_charuco_board_file = (
+                    result.pdf if result.pdf is not None else result.png
+                )
+                self._charuco_outputs.setText(_format_charuco_outputs(result))
+                self._charuco_open_folder_button.setEnabled(result.out_dir.is_dir())
+                self._charuco_open_file_button.setEnabled(
+                    self._last_charuco_board_file.is_file()
+                )
+                self._charuco_preview.show_preview(result.png)
+                self.statusBar().showMessage(
+                    "Generated ChArUco board outputs.",
+                    5000,
+                )
+                self._refresh()
+            finally:
+                self._charuco_generate_button.setEnabled(True)
+
+        def _open_charuco_board_file(self) -> None:
+            target = self._last_charuco_board_file
+            if target is None or not target.is_file():
+                message = "Generated ChArUco board file is not available to open."
+                self.statusBar().showMessage(message, 4000)
+                return
+
+            opened = QtGui.QDesktopServices.openUrl(
+                QtCore.QUrl.fromLocalFile(str(target.resolve()))
+            )
+            message = (
+                "Opened generated ChArUco board file."
+                if opened
+                else "Could not open the generated ChArUco board file."
+            )
+            self.statusBar().showMessage(message, 4000)
+
+        def _open_charuco_output_folder(self) -> None:
+            target = self._last_charuco_output_dir or self._charuco_output_target()
+            if not target.is_dir():
+                message = "ChArUco output folder is not available to open."
+                self.statusBar().showMessage(message, 4000)
+                return
+
+            opened = QtGui.QDesktopServices.openUrl(
+                QtCore.QUrl.fromLocalFile(str(target.resolve()))
+            )
+            message = (
+                "Opened ChArUco output folder."
+                if opened
+                else "Could not open the ChArUco output folder."
+            )
+            self.statusBar().showMessage(message, 4000)
+
         def _refresh(self) -> None:
             root = Path(self._root_input.text()).expanduser()
             self._render_project_context(root)
@@ -309,18 +796,19 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
         def _render_stage_list(self) -> None:
             self._stage_list.blockSignals(True)
             self._stage_list.clear()
+            self._stage_widgets = {}
             for model in self._models:
-                item = QtWidgets.QListWidgetItem(
-                    f"Stage {model.stage_id}\n{model.name}\n{model.status_label}"
-                )
+                item = QtWidgets.QListWidgetItem(_stage_list_label(model))
                 item.setData(QtCore.Qt.ItemDataRole.UserRole, model.stage_id)
                 item.setToolTip(model.message)
-                item.setSizeHint(QtCore.QSize(250, 74))
-                item.setForeground(QtGui.QBrush(QtGui.QColor(model.status_color)))
-                item.setBackground(
-                    QtGui.QBrush(QtGui.QColor(model.status_background))
-                )
+                item.setSizeHint(QtCore.QSize(130, 42))
                 self._stage_list.addItem(item)
+                widget = _make_stage_rail_entry(
+                    model,
+                    selected=model.stage_id == self._selected_stage_id,
+                )
+                self._stage_list.setItemWidget(item, widget)
+                self._stage_widgets[model.stage_id] = widget
             self._stage_list.blockSignals(False)
 
         def _select_stage_by_row(self, row: int) -> None:
@@ -367,11 +855,17 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._errors_label.setText(
                 _format_card_items(model.errors, "No errors reported.")
             )
+            self._warnings_card.setVisible(bool(model.warnings))
+            self._errors_card.setVisible(bool(model.errors))
             self._next_action_label.setText(model.next_action)
             self._command_preview.setText(model.command_preview)
             self._command_preview.setCursorPosition(0)
             self._copy_button.setEnabled(bool(model.command_preview))
-            self._copy_feedback.setText(_command_ready_message(model.command_preview))
+            self._copy_feedback.setText(
+                _command_ready_message(model.command_preview)
+            )
+            self._charuco_card.setVisible(model.stage_id == 1)
+            self._render_stage_rail_selection()
 
         def _render_health(self) -> None:
             health = project_health_view(self._models)
@@ -385,6 +879,11 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             )
             self._health_message_label.setText(health.message)
             self._health_counts_label.setText(_format_health_counts(health))
+            self._health_issues_title.setText(
+                "Checks clear"
+                if health.warning_count == 0 and health.error_count == 0
+                else "Warnings and errors"
+            )
             self._health_issues_label.setText(_format_health_issues(health))
             self._health_next_title.setText("Next recommended action")
             self._health_next_body.setText(
@@ -394,6 +893,7 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
         def _render_error(self, root: Path, exc: Exception) -> None:
             self._render_project_context(root)
             self._stage_list.clear()
+            self._stage_widgets = {}
             self._stage_title.setText("Project inspection failed")
             self._status_label.setText("Needs attention")
             self._status_label.setStyleSheet(
@@ -408,13 +908,28 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._paths_label.setText("Project inspection stopped before path checks.")
             self._warnings_label.setText("No warnings reported.")
             self._errors_label.setText(str(exc))
+            self._warnings_card.setVisible(False)
+            self._errors_card.setVisible(True)
             self._next_action_label.setText(
                 "Check the project path and refresh the dashboard."
             )
             self._command_preview.clear()
             self._copy_button.setEnabled(False)
             self._copy_feedback.setText(_command_ready_message(""))
+            self._charuco_card.setVisible(False)
             self._render_health()
+
+        def _render_stage_rail_selection(self) -> None:
+            for model in self._models:
+                widget = self._stage_widgets.get(model.stage_id)
+                if widget is None:
+                    continue
+                widget.setStyleSheet(
+                    _stage_rail_entry_style(
+                        model,
+                        selected=model.stage_id == self._selected_stage_id,
+                    )
+                )
 
         def _copy_command(self) -> None:
             command = self._command_preview.text()
@@ -439,7 +954,108 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
         def _first_model(self) -> Optional[StageViewModel]:
             return self._models[0] if self._models else None
 
+        def _current_project_root(self) -> Path:
+            text = self._root_input.text().strip()
+            return Path(text or ".").expanduser()
+
+        def _charuco_setup_config(self) -> CharucoBoardSetupConfig:
+            out_dir_text = self._charuco_out_dir.text().strip()
+            out_dir = Path(out_dir_text).expanduser() if out_dir_text else None
+            return CharucoBoardSetupConfig(
+                project_root=self._current_project_root(),
+                squares_x=int(self._charuco_squares_x.value()),
+                squares_y=int(self._charuco_squares_y.value()),
+                square_length_mm=float(self._charuco_square_length.value()),
+                marker_length_mm=float(self._charuco_marker_length.value()),
+                dictionary_name=self._charuco_dictionary.currentText(),
+                paper=self._charuco_paper.currentText(),
+                orientation=self._charuco_orientation.currentText(),
+                dpi=int(self._charuco_dpi.value()),
+                output_format=self._charuco_output_format.currentText(),
+                out_dir=out_dir,
+            )
+
+        def _charuco_output_target(self) -> Path:
+            out_dir_text = self._charuco_out_dir.text().strip()
+            if out_dir_text:
+                return Path(out_dir_text).expanduser()
+            return default_output_dir(self._current_project_root())
+
     return PoseTagMainWindow(project_root)
+
+
+def _stage_list_label(model: StageViewModel) -> str:
+    return f"Stage {model.stage_id}\n{model.name}\n{model.status_label}"
+
+
+_RAIL_STAGE_NAMES = {
+    0: "Tags",
+    1: "Calib",
+    2: "Boards",
+    3: "Shots",
+    4: "Annotate",
+    5: "Dataset",
+    6: "Review",
+}
+
+_RAIL_STATUS_LABELS = {
+    "complete": "Done",
+    "missing": "Missing",
+    "needs_attention": "Attention",
+    "not_applicable": "N/A",
+}
+
+_RAIL_STATUS_BACKGROUNDS = {
+    "complete": "#fbfefd",
+    "missing": "#fbfdff",
+    "needs_attention": "#fffaf0",
+    "not_applicable": "#fbfcfe",
+}
+
+
+def _stage_rail_name(model: StageViewModel) -> str:
+    return _RAIL_STAGE_NAMES.get(model.stage_id, model.name)
+
+
+def _stage_rail_status_label(model: StageViewModel) -> str:
+    return _RAIL_STATUS_LABELS.get(model.status, model.status_label)
+
+
+def _stage_rail_entry_style(model: StageViewModel, selected: bool) -> str:
+    background = "#eef8ff" if selected else _RAIL_STATUS_BACKGROUNDS.get(
+        model.status,
+        "#fbfdff",
+    )
+    border = "#76b8dc" if selected else model.status_border
+    accent = "#0b6f8f" if selected else model.status_color
+    border_color = border if selected else "transparent"
+    return (
+        "QFrame#RailStageEntry { "
+        f"background: {background}; border: 1px solid {border_color}; "
+        f"border-left: 3px solid {accent}; border-radius: 7px; "
+        "}"
+    )
+
+
+def _stage_rail_number_style(model: StageViewModel) -> str:
+    return (
+        f"background: transparent; color: {model.status_color}; "
+        "border: none; font-weight: 700; font-size: 12px;"
+    )
+
+
+def _stage_rail_dot_style(model: StageViewModel) -> str:
+    return (
+        f"background: {model.status_color}; border: none; "
+        "border-radius: 3px; margin-top: 4px;"
+    )
+
+
+def _stage_status_chip_style(model: StageViewModel) -> str:
+    return (
+        f"background: transparent; color: {model.status_color}; "
+        "border: none; padding: 0; font-size: 9px; font-weight: 700;"
+    )
 
 
 def _format_stage_details(model: StageViewModel) -> str:
@@ -462,6 +1078,34 @@ def _format_stage_details(model: StageViewModel) -> str:
     return "\n".join(lines)
 
 
+def _format_charuco_outputs(result: Any) -> str:
+    lines = [
+        f"Folder: {_display_path(getattr(result, 'out_dir', result.png.parent))}",
+        f"PNG:    {Path(result.png).name}",
+        f"YAML:   {Path(result.yaml).name}",
+    ]
+    requested_pdf = getattr(result, "requested_pdf", True)
+    if not requested_pdf:
+        lines.append("PDF:    not requested")
+    elif result.pdf is None:
+        lines.append("PDF:    unavailable in this environment")
+    else:
+        lines.append(f"PDF:    {Path(result.pdf).name}")
+    return "\n".join(lines)
+
+
+def _display_path(path: Path) -> str:
+    home = Path.home()
+    try:
+        resolved = path.expanduser().resolve()
+    except OSError:
+        return str(path)
+    try:
+        return str(Path("~") / resolved.relative_to(home))
+    except ValueError:
+        return str(resolved)
+
+
 def _format_card_items(items: tuple[str, ...], empty_text: str) -> str:
     rendered = _format_items(items)
     if not rendered:
@@ -474,8 +1118,19 @@ def _format_items(items: tuple[str, ...]) -> list[str]:
 
 
 def _format_health_counts(health: ProjectHealthViewModel) -> str:
-    return "\n".join(
-        f"{count.label}: {count.count}" for count in health.counts
+    rows = "".join(
+        "<tr>"
+        f"<td>{count.label}</td>"
+        f"<td align='right'><b>{count.count}</b></td>"
+        "</tr>"
+        for count in health.counts
+    )
+    return (
+        "<span style='font-size:11px; font-weight:700; "
+        "color:#5a6b7c;'>AT A GLANCE</span>"
+        "<table width='100%' cellspacing='0' cellpadding='2'>"
+        f"{rows}"
+        "</table>"
     )
 
 
@@ -502,10 +1157,16 @@ def _copy_confirmation_message(command: str) -> str:
 
 def _project_root_hint(root: Path) -> str:
     if root.is_dir():
-        return "Project folder found. Status checks are read-only."
+        return (
+            "Project folder found. Status checks are read-only except Step 1 "
+            "board generation."
+        )
     if root.exists():
         return "Selected path exists but is not a folder."
-    return "Project folder not found. Status checks are read-only and created no files."
+    return (
+        "Project folder not found. Status checks are read-only; Step 1 board "
+        "generation can create the selected project layout."
+    )
 
 
 def _pill_style(foreground: str, background: str, border: str) -> str:
@@ -519,107 +1180,238 @@ def _pill_style(foreground: str, background: str, border: str) -> str:
 def _health_status_style(foreground: str, background: str, border: str) -> str:
     return (
         f"background: {background}; color: {foreground}; "
-        f"border: 1px solid {border}; border-radius: 6px; "
-        "padding: 14px; font-size: 18px; font-weight: 700;"
+        f"border: 1px solid {border}; border-left: 4px solid {foreground}; "
+        "border-radius: 7px; padding: 9px 12px; "
+        "font-size: 15px; font-weight: 700;"
     )
 
 
 def _style_sheet() -> str:
     return """
-QMainWindow, QWidget {
-    background: #f6f8fb;
+QMainWindow {
+    background: #eef4f8;
+}
+QWidget {
     color: #17202a;
+    font-family: "Aptos", "Segoe UI", "Helvetica Neue", "Arial", sans-serif;
     font-size: 13px;
 }
-QLineEdit, QListWidget {
+QLineEdit, QListWidget, QComboBox, QSpinBox, QDoubleSpinBox {
     background: #ffffff;
-    border: 1px solid #cfd6df;
-    border-radius: 4px;
-    padding: 6px;
+    border: 1px solid #c7d3df;
+    border-radius: 6px;
+    padding: 6px 8px;
+    selection-background-color: #cfe6f5;
+    selection-color: #102030;
+}
+QLineEdit:focus, QComboBox:focus, QSpinBox:focus, QDoubleSpinBox:focus {
+    border: 1px solid #1f7a8c;
+}
+QLineEdit#CommandPreview {
+    background: #f7fafc;
+    border-color: #b4c6d7;
+    font-family: "Menlo", "Consolas", "Courier New", monospace;
+    font-size: 12px;
 }
 QScrollArea#DetailScroll {
     background: transparent;
     border: none;
 }
 QPushButton {
-    background: #22547d;
+    background: #1f5f83;
     color: #ffffff;
-    border: 1px solid #1b4568;
-    border-radius: 4px;
-    padding: 7px 12px;
+    border: 1px solid #194b69;
+    border-radius: 6px;
+    padding: 7px 13px;
     font-weight: 600;
 }
+QPushButton:hover {
+    background: #246d96;
+}
+QPushButton:pressed {
+    background: #174760;
+}
 QPushButton:disabled {
-    background: #b8c1ca;
-    border-color: #aab4bf;
+    background: #b7c0ca;
+    border-color: #aab4be;
+    color: #eef2f6;
+}
+QPushButton#PrimaryActionButton {
+    background: #087966;
+    border-color: #086251;
+    padding: 8px 15px;
+}
+QPushButton#PrimaryActionButton:hover {
+    background: #0b8a74;
+}
+QPushButton#SecondaryActionButton {
+    background: #49697f;
+    border-color: #365467;
+}
+QFrame#HeaderPanel,
+QFrame#RailPanel,
+QFrame#HealthPanel {
+    background: #fbfdff;
+    border: 1px solid #dfe9f1;
+    border-radius: 8px;
 }
 QFrame#Card {
+    background: #fbfdff;
+    border: 1px solid #dfe9f1;
+    border-radius: 8px;
+}
+QFrame#ActionCard {
     background: #ffffff;
-    border: 1px solid #d7dee7;
-    border-radius: 6px;
+    border: 1px solid #d7e6e1;
+    border-left: 3px solid #087966;
+    border-radius: 8px;
+}
+QFrame#CharucoPreviewColumn {
+    background: #f4f8fb;
+    border: 1px solid #dce7ef;
+    border-radius: 8px;
+}
+QFrame#CommandCard {
+    background: #fbfdff;
+    border: 1px solid #d4e1ea;
+    border-left: 3px solid #2b6f9e;
+    border-radius: 8px;
 }
 QFrame#Divider {
-    color: #d7dee7;
-    background: #d7dee7;
+    color: #cbd8e2;
+    background: #cbd8e2;
+    border: none;
+    min-height: 1px;
     max-height: 1px;
 }
 QLabel#AppTitle {
-    font-size: 24px;
-    font-weight: 700;
+    color: #102235;
+    font-size: 22px;
+    font-weight: 800;
+}
+QLabel#AppTitle,
+QLabel#StageTitle,
+QLabel#PanelTitle,
+QLabel#CardTitle,
+QLabel#HealthSectionTitle {
+    font-family: "Aptos Display", "Segoe UI Variable Display", "Segoe UI",
+        "Helvetica Neue", "Arial", sans-serif;
 }
 QLabel#PanelTitle {
-    color: #26323f;
-    font-size: 14px;
-    font-weight: 700;
+    color: #102235;
+    font-size: 15px;
+    font-weight: 800;
 }
 QLabel#CardTitle {
-    color: #26323f;
-    font-weight: 700;
+    color: #102235;
+    background: #eef5f8;
+    border-left: 3px solid #54708a;
+    border-radius: 4px;
+    padding: 4px 7px;
+    font-size: 13px;
+    font-weight: 800;
 }
 QLabel#CardBody {
     color: #334150;
 }
 QLabel#MutedText {
-    color: #59636f;
+    color: #5c6b7b;
+}
+QLabel#HealthMessage {
+    color: #56687a;
+    line-height: 120%;
+}
+QLabel#FieldLabel {
+    color: #405367;
+    font-size: 12px;
+    font-weight: 700;
+}
+QLabel#GuidanceText {
+    color: #62460b;
+    background: #fffaf0;
+    border: 1px solid #e5c865;
+    border-radius: 8px;
+    padding: 7px 9px;
+}
+QLabel#OutputText {
+    color: #263545;
+    background: #ffffff;
+    border: 1px solid #d4e1ea;
+    border-radius: 6px;
+    padding: 7px;
+    font-family: "Menlo", "Consolas", "Courier New", monospace;
+    font-size: 11px;
+}
+QLabel#CharucoPreviewCanvas {
+    color: #5c6b7b;
+    background: #edf4f8;
+    border: 1px solid #d4e0e9;
+    border-radius: 7px;
+    padding: 10px;
 }
 QLabel#HealthCounts {
-    color: #26323f;
-    background: #ffffff;
-    border: 1px solid #d7dee7;
-    border-radius: 6px;
-    padding: 10px;
+    color: #263545;
+    background: #f6f9fc;
+    border: 1px solid #d9e5ee;
+    border-radius: 7px;
+    padding: 9px 10px;
+}
+QLabel#HealthSectionTitle {
+    color: #102235;
+    font-size: 13px;
+    font-weight: 800;
+    padding-top: 2px;
+}
+QLabel#HealthSectionBody {
+    color: #34495e;
+    line-height: 120%;
 }
 QStatusBar {
     background: #ffffff;
-    color: #59636f;
+    color: #5c6b7b;
     border-top: 1px solid #d7dee7;
 }
 QListWidget#WorkflowRail {
-    padding: 8px;
+    background: transparent;
+    border: none;
+    padding: 0;
 }
 QListWidget::item {
-    padding: 10px;
+    padding: 0;
     border: 1px solid transparent;
-    border-radius: 6px;
+    border-radius: 8px;
 }
 QListWidget::item:selected {
-    background: #e7f0fa;
+    background: transparent;
     color: #0b1724;
-    border: 1px solid #8ab5dd;
-    border-left: 4px solid #22547d;
+    border: 1px solid transparent;
 }
 QListWidget::item:selected:!active {
-    background: #e7f0fa;
+    background: transparent;
     color: #0b1724;
-    border: 1px solid #8ab5dd;
-    border-left: 4px solid #22547d;
+    border: 1px solid transparent;
+}
+QLabel#RailStageName {
+    color: #1f3042;
+    font-size: 11px;
+    font-weight: 700;
+}
+QLabel#RailStageNumber,
+QLabel#RailStageDot,
+QLabel#RailStageStatus {
+    min-width: 0;
 }
 QLabel#StageTitle {
-    font-size: 22px;
-    font-weight: 700;
+    color: #102235;
+    font-size: 25px;
+    font-weight: 800;
 }
 QLabel#StageMessage {
     color: #394653;
     padding: 2px 0 4px 0;
+}
+QSplitter::handle {
+    background: #d7e1ea;
+    margin: 0 6px;
 }
 """

--- a/src/posetag/pipelines/generate_charuco.py
+++ b/src/posetag/pipelines/generate_charuco.py
@@ -3,7 +3,7 @@
 Outputs
 -------
 - PNG is always written.
-- PDF is additionally written when Pillow is installed.
+- PDF is written by standard PoseTag installs.
 - YAML metadata records the board, paper, DPI, and output filenames.
 
 Project behavior
@@ -444,6 +444,7 @@ def generate_charuco_board(
     dpi: int,
     out_dir: Path,
     prefix: str = DEFAULT_PREFIX,
+    write_pdf: bool | None = None,
 ) -> CharucoBoardOutputs:
     """Generate a ChArUco board PNG/PDF and metadata YAML."""
 
@@ -488,7 +489,8 @@ def generate_charuco_board(
         dpi=dpi,
     )
     png_path = out_dir / f"{stem}.png"
-    pdf_path = out_dir / f"{stem}.pdf" if HAVE_PIL else None
+    should_write_pdf = HAVE_PIL if write_pdf is None else bool(write_pdf)
+    pdf_path = out_dir / f"{stem}.pdf" if should_write_pdf and HAVE_PIL else None
     yaml_path = out_dir / f"{stem}.yaml"
 
     write_png_with_dpi(png_path, page, dpi)
@@ -618,7 +620,7 @@ def main(argv: list[str] | None = None) -> int:
     if outputs.pdf is not None:
         print(f"  PDF:  {outputs.pdf}")
     else:
-        print("  PDF:  not written (install Pillow to enable PDF output)")
+        print("  PDF:  unavailable in this environment")
     print("Print at 100% / Actual Size. Do not use Fit to Page.")
     return 0
 

--- a/src/posetag/pipelines/generate_tags.py
+++ b/src/posetag/pipelines/generate_tags.py
@@ -3,7 +3,7 @@
 Outputs
 -------
 - PNG is always written.
-- PDF is additionally written when Pillow is installed.
+- PDF is written by standard PoseTag installs.
 
 Project behavior
 ----------------
@@ -468,7 +468,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--pil-text",
         action="store_true",
-        help="Use Pillow for nicer text when available. Pillow also enables PDF output.",
+        help="Use Pillow for nicer text rendering.",
     )
     parser.add_argument(
         "--margin-frac",
@@ -509,7 +509,7 @@ def build_parser() -> argparse.ArgumentParser:
 def run(args: argparse.Namespace) -> tuple[list[Path], list[Path]]:
     if args.pil_text and not HAVE_PIL:
         print(
-            "Note: Pillow not found; continuing with OpenCV text and PNG-only output.",
+            "Note: PDF output is unavailable in this environment; continuing with PNG output.",
             file=sys.stderr,
         )
 
@@ -550,7 +550,7 @@ def main(argv: list[str] | None = None) -> int:
     if pdf_paths:
         print(f"Saved {len(png_paths)} PNG sheet(s) and {len(pdf_paths)} PDF sheet(s):")
     else:
-        print(f"Saved {len(png_paths)} PNG sheet(s) (install Pillow to also produce PDF):")
+        print(f"Saved {len(png_paths)} PNG sheet(s); PDF output is unavailable in this environment:")
     for png_path in png_paths:
         print(f"  {png_path}")
     for pdf_path in pdf_paths:

--- a/src/posetag/workflows/charuco_setup.py
+++ b/src/posetag/workflows/charuco_setup.py
@@ -1,0 +1,189 @@
+"""Workflow helpers for guided ChArUco board setup.
+
+This module is GUI-independent.  It validates user-facing Step 1 setup values,
+resolves PoseTag project output paths, and delegates all board rendering to
+``posetag.pipelines.generate_charuco``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
+
+from posetag.pipelines.charuco_calibration import supported_dictionary_names
+from posetag.pipelines.generate_charuco import (
+    DEFAULT_DPI,
+    DEFAULT_PREFIX,
+    PAPER_MM,
+    CharucoBoardGenerationError,
+    parse_paper,
+    resolve_output_dir,
+    generate_charuco_board,
+)
+
+
+DEFAULT_SQUARES_X = 3
+DEFAULT_SQUARES_Y = 5
+DEFAULT_SQUARE_LENGTH_MM = 50.0
+DEFAULT_MARKER_LENGTH_MM = 37.0
+DEFAULT_DICTIONARY = "7X7_50"
+PAPER_CHOICES = tuple(PAPER_MM.keys())
+ORIENTATION_CHOICES = ("portrait", "landscape")
+OUTPUT_FORMAT_PNG_PDF = "PNG + PDF"
+OUTPUT_FORMAT_PNG = "PNG only"
+OUTPUT_FORMAT_CHOICES = (OUTPUT_FORMAT_PNG_PDF, OUTPUT_FORMAT_PNG)
+DEFAULT_OUTPUT_FORMAT = OUTPUT_FORMAT_PNG_PDF
+PRINT_GUIDANCE = (
+    "Print at 100% / Actual Size. Do not use Fit to Page. Verify the printed "
+    "square length with a ruler or calipers before calibration."
+)
+
+
+class CharucoBoardSetupError(ValueError):
+    """User-facing validation error for guided ChArUco board setup."""
+
+
+@dataclass(frozen=True)
+class CharucoBoardSetupConfig:
+    """User-facing ChArUco board setup values."""
+
+    project_root: Union[Path, str]
+    squares_x: int = DEFAULT_SQUARES_X
+    squares_y: int = DEFAULT_SQUARES_Y
+    square_length_mm: float = DEFAULT_SQUARE_LENGTH_MM
+    marker_length_mm: float = DEFAULT_MARKER_LENGTH_MM
+    dictionary_name: str = DEFAULT_DICTIONARY
+    paper: str = "A4"
+    orientation: str = "portrait"
+    dpi: int = DEFAULT_DPI
+    output_format: str = DEFAULT_OUTPUT_FORMAT
+    out_dir: Optional[Union[Path, str]] = None
+    prefix: str = DEFAULT_PREFIX
+
+
+@dataclass(frozen=True)
+class CharucoBoardSetupResult:
+    """Paths written by the guided ChArUco setup action."""
+
+    png: Path
+    yaml: Path
+    pdf: Optional[Path]
+    out_dir: Path
+    requested_pdf: bool
+
+    @property
+    def output_paths(self) -> tuple[Path, ...]:
+        """Return generated paths in display order."""
+
+        paths = [self.png, self.yaml]
+        if self.pdf is not None:
+            paths.append(self.pdf)
+        return tuple(paths)
+
+
+def dictionary_choices() -> tuple[str, ...]:
+    """Return supported dictionary names for GUI controls."""
+
+    names = tuple(supported_dictionary_names())
+    if DEFAULT_DICTIONARY in names:
+        return (
+            DEFAULT_DICTIONARY,
+            *(name for name in names if name != DEFAULT_DICTIONARY),
+        )
+    return names
+
+
+def default_output_dir(project_root: Union[Path, str]) -> Path:
+    """Return the default project-root output directory without creating it."""
+
+    return Path(project_root).expanduser() / "calib" / "boards"
+
+
+def generate_charuco_board_setup(
+    config: CharucoBoardSetupConfig,
+) -> CharucoBoardSetupResult:
+    """Generate a ChArUco board from guided workflow setup values."""
+
+    try:
+        _validate_setup_config(config)
+        paper_name, paper_width_mm, paper_height_mm = parse_paper(
+            config.paper,
+            custom_mm=None,
+            orientation=config.orientation,
+        )
+        out_dir = resolve_output_dir(
+            Path(config.project_root).expanduser(),
+            _optional_path(config.out_dir),
+        )
+        requested_pdf = _requests_pdf(config.output_format)
+        outputs = generate_charuco_board(
+            squares_x=config.squares_x,
+            squares_y=config.squares_y,
+            square_length_mm=config.square_length_mm,
+            marker_length_mm=config.marker_length_mm,
+            dictionary_name=config.dictionary_name,
+            paper=paper_name,
+            paper_width_mm=paper_width_mm,
+            paper_height_mm=paper_height_mm,
+            dpi=config.dpi,
+            out_dir=out_dir,
+            prefix=config.prefix,
+            write_pdf=requested_pdf,
+        )
+    except CharucoBoardGenerationError as exc:
+        raise CharucoBoardSetupError(str(exc)) from exc
+    except OSError as exc:
+        raise CharucoBoardSetupError(
+            f"Could not write ChArUco outputs: {exc}"
+        ) from exc
+
+    return CharucoBoardSetupResult(
+        png=outputs.png,
+        yaml=outputs.yaml,
+        pdf=outputs.pdf,
+        out_dir=out_dir,
+        requested_pdf=requested_pdf,
+    )
+
+
+def _validate_setup_config(config: CharucoBoardSetupConfig) -> None:
+    if not str(config.dictionary_name).strip():
+        raise CharucoBoardSetupError("ChArUco dictionary must not be empty.")
+    if config.paper.upper() not in PAPER_CHOICES:
+        raise CharucoBoardSetupError(
+            f"Paper size must be one of: {', '.join(PAPER_CHOICES)}."
+        )
+    if config.orientation.lower() not in ORIENTATION_CHOICES:
+        raise CharucoBoardSetupError(
+            f"Orientation must be one of: {', '.join(ORIENTATION_CHOICES)}."
+        )
+    if not str(config.prefix).strip():
+        raise CharucoBoardSetupError("Output filename prefix must not be empty.")
+    _normalize_output_format(config.output_format)
+
+
+def _optional_path(path: Optional[Union[Path, str]]) -> Optional[Path]:
+    if path is None:
+        return None
+    text = str(path).strip()
+    if not text:
+        return None
+    return Path(text).expanduser()
+
+
+def _requests_pdf(output_format: str) -> bool:
+    return _normalize_output_format(output_format) == OUTPUT_FORMAT_PNG_PDF
+
+
+def _normalize_output_format(output_format: str) -> str:
+    text = str(output_format).strip().lower().replace("&", "+")
+    collapsed = " ".join(text.split())
+    compact = collapsed.replace(" ", "")
+    if compact in {"png+pdf", "pdf+png"}:
+        return OUTPUT_FORMAT_PNG_PDF
+    if collapsed in {"png", "png only"}:
+        return OUTPUT_FORMAT_PNG
+    raise CharucoBoardSetupError(
+        f"Output format must be one of: {', '.join(OUTPUT_FORMAT_CHOICES)}."
+    )

--- a/src/posetag/workflows/status.py
+++ b/src/posetag/workflows/status.py
@@ -142,15 +142,36 @@ def inspect_step1(project_root: Union[Path, str]) -> StageSummary:
 
     root = Path(project_root).expanduser()
     calib_path = root / "calib" / "calib_color.yaml"
-    checked_paths = _path_tuple([calib_path])
+    charuco_metadata_paths = _generated_charuco_metadata_paths(root)
+    checked_paths = _path_tuple([calib_path, *charuco_metadata_paths])
 
     if not calib_path.exists():
+        if charuco_metadata_paths:
+            count = len(charuco_metadata_paths)
+            return _stage(
+                stage_id=1,
+                status=WorkflowStatus.MISSING,
+                message=(
+                    f"Found {count} generated ChArUco board metadata "
+                    f"file{'s' if count != 1 else ''}, but colour-camera "
+                    "calibration YAML was not found."
+                ),
+                checked_paths=checked_paths,
+                next_action=(
+                    "Print the generated ChArUco board at 100% / Actual Size, "
+                    "verify the square length, then run posetag-calib-charuco "
+                    "to create calib/calib_color.yaml."
+                ),
+            )
         return _stage(
             stage_id=1,
             status=WorkflowStatus.MISSING,
             message="Colour-camera calibration YAML was not found.",
             checked_paths=checked_paths,
-            next_action="Run posetag-calib-charuco to create calib/calib_color.yaml.",
+            next_action=(
+                "Generate and print a ChArUco board if needed, then run "
+                "posetag-calib-charuco to create calib/calib_color.yaml."
+            ),
         )
 
     try:
@@ -368,6 +389,13 @@ def _placeholder_summaries(step2_complete: bool) -> list[StageSummary]:
             next_action="Complete Step 5 before checking Step 6.",
         ),
     ]
+
+
+def _generated_charuco_metadata_paths(project_root: Path) -> tuple[Path, ...]:
+    boards_dir = project_root / "calib" / "boards"
+    return tuple(
+        sorted(path for path in boards_dir.glob("charuco_*.yaml") if path.is_file())
+    )
 
 
 def _validate_calibration_workflow_schema(path: Path) -> tuple[str, ...]:

--- a/tests/test_rename_phase0.py
+++ b/tests/test_rename_phase0.py
@@ -27,6 +27,7 @@ class RenamePhase0Tests(unittest.TestCase):
 
         self.assertEqual(project["name"], "posetag")
         self.assertEqual(project["readme"], "README.md")
+        self.assertIn("Pillow", project["dependencies"])
         self.assertEqual(scripts["posetag"], "posetag.cli.posetag:main")
         self.assertEqual(scripts["posetag-gen-tags"], "posetag.cli.gen_tags:main")
         self.assertEqual(scripts["posetag-gen-charuco"], "posetag.cli.gen_charuco:main")

--- a/tests/test_workflow_charuco_setup.py
+++ b/tests/test_workflow_charuco_setup.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import yaml
+
+from posetag.workflows.charuco_setup import (
+    DEFAULT_DICTIONARY,
+    OUTPUT_FORMAT_CHOICES,
+    OUTPUT_FORMAT_PNG,
+    CharucoBoardSetupConfig,
+    CharucoBoardSetupError,
+    default_output_dir,
+    dictionary_choices,
+    generate_charuco_board_setup,
+)
+
+
+class WorkflowCharucoSetupTests(unittest.TestCase):
+    def test_valid_setup_generates_outputs_under_project_calib_boards(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            with _isolated_project_config(tmpdir):
+                result = generate_charuco_board_setup(
+                    CharucoBoardSetupConfig(
+                        project_root=project_root,
+                        squares_x=3,
+                        squares_y=4,
+                        square_length_mm=20.0,
+                        marker_length_mm=14.0,
+                        dictionary_name="7X7_50",
+                        paper="A4",
+                        orientation="portrait",
+                        dpi=80,
+                    )
+                )
+
+            expected_dir = project_root.resolve() / "calib" / "boards"
+            self.assertEqual(result.out_dir.resolve(), expected_dir)
+            self.assertEqual(result.png.parent.resolve(), expected_dir)
+            self.assertEqual(result.yaml.parent.resolve(), expected_dir)
+            self.assertTrue(result.png.exists())
+            self.assertTrue(result.yaml.exists())
+            self.assertIn(result.png, result.output_paths)
+            self.assertIn(result.yaml, result.output_paths)
+
+            metadata = yaml.safe_load(result.yaml.read_text(encoding="utf-8"))
+            self.assertEqual(metadata["squares_x"], 3)
+            self.assertEqual(metadata["squares_y"], 4)
+            self.assertEqual(metadata["square_length_mm"], 20.0)
+            self.assertEqual(metadata["marker_length_mm"], 14.0)
+            self.assertEqual(metadata["dictionary"], "7X7_50")
+            self.assertEqual(metadata["paper"], "A4")
+            self.assertEqual(metadata["png"], result.png.name)
+            self.assertIn("Actual Size", metadata["notes"])
+
+            if result.pdf is None:
+                self.assertNotIn("pdf", metadata)
+            else:
+                self.assertTrue(result.pdf.exists())
+                self.assertIn(result.pdf, result.output_paths)
+                self.assertEqual(metadata["pdf"], result.pdf.name)
+
+    def test_explicit_output_folder_overrides_project_default(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            out_dir = base / "printed-board"
+            with _isolated_project_config(tmpdir):
+                result = generate_charuco_board_setup(
+                    CharucoBoardSetupConfig(
+                        project_root=project_root,
+                        out_dir=out_dir,
+                        squares_x=3,
+                        squares_y=4,
+                        square_length_mm=20.0,
+                        marker_length_mm=14.0,
+                        dpi=80,
+                    )
+                )
+
+            self.assertEqual(result.out_dir, out_dir)
+            self.assertEqual(result.png.parent, out_dir)
+            self.assertTrue(result.png.exists())
+            self.assertFalse((project_root / "calib" / "boards").exists())
+
+    def test_png_only_output_format_suppresses_pdf_output(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "printed-board"
+            with _isolated_project_config(tmpdir):
+                result = generate_charuco_board_setup(
+                    CharucoBoardSetupConfig(
+                        project_root=Path(tmpdir) / "project",
+                        out_dir=out_dir,
+                        output_format=OUTPUT_FORMAT_PNG,
+                        squares_x=3,
+                        squares_y=4,
+                        square_length_mm=20.0,
+                        marker_length_mm=14.0,
+                        dpi=80,
+                    )
+                )
+
+            self.assertTrue(result.png.exists())
+            self.assertTrue(result.yaml.exists())
+            self.assertIsNone(result.pdf)
+            self.assertFalse(result.requested_pdf)
+            self.assertEqual(sorted(out_dir.glob("*.pdf")), [])
+
+    def test_invalid_values_fail_clearly_before_output_artifacts(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "out"
+            with _isolated_project_config(tmpdir):
+                with self.assertRaises(CharucoBoardSetupError) as ctx:
+                    generate_charuco_board_setup(
+                        CharucoBoardSetupConfig(
+                            project_root=Path(tmpdir) / "project",
+                            out_dir=out_dir,
+                            square_length_mm=20.0,
+                            marker_length_mm=20.0,
+                            dpi=80,
+                        )
+                    )
+
+            self.assertIn("smaller than --square-length-mm", str(ctx.exception))
+            self.assertFalse(out_dir.exists())
+
+    def test_invalid_orientation_fails_before_project_dirs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            with _isolated_project_config(tmpdir):
+                with self.assertRaises(CharucoBoardSetupError) as ctx:
+                    generate_charuco_board_setup(
+                        CharucoBoardSetupConfig(
+                            project_root=project_root,
+                            orientation="diagonal",
+                        )
+                    )
+
+            self.assertIn("Orientation must be one of", str(ctx.exception))
+            self.assertFalse(project_root.exists())
+
+    def test_invalid_output_format_fails_before_project_dirs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            with _isolated_project_config(tmpdir):
+                with self.assertRaises(CharucoBoardSetupError) as ctx:
+                    generate_charuco_board_setup(
+                        CharucoBoardSetupConfig(
+                            project_root=project_root,
+                            output_format="SVG",
+                        )
+                    )
+
+            self.assertIn("Output format must be one of", str(ctx.exception))
+            self.assertFalse(project_root.exists())
+
+    def test_default_output_dir_is_display_only(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            output_dir = default_output_dir(project_root)
+
+            self.assertEqual(output_dir, project_root / "calib" / "boards")
+            self.assertFalse(project_root.exists())
+
+    def test_dictionary_choices_keep_default_first_when_supported(self) -> None:
+        choices = dictionary_choices()
+
+        self.assertIn(DEFAULT_DICTIONARY, choices)
+        self.assertEqual(choices[0], DEFAULT_DICTIONARY)
+
+    def test_output_format_choices_include_pdf_and_png_only(self) -> None:
+        self.assertIn("PNG + PDF", OUTPUT_FORMAT_CHOICES)
+        self.assertIn(OUTPUT_FORMAT_PNG, OUTPUT_FORMAT_CHOICES)
+
+
+def _isolated_project_config(tmpdir: str):
+    base = Path(tmpdir)
+    return patch.dict(
+        os.environ,
+        {
+            "HOME": str(base / "home"),
+            "XDG_CONFIG_HOME": str(base / ".config"),
+        },
+        clear=False,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_gui.py
+++ b/tests/test_workflow_gui.py
@@ -9,6 +9,7 @@ import unittest
 from contextlib import redirect_stderr
 from io import StringIO
 from pathlib import Path
+from types import SimpleNamespace
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
 
@@ -17,7 +18,17 @@ import yaml
 from posetag.gui import app as gui_app
 from posetag.gui.main_window import (
     _copy_confirmation_message,
+    _format_charuco_outputs,
+    _format_health_counts,
+    _health_status_style,
     _project_root_hint,
+    _stage_list_label,
+    _stage_rail_dot_style,
+    _stage_rail_entry_style,
+    _stage_rail_name,
+    _stage_rail_status_label,
+    _stage_rail_number_style,
+    _stage_status_chip_style,
     _style_sheet,
 )
 from posetag.gui.models import inspect_project_view, project_health_view
@@ -83,6 +94,21 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertEqual(rc, 2)
         self.assertIn("PySide6 is required", stderr.getvalue())
         self.assertIn('pip install -e ".[gui]"', stderr.getvalue())
+
+    def test_terminal_shutdown_handlers_quit_qt_application(self) -> None:
+        fake_app = _FakeQtApp()
+        fake_qt_core = _FakeQtCore()
+
+        with patch.object(gui_app.signal, "signal") as signal_fn:
+            gui_app._install_terminal_shutdown_handlers(fake_app, fake_qt_core)
+
+        self.assertGreaterEqual(signal_fn.call_count, 2)
+        handler = signal_fn.call_args_list[0].args[1]
+        handler(2, None)
+
+        self.assertEqual(fake_app.quit_calls, 1)
+        self.assertTrue(fake_app._posetag_signal_timer.started)
+        self.assertEqual(fake_app._posetag_signal_timer.interval, 200)
 
     def test_view_models_are_built_from_workflow_status_helpers(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -209,9 +235,110 @@ class WorkflowGuiTests(unittest.TestCase):
         style = _style_sheet()
 
         self.assertIn("QListWidget::item:selected", style)
-        self.assertIn("background: #e7f0fa", style)
+        self.assertIn("background: transparent", style)
         self.assertIn("color: #0b1724", style)
         self.assertIn("QListWidget::item:selected:!active", style)
+
+    def test_dashboard_style_uses_professional_instrumentation_layout(self) -> None:
+        style = _style_sheet()
+
+        self.assertIn('"Aptos"', style)
+        self.assertIn('"Aptos Display"', style)
+        self.assertIn('"Segoe UI"', style)
+        self.assertIn('"Segoe UI Variable Display"', style)
+        self.assertNotIn('"Virgil"', style)
+        self.assertNotIn('"Comic Sans MS"', style)
+        self.assertIn("QFrame#HeaderPanel", style)
+        self.assertIn("QFrame#RailPanel", style)
+        self.assertIn("QFrame#HealthPanel", style)
+        self.assertIn("QLabel#StageTitle", style)
+        self.assertIn("QLineEdit#CommandPreview", style)
+        self.assertIn("QLabel#HealthMessage", style)
+        self.assertIn("QLabel#HealthSectionTitle", style)
+        self.assertIn("QLabel#HealthSectionBody", style)
+        self.assertIn("QLabel#RailStageName", style)
+        self.assertIn("QLabel#RailStageNumber", style)
+        self.assertIn("QLabel#RailStageDot", style)
+        self.assertIn("QLabel#RailStageStatus", style)
+        self.assertIn("QLabel#CharucoPreviewCanvas", style)
+        self.assertIn("monospace", style)
+        self.assertIn("font-weight: 800", style)
+        self.assertIn("border-left: 3px solid #54708a", style)
+        self.assertIn("border-radius: 8px", style)
+
+    def test_charuco_output_summary_reflects_pdf_format_choice(self) -> None:
+        result = SimpleNamespace(
+            png=Path("board.png"),
+            yaml=Path("board.yaml"),
+            pdf=None,
+            requested_pdf=False,
+        )
+
+        summary = _format_charuco_outputs(result)
+
+        self.assertIn("Folder:", summary)
+        self.assertIn("PNG:    board.png", summary)
+        self.assertIn("YAML:   board.yaml", summary)
+        self.assertIn("PDF:    not requested", summary)
+
+    def test_health_panel_counts_and_status_are_compact(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            health = project_health_view(inspect_project_view(Path(tmpdir) / "project"))
+
+        counts = _format_health_counts(health)
+        self.assertIn("AT A GLANCE", counts)
+        self.assertIn("<table", counts)
+        self.assertIn("<td>Missing</td>", counts)
+        self.assertIn("<b>3</b>", counts)
+
+        status_style = _health_status_style(
+            foreground=health.status_color,
+            background=health.status_background,
+            border=health.status_border,
+        )
+        self.assertIn("font-size: 15px", status_style)
+        self.assertIn("border-left: 4px", status_style)
+        self.assertNotIn("font-size: 18px", status_style)
+
+    def test_stage_rail_has_compact_labels_without_progress_strip(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            models = inspect_project_view(Path(tmpdir) / "project")
+
+        stage0 = models[0]
+
+        self.assertEqual(
+            _stage_list_label(stage0),
+            "Stage 0\nGenerate AprilTag Sheets\nMissing",
+        )
+        stage3 = models[3]
+
+        self.assertEqual(_stage_rail_name(stage0), "Tags")
+        self.assertEqual(_stage_rail_status_label(stage0), "Missing")
+        self.assertEqual(_stage_rail_name(stage3), "Shots")
+        self.assertEqual(_stage_rail_status_label(stage3), "N/A")
+        self.assertIn("#eef8ff", _stage_rail_entry_style(stage0, selected=True))
+        self.assertIn("#0b6f8f", _stage_rail_entry_style(stage0, selected=True))
+        self.assertIn(
+            "border-left: 3px",
+            _stage_rail_entry_style(stage0, selected=True),
+        )
+        self.assertIn(
+            "border: 1px solid transparent",
+            _stage_rail_entry_style(stage0, selected=False),
+        )
+        self.assertIn("background: transparent", _stage_rail_number_style(stage0))
+        self.assertIn("border: none", _stage_rail_number_style(stage0))
+        self.assertIn("font-size: 12px", _stage_rail_number_style(stage0))
+        self.assertIn(stage0.status_color, _stage_rail_dot_style(stage0))
+        self.assertIn("border-radius: 3px", _stage_rail_dot_style(stage0))
+        self.assertIn(stage0.status_color, _stage_status_chip_style(stage0))
+        self.assertIn("background: transparent", _stage_status_chip_style(stage0))
+        self.assertIn("font-size: 9px", _stage_status_chip_style(stage0))
+
+        style = _style_sheet()
+        self.assertIn("QListWidget#WorkflowRail", style)
+        self.assertNotIn("ProgressStrip", style)
+        self.assertNotIn("ProgressStep", style)
 
     def test_backend_workflow_modules_do_not_import_gui(self) -> None:
         backend_files = list((SRC_ROOT / "posetag" / "workflows").glob("*.py"))
@@ -260,6 +387,39 @@ def _pythonpath_with_src(env: dict[str, str]) -> str:
     if existing:
         return f"{SRC_ROOT}{os.pathsep}{existing}"
     return str(SRC_ROOT)
+
+
+class _FakeSignal:
+    def __init__(self) -> None:
+        self.callback = None
+
+    def connect(self, callback) -> None:
+        self.callback = callback
+
+
+class _FakeTimer:
+    def __init__(self) -> None:
+        self.interval = None
+        self.started = False
+        self.timeout = _FakeSignal()
+
+    def setInterval(self, interval: int) -> None:
+        self.interval = interval
+
+    def start(self) -> None:
+        self.started = True
+
+
+class _FakeQtCore:
+    QTimer = _FakeTimer
+
+
+class _FakeQtApp:
+    def __init__(self) -> None:
+        self.quit_calls = 0
+
+    def quit(self) -> None:
+        self.quit_calls += 1
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_status.py
+++ b/tests/test_workflow_status.py
@@ -119,6 +119,25 @@ class WorkflowStatusTests(unittest.TestCase):
             self.assertEqual(stage.status, WorkflowStatus.COMPLETE)
             self.assertEqual(stage.errors, ())
 
+    def test_generated_charuco_metadata_is_reported_before_calibration(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            metadata_path = (
+                project_root
+                / "calib"
+                / "boards"
+                / "charuco_3x5_square50mm_marker37mm_7X7_50_A4_300dpi.yaml"
+            )
+            metadata_path.parent.mkdir(parents=True)
+            metadata_path.write_text("squares_x: 3\n", encoding="utf-8")
+
+            stage = _stage_by_id(project_root, 1)
+
+            self.assertEqual(stage.status, WorkflowStatus.MISSING)
+            self.assertIn(str(metadata_path), stage.checked_paths)
+            self.assertIn("generated ChArUco board metadata", stage.message)
+            self.assertIn("Actual Size", stage.next_action)
+
     def test_malformed_calib_color_yaml_needs_attention(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"


### PR DESCRIPTION
Issue #54 tracks guided ChArUco board setup in the PoseTag GUI. This PR adds Step 1 board generation from the desktop dashboard while keeping calibration capture/solve separate and reusing the existing ChArUco generation pipeline.

Summary:
- Add GUI-independent ChArUco setup workflow helpers for validation, output-path resolution, and PNG/PDF/YAML generation.
- Add Step 1 GUI controls for board dimensions, physical lengths, dictionary, paper, orientation, DPI, output format, and output folder.
- Show generated board preview, generated paths, print guidance, and open-file/open-folder actions.
- Refresh workflow status after generation and report generated ChArUco metadata before calibration exists.
- Make Pillow a runtime dependency so PDF output is available in standard installs.
- Refine the dashboard visual hierarchy, workflow rail, project health panel, heading treatment, and terminal shutdown handling.

Validation:
- python3 -m unittest discover -s tests -v
- python3 -m compileall -q src utils tests
- git diff --check

Residual risk:
- PySide6 is not installed in the local shell used for this pass, so the live Qt window was not re-screenshot after the final heading polish. The GUI entry point/import behavior and presentation helpers are covered by hardware-free tests.

Closes #54