### PR TITLE
Reorder GUI workflow around calibration-first setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,15 @@ python3 -m pip install -e ".[gui]"
 posetag-gui --project_root my_project
 ```
 
-The dashboard shows the selected project root, stages 0-6, a project-health
+The dashboard shows the selected project root, stages 0-8, a project-health
 summary, checked paths, warnings, errors, next recommended action, and copyable
-command previews. In Step 1 it can generate the ChArUco board PNG, PDF, and
-metadata YAML using the same package helper as `posetag-gen-charuco`.
-It can open selected folders in the system file manager, but it does not launch
-camera capture, calibration solving, board-building, annotation, or dataset
-workflows.
+command previews. The GUI order is project setup, ChArUco board generation,
+camera calibration, object AprilTag generation, board definitions, face-shot
+capture, annotation, dataset collection, and review/export. In Stage 1 it can
+generate the ChArUco board PNG, PDF, and metadata YAML using the same package
+helper as `posetag-gen-charuco`. It can open selected folders in the system
+file manager, but it does not launch camera capture, calibration solving,
+board-building, annotation, or dataset workflows.
 
 ## Scientific Contract
 
@@ -213,7 +215,7 @@ Print at **100%** / **Actual Size** and do not use “Fit to page”. Verify the
 printed square edge with a ruler before calibration.
 
 The optional `posetag-gui` dashboard provides the same ChArUco board setup from
-the Step 1 panel and refreshes project status after writing the files.
+the Stage 1 ChArUco panel and refreshes project status after writing the files.
 
 Then calibrate with the same board parameters. Press `SPACE` to capture a
 sample and `ENTER` to solve. The calibration command outputs

--- a/docs/workflows/step1_calibrate_charuco.md
+++ b/docs/workflows/step1_calibrate_charuco.md
@@ -81,10 +81,11 @@ Use `--out_dir <path>` to write the PNG/PDF/YAML somewhere other than
 `<project_root>/calib/boards/`. Custom paper can be supplied with
 `--paper-mm WxH`, for example `--paper-mm 210x297`.
 
-The optional `posetag-gui` dashboard exposes this setup as a guided Step 1
-panel. It calls the same package generator as `posetag-gen-charuco`, displays
-the generated PNG/YAML/PDF paths, and refreshes workflow status. It does not
-start camera capture or run `posetag-calib-charuco`.
+The optional `posetag-gui` dashboard exposes this setup as the guided Stage 1
+ChArUco board panel, before the Stage 2 camera-calibration command preview. It
+calls the same package generator as `posetag-gen-charuco`, displays the
+generated PNG/YAML/PDF paths, and refreshes workflow status. It does not start
+camera capture or run `posetag-calib-charuco`.
 
 ## Command Examples
 

--- a/src/posetag/gui/main_window.py
+++ b/src/posetag/gui/main_window.py
@@ -330,20 +330,16 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             command_layout = QtWidgets.QVBoxLayout(command_card)
             command_layout.setContentsMargins(14, 12, 14, 12)
             command_layout.setSpacing(8)
-            command_title = QtWidgets.QLabel("Command preview")
-            command_title.setObjectName("CardTitle")
-            command_note = QtWidgets.QLabel(
-                "Copy the preview into a terminal. Camera, calibration, "
-                "board-building, annotation, and dataset workflows are not "
-                "executed by the dashboard."
-            )
-            command_note.setObjectName("MutedText")
-            command_note.setWordWrap(True)
+            self._command_title = QtWidgets.QLabel("Command preview")
+            self._command_title.setObjectName("CardTitle")
+            self._command_note = QtWidgets.QLabel()
+            self._command_note.setObjectName("MutedText")
+            self._command_note.setWordWrap(True)
             command_row = QtWidgets.QHBoxLayout()
             command_row.addWidget(self._command_preview, 1)
             command_row.addWidget(self._copy_button)
-            command_layout.addWidget(command_title)
-            command_layout.addWidget(command_note)
+            command_layout.addWidget(self._command_title)
+            command_layout.addWidget(self._command_note)
             command_layout.addLayout(command_row)
             command_layout.addWidget(self._copy_feedback)
 
@@ -358,7 +354,7 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             charuco_title = QtWidgets.QLabel("ChArUco board setup")
             charuco_title.setObjectName("CardTitle")
             charuco_note = QtWidgets.QLabel(
-                "Generate the printed board for Step 1. Calibration capture "
+                "Generate the printed board for Stage 1. Calibration capture "
                 "and solve stay in posetag-calib-charuco."
             )
             charuco_note.setObjectName("MutedText")
@@ -858,11 +854,17 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._warnings_card.setVisible(bool(model.warnings))
             self._errors_card.setVisible(bool(model.errors))
             self._next_action_label.setText(model.next_action)
+            self._command_title.setText(_command_card_title(model))
+            self._command_note.setText(_command_card_note(model))
             self._command_preview.setText(model.command_preview)
             self._command_preview.setCursorPosition(0)
+            self._copy_button.setText(_command_button_label(model))
             self._copy_button.setEnabled(bool(model.command_preview))
             self._copy_feedback.setText(
-                _command_ready_message(model.command_preview)
+                _command_ready_message(
+                    model.command_preview,
+                    stage_complete=model.status == "complete",
+                )
             )
             self._charuco_card.setVisible(model.stage_id == 1)
             self._render_stage_rail_selection()
@@ -935,7 +937,11 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             command = self._command_preview.text()
             if command:
                 QtWidgets.QApplication.clipboard().setText(command)
-            message = _copy_confirmation_message(command)
+            model = self._model_by_stage_id(self._selected_stage_id)
+            message = _copy_confirmation_message(
+                command,
+                stage_complete=bool(model and model.status == "complete"),
+            )
             self._copy_feedback.setText(message)
             self.statusBar().showMessage(message, 3000)
 
@@ -989,13 +995,15 @@ def _stage_list_label(model: StageViewModel) -> str:
 
 
 _RAIL_STAGE_NAMES = {
-    0: "Tags",
-    1: "Calib",
-    2: "Boards",
-    3: "Shots",
-    4: "Annotate",
-    5: "Dataset",
-    6: "Review",
+    0: "Project",
+    1: "ChArUco",
+    2: "Calib",
+    3: "Tags",
+    4: "Boards",
+    5: "Shots",
+    6: "Annotate",
+    7: "Dataset",
+    8: "Export",
 }
 
 _RAIL_STATUS_LABELS = {
@@ -1143,14 +1151,46 @@ def _format_health_issues(health: ProjectHealthViewModel) -> str:
     )
 
 
-def _command_ready_message(command: str) -> str:
+def _command_card_title(model: StageViewModel) -> str:
+    if model.status == "complete" and model.command_preview:
+        return "Rerun command"
+    return "Command preview"
+
+
+def _command_card_note(model: StageViewModel) -> str:
+    if model.status == "complete" and model.command_preview:
+        return (
+            "This stage is already complete. The checked paths above are the "
+            "evidence for this stage; copy this command only if you need to "
+            "regenerate outputs."
+        )
+    if model.command_preview:
+        return (
+            "Copy the preview into a terminal. Camera calibration, "
+            "object-board building, annotation, and dataset workflows are not "
+            "executed by the dashboard."
+        )
+    return "No command preview is defined for this stage."
+
+
+def _command_button_label(model: StageViewModel) -> str:
+    if model.status == "complete" and model.command_preview:
+        return "Copy Rerun"
+    return "Copy Command"
+
+
+def _command_ready_message(command: str, *, stage_complete: bool = False) -> str:
     if command:
+        if stage_complete:
+            return "Stage complete. Copy only if you need to regenerate outputs."
         return "Ready to copy. Replace placeholder values before running it."
     return "No command preview is available for this stage."
 
 
-def _copy_confirmation_message(command: str) -> str:
+def _copy_confirmation_message(command: str, *, stage_complete: bool = False) -> str:
     if command:
+        if stage_complete:
+            return "Copied rerun command to the clipboard."
         return "Copied command preview to the clipboard."
     return "No command preview is available for this stage."
 
@@ -1158,13 +1198,13 @@ def _copy_confirmation_message(command: str) -> str:
 def _project_root_hint(root: Path) -> str:
     if root.is_dir():
         return (
-            "Project folder found. Status checks are read-only except Step 1 "
+            "Project folder found. Status checks are read-only except Stage 1 "
             "board generation."
         )
     if root.exists():
         return "Selected path exists but is not a folder."
     return (
-        "Project folder not found. Status checks are read-only; Step 1 board "
+        "Project folder not found. Status checks are read-only; Stage 1 board "
         "generation can create the selected project layout."
     )
 

--- a/src/posetag/gui/models.py
+++ b/src/posetag/gui/models.py
@@ -195,7 +195,10 @@ def project_health_view(
         return _health(
             status="missing",
             headline="No workflow outputs found",
-            message="Start by generating AprilTag sheets for this project.",
+            message=(
+                "Start by creating or selecting a project, then generate the "
+                "ChArUco calibration board."
+            ),
             counts=counts,
             warning_count=warning_count,
             error_count=error_count,

--- a/src/posetag/workflows/commands.py
+++ b/src/posetag/workflows/commands.py
@@ -8,7 +8,42 @@ from typing import Iterable, Union
 
 
 _COMMAND_TEMPLATES = {
+    "project_setup": (
+        "posetag",
+        "project",
+        "new",
+        "--root",
+        "{project_root}",
+    ),
+    "generate_charuco_board": (
+        "posetag-gen-charuco",
+        "--project_root",
+        "{project_root}",
+        "--squares-x",
+        "3",
+        "--squares-y",
+        "5",
+        "--square-length-mm",
+        "50",
+        "--marker-length-mm",
+        "37",
+        "--dict",
+        "7X7_50",
+        "--paper",
+        "A4",
+        "--dpi",
+        "300",
+    ),
     "generate_tags": (
+        "posetag-gen-tags",
+        "--project_root",
+        "{project_root}",
+        "--tag-size-mm",
+        "TAG_SIZE_MM",
+        "--ids",
+        "TAG_IDS",
+    ),
+    "generate_object_tags": (
         "posetag-gen-tags",
         "--project_root",
         "{project_root}",
@@ -27,6 +62,15 @@ _COMMAND_TEMPLATES = {
         "0",
     ),
     "build_boards": (
+        "posetag-make-board",
+        "--project_root",
+        "{project_root}",
+        "--object_name",
+        "OBJECT_FACE",
+        "--calib",
+        "calib_color.yaml",
+    ),
+    "build_object_boards": (
         "posetag-make-board",
         "--project_root",
         "{project_root}",

--- a/src/posetag/workflows/status.py
+++ b/src/posetag/workflows/status.py
@@ -1,8 +1,8 @@
 """Read-only workflow status inspection for PoseTag project directories.
 
-The helpers in this module are GUI-independent.  They report whether the
-validated PoseTag workflow artifacts for Steps 0-2 are present and readable,
-while leaving camera capture, calibration, board construction, annotation, and
+The helpers in this module are GUI-independent. They report whether the
+calibration-first GUI workflow artifacts are present and readable, while
+leaving camera capture, calibration, board construction, annotation, and
 pose-estimation algorithms in their existing pipeline modules.
 """
 
@@ -64,13 +64,15 @@ class _BoardSchema:
 
 
 _STAGE_NAMES = {
-    0: ("generate_tags", "Generate AprilTag Sheets"),
-    1: ("calibrate_camera", "Calibrate Camera"),
-    2: ("build_boards", "Build Boards"),
-    3: ("capture_face_shots", "Capture Face Shots"),
-    4: ("annotate_faces", "Annotate Faces"),
-    5: ("collect_dataset", "Collect Dataset"),
-    6: ("review_export", "Review and Export"),
+    0: ("project_setup", "Project Setup"),
+    1: ("generate_charuco_board", "Generate ChArUco Calibration Board"),
+    2: ("calibrate_camera", "Calibrate Camera"),
+    3: ("generate_object_tags", "Generate Object AprilTags"),
+    4: ("build_object_boards", "Build Object Board Definitions"),
+    5: ("capture_face_shots", "Capture Face Shots"),
+    6: ("annotate_faces", "Annotate Faces / Board-To-Object Transforms"),
+    7: ("collect_dataset", "Collect Dataset / Estimate Poses"),
+    8: ("review_export", "Review And Export"),
 }
 
 _CALIBRATION_REQUIRED_FIELDS = (
@@ -97,21 +99,193 @@ def inspect_project(project_root: Union[Path, str]) -> list[StageSummary]:
     """
 
     root = Path(project_root).expanduser()
+    project_setup = inspect_project_setup(root)
+    charuco_board = inspect_charuco_board(root)
+    camera_calibration = inspect_camera_calibration(root)
+    object_tags = inspect_object_tags(
+        root,
+        calibration_complete=camera_calibration.status == WorkflowStatus.COMPLETE,
+    )
+    board_definitions = inspect_board_definitions(
+        root,
+        calibration_complete=camera_calibration.status == WorkflowStatus.COMPLETE,
+        object_tags_complete=object_tags.status == WorkflowStatus.COMPLETE,
+    )
     summaries = [
-        inspect_step0(root),
-        inspect_step1(root),
-        inspect_step2(root),
+        project_setup,
+        charuco_board,
+        camera_calibration,
+        object_tags,
+        board_definitions,
     ]
     summaries.extend(
         _placeholder_summaries(
-            step2_complete=summaries[2].status == WorkflowStatus.COMPLETE
+            board_definitions_complete=board_definitions.status
+            == WorkflowStatus.COMPLETE
         )
     )
     return summaries
 
 
-def inspect_step0(project_root: Union[Path, str]) -> StageSummary:
-    """Inspect Step 0 AprilTag sheet outputs."""
+def inspect_project_setup(project_root: Union[Path, str]) -> StageSummary:
+    """Inspect Stage 0 project-root readiness."""
+
+    root = Path(project_root).expanduser()
+    checked_paths = _path_tuple([root])
+
+    if root.is_dir():
+        return _stage(
+            stage_id=0,
+            status=WorkflowStatus.COMPLETE,
+            message="Project folder exists and can be inspected.",
+            checked_paths=checked_paths,
+            next_action=(
+                "Generate the ChArUco calibration board for this project."
+            ),
+        )
+
+    if root.exists():
+        return _stage(
+            stage_id=0,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="Selected project root exists but is not a directory.",
+            checked_paths=checked_paths,
+            next_action="Choose a directory or create a new PoseTag project root.",
+        )
+
+    return _stage(
+        stage_id=0,
+        status=WorkflowStatus.MISSING,
+        message="Project folder was not found.",
+        checked_paths=checked_paths,
+        next_action=(
+            "Create the project with posetag project new --root, or select "
+            "an existing PoseTag project folder."
+        ),
+    )
+
+
+def inspect_charuco_board(project_root: Union[Path, str]) -> StageSummary:
+    """Inspect Stage 1 generated ChArUco calibration-board metadata."""
+
+    root = Path(project_root).expanduser()
+    boards_dir = root / "calib" / "boards"
+    metadata_paths = _generated_charuco_metadata_paths(root)
+    checked_paths = _path_tuple([boards_dir, *metadata_paths])
+
+    if metadata_paths:
+        count = len(metadata_paths)
+        return _stage(
+            stage_id=1,
+            status=WorkflowStatus.COMPLETE,
+            message=(
+                f"Found {count} generated ChArUco calibration board metadata "
+                f"file{'s' if count != 1 else ''}."
+            ),
+            checked_paths=checked_paths,
+            next_action=(
+                "Print the generated ChArUco board at 100% / Actual Size, "
+                "verify the square length, then calibrate the camera."
+            ),
+        )
+
+    return _stage(
+        stage_id=1,
+        status=WorkflowStatus.MISSING,
+        message="No generated ChArUco calibration board metadata files were found.",
+        checked_paths=checked_paths,
+        next_action=(
+            "Generate a ChArUco calibration board with posetag-gen-charuco, "
+            "print it at 100% / Actual Size, and verify the square length."
+        ),
+    )
+
+
+def inspect_camera_calibration(project_root: Union[Path, str]) -> StageSummary:
+    """Inspect Stage 2 colour-camera calibration output."""
+
+    root = Path(project_root).expanduser()
+    calib_path = root / "calib" / "calib_color.yaml"
+    charuco_metadata_paths = _generated_charuco_metadata_paths(root)
+    checked_paths = _path_tuple([calib_path, *charuco_metadata_paths])
+
+    if not calib_path.exists() and not charuco_metadata_paths:
+        return _stage(
+            stage_id=2,
+            status=WorkflowStatus.NOT_APPLICABLE,
+            message=(
+                "Camera calibration follows ChArUco board generation in the "
+                "guided workflow."
+            ),
+            checked_paths=checked_paths,
+            next_action="Complete Stage 1 before checking Stage 2.",
+        )
+
+    if not calib_path.exists():
+        count = len(charuco_metadata_paths)
+        return _stage(
+            stage_id=2,
+            status=WorkflowStatus.MISSING,
+            message=(
+                f"Found {count} generated ChArUco board metadata "
+                f"file{'s' if count != 1 else ''}, but colour-camera "
+                "calibration YAML was not found."
+            ),
+            checked_paths=checked_paths,
+            next_action=(
+                "Print the generated ChArUco board at 100% / Actual Size, "
+                "verify the square length, then run posetag-calib-charuco "
+                "to create calib/calib_color.yaml."
+            ),
+        )
+
+    try:
+        load_calibration_yaml(calib_path)
+    except MakeBoardError as exc:
+        return _stage(
+            stage_id=2,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message=(
+                "Colour-camera calibration YAML exists but did not pass "
+                "schema checks."
+            ),
+            checked_paths=checked_paths,
+            errors=(str(exc),),
+            next_action=(
+                "Regenerate or repair calib/calib_color.yaml before "
+                "generating object AprilTags."
+            ),
+        )
+
+    workflow_errors = _validate_calibration_workflow_schema(calib_path)
+    if workflow_errors:
+        return _stage(
+            stage_id=2,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="Colour-camera calibration YAML exists but is incomplete.",
+            checked_paths=checked_paths,
+            errors=workflow_errors,
+            next_action=(
+                "Regenerate or repair calib/calib_color.yaml before "
+                "generating object AprilTags."
+            ),
+        )
+
+    return _stage(
+        stage_id=2,
+        status=WorkflowStatus.COMPLETE,
+        message="Colour-camera calibration YAML exists and passed schema checks.",
+        checked_paths=checked_paths,
+        next_action="Proceed to Stage 3 object AprilTag generation.",
+    )
+
+
+def inspect_object_tags(
+    project_root: Union[Path, str],
+    *,
+    calibration_complete: bool = False,
+) -> StageSummary:
+    """Inspect Stage 3 object AprilTag sheet outputs."""
 
     root = Path(project_root).expanduser()
     patterns_dir = root / "boards" / "patterns"
@@ -121,112 +295,77 @@ def inspect_step0(project_root: Union[Path, str]) -> StageSummary:
     if png_paths:
         count = len(png_paths)
         return _stage(
-            stage_id=0,
+            stage_id=3,
             status=WorkflowStatus.COMPLETE,
-            message=f"Found {count} AprilTag sheet PNG file{'s' if count != 1 else ''}.",
-            checked_paths=checked_paths,
-            next_action="Proceed to Step 1 camera calibration.",
-        )
-
-    return _stage(
-        stage_id=0,
-        status=WorkflowStatus.MISSING,
-        message="No generated AprilTag sheet PNG files were found.",
-        checked_paths=checked_paths,
-        next_action="Run posetag-gen-tags to write sheets under boards/patterns/.",
-    )
-
-
-def inspect_step1(project_root: Union[Path, str]) -> StageSummary:
-    """Inspect Step 1 colour-camera calibration output."""
-
-    root = Path(project_root).expanduser()
-    calib_path = root / "calib" / "calib_color.yaml"
-    charuco_metadata_paths = _generated_charuco_metadata_paths(root)
-    checked_paths = _path_tuple([calib_path, *charuco_metadata_paths])
-
-    if not calib_path.exists():
-        if charuco_metadata_paths:
-            count = len(charuco_metadata_paths)
-            return _stage(
-                stage_id=1,
-                status=WorkflowStatus.MISSING,
-                message=(
-                    f"Found {count} generated ChArUco board metadata "
-                    f"file{'s' if count != 1 else ''}, but colour-camera "
-                    "calibration YAML was not found."
-                ),
-                checked_paths=checked_paths,
-                next_action=(
-                    "Print the generated ChArUco board at 100% / Actual Size, "
-                    "verify the square length, then run posetag-calib-charuco "
-                    "to create calib/calib_color.yaml."
-                ),
-            )
-        return _stage(
-            stage_id=1,
-            status=WorkflowStatus.MISSING,
-            message="Colour-camera calibration YAML was not found.",
-            checked_paths=checked_paths,
-            next_action=(
-                "Generate and print a ChArUco board if needed, then run "
-                "posetag-calib-charuco to create calib/calib_color.yaml."
+            message=(
+                f"Found {count} object AprilTag sheet PNG "
+                f"file{'s' if count != 1 else ''}."
             ),
+            checked_paths=checked_paths,
+            next_action="Proceed to Stage 4 object board definition.",
         )
 
-    try:
-        load_calibration_yaml(calib_path)
-    except MakeBoardError as exc:
+    if not calibration_complete:
         return _stage(
-            stage_id=1,
-            status=WorkflowStatus.NEEDS_ATTENTION,
-            message="Colour-camera calibration YAML exists but did not pass schema checks.",
+            stage_id=3,
+            status=WorkflowStatus.NOT_APPLICABLE,
+            message="Object AprilTag generation follows camera calibration in the GUI.",
             checked_paths=checked_paths,
-            errors=(str(exc),),
-            next_action="Regenerate or repair calib/calib_color.yaml before building boards.",
-        )
-
-    workflow_errors = _validate_calibration_workflow_schema(calib_path)
-    if workflow_errors:
-        return _stage(
-            stage_id=1,
-            status=WorkflowStatus.NEEDS_ATTENTION,
-            message="Colour-camera calibration YAML exists but is incomplete.",
-            checked_paths=checked_paths,
-            errors=workflow_errors,
-            next_action="Regenerate or repair calib/calib_color.yaml before building boards.",
+            next_action="Complete Stage 2 before checking Stage 3.",
         )
 
     return _stage(
-        stage_id=1,
-        status=WorkflowStatus.COMPLETE,
-        message="Colour-camera calibration YAML exists and passed schema checks.",
+        stage_id=3,
+        status=WorkflowStatus.MISSING,
+        message="No generated object AprilTag sheet PNG files were found.",
         checked_paths=checked_paths,
-        next_action="Proceed to Step 2 board building.",
+        next_action=(
+            "Run posetag-gen-tags to write object tag sheets under "
+            "boards/patterns/."
+        ),
     )
 
 
-def inspect_step2(project_root: Union[Path, str]) -> StageSummary:
-    """Inspect Step 2 board YAML files and tag registry output."""
+def inspect_board_definitions(
+    project_root: Union[Path, str],
+    *,
+    calibration_complete: bool = False,
+    object_tags_complete: bool = False,
+) -> StageSummary:
+    """Inspect Stage 4 board YAML files and tag registry output."""
 
     root = Path(project_root).expanduser()
     registry_path = root / "boards" / "tag_registry.yaml"
     checked_paths: list[Path] = [registry_path]
 
     if not registry_path.exists():
+        if not (calibration_complete and object_tags_complete):
+            return _stage(
+                stage_id=4,
+                status=WorkflowStatus.NOT_APPLICABLE,
+                message=(
+                    "Object board definitions depend on camera calibration "
+                    "and printed object AprilTags."
+                ),
+                checked_paths=_path_tuple(checked_paths),
+                next_action="Complete Stages 2 and 3 before checking Stage 4.",
+            )
         return _stage(
-            stage_id=2,
+            stage_id=4,
             status=WorkflowStatus.MISSING,
             message="Tag registry YAML was not found.",
             checked_paths=_path_tuple(checked_paths),
-            next_action="Run posetag-make-board after completing camera calibration.",
+            next_action=(
+                "Run posetag-make-board after completing camera calibration "
+                "and printing object AprilTags."
+            ),
         )
 
     try:
         registry = load_registry(registry_path)
     except MakeBoardError as exc:
         return _stage(
-            stage_id=2,
+            stage_id=4,
             status=WorkflowStatus.NEEDS_ATTENTION,
             message="Tag registry YAML exists but did not pass schema checks.",
             checked_paths=_path_tuple(checked_paths),
@@ -237,7 +376,7 @@ def inspect_step2(project_root: Union[Path, str]) -> StageSummary:
     tags = registry.get("tags", {})
     if not tags:
         return _stage(
-            stage_id=2,
+            stage_id=4,
             status=WorkflowStatus.NEEDS_ATTENTION,
             message="Tag registry YAML has no tag mappings.",
             checked_paths=_path_tuple(checked_paths),
@@ -306,10 +445,11 @@ def inspect_step2(project_root: Union[Path, str]) -> StageSummary:
         if valid_board_paths:
             warnings.append(
                 f"Found {len(valid_board_paths)} valid referenced board YAML file"
-                f"{'s' if len(valid_board_paths) != 1 else ''}, but the registry also has errors."
+                f"{'s' if len(valid_board_paths) != 1 else ''}, but the "
+                "registry also has errors."
             )
         return _stage(
-            stage_id=2,
+            stage_id=4,
             status=WorkflowStatus.NEEDS_ATTENTION,
             message="Tag registry or referenced board YAML files need attention.",
             checked_paths=_path_tuple(checked_paths),
@@ -323,7 +463,7 @@ def inspect_step2(project_root: Union[Path, str]) -> StageSummary:
 
     if not valid_board_paths:
         return _stage(
-            stage_id=2,
+            stage_id=4,
             status=WorkflowStatus.NEEDS_ATTENTION,
             message="No referenced board YAML files passed schema checks.",
             checked_paths=_path_tuple(checked_paths),
@@ -331,62 +471,71 @@ def inspect_step2(project_root: Union[Path, str]) -> StageSummary:
                 "At least one referenced board YAML must exist and match the "
                 "Step 2 schema.",
             ),
-            next_action="Run posetag-make-board to create a board YAML and registry mapping.",
+            next_action=(
+                "Run posetag-make-board to create a board YAML and registry "
+                "mapping."
+            ),
         )
 
     count = len(valid_board_paths)
     return _stage(
-        stage_id=2,
+        stage_id=4,
         status=WorkflowStatus.COMPLETE,
         message=(
             f"Tag registry maps tags to {count} valid board YAML "
             f"file{'s' if count != 1 else ''}."
         ),
         checked_paths=_path_tuple(checked_paths),
-        next_action="Proceed to Step 3 face-shot capture.",
+        next_action="Proceed to Stage 5 face-shot capture.",
     )
 
 
-def _placeholder_summaries(step2_complete: bool) -> list[StageSummary]:
-    if step2_complete:
-        step3 = _stage(
-            stage_id=3,
+def _placeholder_summaries(board_definitions_complete: bool) -> list[StageSummary]:
+    if board_definitions_complete:
+        stage5 = _stage(
+            stage_id=5,
             status=WorkflowStatus.MISSING,
             message="Face-shot capture status validation is not implemented yet.",
             checked_paths=(),
-            next_action="Run the Step 3 capture workflow after confirming board coverage.",
+            next_action=(
+                "Run the Stage 5 capture workflow after confirming board "
+                "coverage."
+            ),
         )
     else:
-        step3 = _stage(
-            stage_id=3,
+        stage5 = _stage(
+            stage_id=5,
             status=WorkflowStatus.NOT_APPLICABLE,
             message="Face-shot capture depends on a valid tag registry and board YAML.",
             checked_paths=(),
-            next_action="Complete Step 2 before checking Step 3.",
+            next_action="Complete Stage 4 before checking Stage 5.",
         )
 
     return [
-        step3,
-        _stage(
-            stage_id=4,
-            status=WorkflowStatus.NOT_APPLICABLE,
-            message="Face annotation depends on captured face shots.",
-            checked_paths=(),
-            next_action="Complete Step 3 before checking Step 4.",
-        ),
-        _stage(
-            stage_id=5,
-            status=WorkflowStatus.NOT_APPLICABLE,
-            message="Dataset collection depends on calibration, boards, and annotations.",
-            checked_paths=(),
-            next_action="Complete Steps 1-4 before checking Step 5.",
-        ),
+        stage5,
         _stage(
             stage_id=6,
             status=WorkflowStatus.NOT_APPLICABLE,
+            message="Face annotation depends on captured face shots.",
+            checked_paths=(),
+            next_action="Complete Stage 5 before checking Stage 6.",
+        ),
+        _stage(
+            stage_id=7,
+            status=WorkflowStatus.NOT_APPLICABLE,
+            message=(
+                "Dataset collection depends on calibration, boards, and "
+                "annotations."
+            ),
+            checked_paths=(),
+            next_action="Complete Stages 2-6 before checking Stage 7.",
+        ),
+        _stage(
+            stage_id=8,
+            status=WorkflowStatus.NOT_APPLICABLE,
             message="Review and export depends on generated dataset outputs.",
             checked_paths=(),
-            next_action="Complete Step 5 before checking Step 6.",
+            next_action="Complete Stage 7 before checking Stage 8.",
         ),
     ]
 

--- a/tests/test_workflow_gui.py
+++ b/tests/test_workflow_gui.py
@@ -17,6 +17,10 @@ import yaml
 
 from posetag.gui import app as gui_app
 from posetag.gui.main_window import (
+    _command_button_label,
+    _command_card_note,
+    _command_card_title,
+    _command_ready_message,
     _copy_confirmation_message,
     _format_charuco_outputs,
     _format_health_counts,
@@ -115,12 +119,15 @@ class WorkflowGuiTests(unittest.TestCase):
             project_root = Path(tmpdir) / "project with spaces"
             models = inspect_project_view(project_root)
 
-        self.assertEqual(len(models), 7)
+        self.assertEqual(len(models), 9)
         self.assertEqual(models[0].stage_id, 0)
         self.assertEqual(models[0].status, "missing")
-        self.assertIn("posetag-gen-tags", models[0].command_preview)
-        self.assertIn("--project_root", models[0].command_preview)
-        self.assertEqual(models[6].command_preview, "")
+        self.assertIn("posetag project new", models[0].command_preview)
+        self.assertIn("posetag-gen-charuco", models[1].command_preview)
+        self.assertIn("posetag-calib-charuco", models[2].command_preview)
+        self.assertIn("posetag-gen-tags", models[3].command_preview)
+        self.assertIn("--project_root", models[3].command_preview)
+        self.assertEqual(models[8].command_preview, "")
 
     def test_project_health_view_handles_empty_project_state(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -130,8 +137,8 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertEqual(health.status, "missing")
         self.assertEqual(health.headline, "No workflow outputs found")
         self.assertEqual(health.error_count, 0)
-        self.assertEqual(health.next_stage_label, "Stage 0: Generate AprilTag Sheets")
-        self.assertIn("posetag-gen-tags", health.next_action)
+        self.assertEqual(health.next_stage_label, "Stage 0: Project Setup")
+        self.assertIn("posetag project new", health.next_action)
 
     def test_project_health_view_prioritizes_attention_states(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -145,7 +152,7 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertEqual(health.status, "needs_attention")
         self.assertEqual(health.headline, "Needs attention")
         self.assertGreater(health.error_count, 0)
-        self.assertEqual(health.next_stage_label, "Stage 1: Calibrate Camera")
+        self.assertEqual(health.next_stage_label, "Stage 2: Calibrate Camera")
         self.assertIn("calib_color.yaml", health.next_action)
 
     def test_project_health_view_keeps_mixed_missing_outputs_incomplete(self) -> None:
@@ -189,7 +196,10 @@ class WorkflowGuiTests(unittest.TestCase):
 
         self.assertEqual(health.status, "missing")
         self.assertEqual(health.headline, "Workflow outputs missing")
-        self.assertEqual(health.next_stage_label, "Stage 0: Generate AprilTag Sheets")
+        self.assertEqual(
+            health.next_stage_label,
+            "Stage 1: Generate ChArUco Calibration Board",
+        )
         self.assertIn("required outputs are still missing", health.message)
 
     def test_command_preview_quotes_project_paths(self) -> None:
@@ -219,8 +229,53 @@ class WorkflowGuiTests(unittest.TestCase):
             "Copied command preview to the clipboard.",
         )
         self.assertEqual(
+            _copy_confirmation_message(
+                "posetag-gen-tags --project_root project",
+                stage_complete=True,
+            ),
+            "Copied rerun command to the clipboard.",
+        )
+        self.assertEqual(
             _copy_confirmation_message(""),
             "No command preview is available for this stage.",
+        )
+
+    def test_complete_stage_command_copy_reads_as_secondary_rerun(self) -> None:
+        complete = SimpleNamespace(
+            status="complete",
+            command_preview="posetag-gen-charuco --project_root project",
+        )
+        missing = SimpleNamespace(
+            status="missing",
+            command_preview="posetag-gen-tags --project_root project",
+        )
+        no_command = SimpleNamespace(status="not_applicable", command_preview="")
+
+        self.assertEqual(_command_card_title(complete), "Rerun command")
+        self.assertEqual(_command_button_label(complete), "Copy Rerun")
+        self.assertIn("already complete", _command_card_note(complete))
+        self.assertIn("checked paths", _command_card_note(complete))
+        self.assertEqual(
+            _command_ready_message(
+                complete.command_preview,
+                stage_complete=True,
+            ),
+            "Stage complete. Copy only if you need to regenerate outputs.",
+        )
+
+        self.assertEqual(_command_card_title(missing), "Command preview")
+        self.assertEqual(_command_button_label(missing), "Copy Command")
+        self.assertIn("Copy the preview", _command_card_note(missing))
+        self.assertEqual(
+            _command_ready_message(missing.command_preview),
+            "Ready to copy. Replace placeholder values before running it.",
+        )
+
+        self.assertEqual(_command_card_title(no_command), "Command preview")
+        self.assertEqual(_command_button_label(no_command), "Copy Command")
+        self.assertEqual(
+            _command_card_note(no_command),
+            "No command preview is defined for this stage.",
         )
 
     def test_project_root_hint_does_not_create_empty_project(self) -> None:
@@ -289,7 +344,9 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertIn("AT A GLANCE", counts)
         self.assertIn("<table", counts)
         self.assertIn("<td>Missing</td>", counts)
-        self.assertIn("<b>3</b>", counts)
+        self.assertIn("<b>2</b>", counts)
+        self.assertIn("<td>Not applicable</td>", counts)
+        self.assertIn("<b>7</b>", counts)
 
         status_style = _health_status_style(
             foreground=health.status_color,
@@ -308,14 +365,16 @@ class WorkflowGuiTests(unittest.TestCase):
 
         self.assertEqual(
             _stage_list_label(stage0),
-            "Stage 0\nGenerate AprilTag Sheets\nMissing",
+            "Stage 0\nProject Setup\nMissing",
         )
         stage3 = models[3]
+        stage5 = models[5]
 
-        self.assertEqual(_stage_rail_name(stage0), "Tags")
+        self.assertEqual(_stage_rail_name(stage0), "Project")
         self.assertEqual(_stage_rail_status_label(stage0), "Missing")
-        self.assertEqual(_stage_rail_name(stage3), "Shots")
+        self.assertEqual(_stage_rail_name(stage3), "Tags")
         self.assertEqual(_stage_rail_status_label(stage3), "N/A")
+        self.assertEqual(_stage_rail_name(stage5), "Shots")
         self.assertIn("#eef8ff", _stage_rail_entry_style(stage0, selected=True))
         self.assertIn("#0b6f8f", _stage_rail_entry_style(stage0, selected=True))
         self.assertIn(

--- a/tests/test_workflow_status.py
+++ b/tests/test_workflow_status.py
@@ -70,7 +70,7 @@ def _write_valid_board_and_registry(project_root: Path) -> tuple[Path, Path]:
 
 
 class WorkflowStatusTests(unittest.TestCase):
-    def test_empty_project_reports_steps_0_to_2_missing(self) -> None:
+    def test_empty_project_reports_calibration_first_gui_order(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
             summaries = inspect_project(project_root)
@@ -78,8 +78,24 @@ class WorkflowStatusTests(unittest.TestCase):
 
             self.assertEqual(by_id[0].status, WorkflowStatus.MISSING)
             self.assertEqual(by_id[1].status, WorkflowStatus.MISSING)
-            self.assertEqual(by_id[2].status, WorkflowStatus.MISSING)
-            self.assertEqual(len(summaries), 7)
+            self.assertEqual(by_id[2].status, WorkflowStatus.NOT_APPLICABLE)
+            self.assertEqual(by_id[3].status, WorkflowStatus.NOT_APPLICABLE)
+            self.assertEqual(by_id[4].status, WorkflowStatus.NOT_APPLICABLE)
+            self.assertEqual(len(summaries), 9)
+            self.assertEqual(
+                [summary.name for summary in summaries],
+                [
+                    "Project Setup",
+                    "Generate ChArUco Calibration Board",
+                    "Calibrate Camera",
+                    "Generate Object AprilTags",
+                    "Build Object Board Definitions",
+                    "Capture Face Shots",
+                    "Annotate Faces / Board-To-Object Transforms",
+                    "Collect Dataset / Estimate Poses",
+                    "Review And Export",
+                ],
+            )
             for summary in summaries:
                 rendered = summary.to_dict()
                 for key in (
@@ -95,7 +111,7 @@ class WorkflowStatusTests(unittest.TestCase):
                 ):
                     self.assertIn(key, rendered)
 
-    def test_patterns_png_marks_step0_complete(self) -> None:
+    def test_patterns_png_marks_object_tag_stage_complete(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
             patterns_dir = project_root / "boards" / "patterns"
@@ -104,22 +120,22 @@ class WorkflowStatusTests(unittest.TestCase):
                 b"not-an-image-but-a-png-path"
             )
 
-            stage = _stage_by_id(project_root, 0)
+            stage = _stage_by_id(project_root, 3)
 
             self.assertEqual(stage.status, WorkflowStatus.COMPLETE)
             self.assertIn(str(patterns_dir / "apriltag_sheet.png"), stage.checked_paths)
 
-    def test_valid_calib_color_yaml_marks_step1_complete(self) -> None:
+    def test_valid_calib_color_yaml_marks_calibration_stage_complete(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
             _write_valid_calibration(project_root / "calib" / "calib_color.yaml")
 
-            stage = _stage_by_id(project_root, 1)
+            stage = _stage_by_id(project_root, 2)
 
             self.assertEqual(stage.status, WorkflowStatus.COMPLETE)
             self.assertEqual(stage.errors, ())
 
-    def test_generated_charuco_metadata_is_reported_before_calibration(self) -> None:
+    def test_generated_charuco_metadata_is_stage_before_calibration(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
             metadata_path = (
@@ -131,12 +147,18 @@ class WorkflowStatusTests(unittest.TestCase):
             metadata_path.parent.mkdir(parents=True)
             metadata_path.write_text("squares_x: 3\n", encoding="utf-8")
 
-            stage = _stage_by_id(project_root, 1)
+            charuco_stage = _stage_by_id(project_root, 1)
+            calibration_stage = _stage_by_id(project_root, 2)
 
-            self.assertEqual(stage.status, WorkflowStatus.MISSING)
-            self.assertIn(str(metadata_path), stage.checked_paths)
-            self.assertIn("generated ChArUco board metadata", stage.message)
-            self.assertIn("Actual Size", stage.next_action)
+            self.assertEqual(charuco_stage.status, WorkflowStatus.COMPLETE)
+            self.assertIn(str(metadata_path), charuco_stage.checked_paths)
+            self.assertIn(
+                "generated ChArUco calibration board metadata",
+                charuco_stage.message,
+            )
+            self.assertIn("Actual Size", charuco_stage.next_action)
+            self.assertEqual(calibration_stage.status, WorkflowStatus.MISSING)
+            self.assertIn(str(metadata_path), calibration_stage.checked_paths)
 
     def test_malformed_calib_color_yaml_needs_attention(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -145,7 +167,7 @@ class WorkflowStatusTests(unittest.TestCase):
             calib_path.parent.mkdir(parents=True)
             calib_path.write_text("not_camera_matrix: true\n", encoding="utf-8")
 
-            stage = _stage_by_id(project_root, 1)
+            stage = _stage_by_id(project_root, 2)
 
             self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
             self.assertTrue(stage.errors)
@@ -177,18 +199,20 @@ class WorkflowStatusTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            stage = _stage_by_id(project_root, 1)
+            stage = _stage_by_id(project_root, 2)
 
             self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
             self.assertTrue(any("image_width" in error for error in stage.errors))
             self.assertTrue(any("reproj_rms" in error for error in stage.errors))
 
-    def test_valid_board_yaml_and_registry_mark_step2_complete(self) -> None:
+    def test_valid_board_yaml_and_registry_mark_board_definition_stage_complete(
+        self,
+    ) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
             board_path, registry_path = _write_valid_board_and_registry(project_root)
 
-            stage = _stage_by_id(project_root, 2)
+            stage = _stage_by_id(project_root, 4)
 
             self.assertEqual(stage.status, WorkflowStatus.COMPLETE)
             self.assertEqual(stage.errors, ())
@@ -217,7 +241,7 @@ class WorkflowStatusTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            stage = _stage_by_id(project_root, 2)
+            stage = _stage_by_id(project_root, 4)
 
             self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
             self.assertTrue(stage.errors)
@@ -252,7 +276,7 @@ class WorkflowStatusTests(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            stage = _stage_by_id(project_root, 2)
+            stage = _stage_by_id(project_root, 4)
 
             self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
             self.assertTrue(any("not present" in error for error in stage.errors))
@@ -265,7 +289,7 @@ class WorkflowStatusTests(unittest.TestCase):
             registry["tags"]["52"]["object"] = "different_object"
             registry_path.write_text(yaml.safe_dump(registry), encoding="utf-8")
 
-            stage = _stage_by_id(project_root, 2)
+            stage = _stage_by_id(project_root, 4)
 
             self.assertEqual(stage.status, WorkflowStatus.NEEDS_ATTENTION)
             self.assertTrue(any("different_object" in error for error in stage.errors))


### PR DESCRIPTION
Issue #56: reorder the PoseTag GUI workflow around the logical calibration-first user journey.

Summary:
- Reorders GUI/status stages to Project Setup, ChArUco board generation, camera calibration, object AprilTags, object board definitions, face shots, annotation, dataset collection, and review/export.
- Adds command previews for project setup and ChArUco generation while preserving existing CLI commands and output schemas.
- Reframes complete-stage command previews as secondary rerun actions, with checked paths kept as the primary evidence.
- Updates GUI/status tests and GUI-order documentation.

Validation:
- python3 -m unittest discover -s tests -v
- python3 -m compileall -q src utils tests
- git diff --check

Residual risks:
- PySide6 was not installed in the local environment, so the live Qt window could not be smoke-checked here. The GUI view-model tests cover the reordered stages and complete-stage rerun copy.

Technical debt:
- Later GUI work can further separate verified-output review surfaces from rerun command affordances, but this PR keeps the issue #56 scope small.

Closes #56