### PR TITLE
Add guided GUI camera calibration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,13 @@ command previews. The GUI order is project setup, ChArUco board generation,
 camera calibration, object AprilTag generation, board definitions, face-shot
 capture, annotation, dataset collection, and review/export. In Stage 1 it can
 generate the ChArUco board PNG, PDF, and metadata YAML using the same package
-helper as `posetag-gen-charuco`. It can open selected folders in the system
-file manager, but it does not launch camera capture, calibration solving,
-board-building, annotation, or dataset workflows.
+helper as `posetag-gen-charuco`. In Stage 2 it reads the generated ChArUco
+metadata, autofills the calibration board parameters, lets you choose webcam,
+RealSense, or video source settings, and prepares a copyable
+`posetag-calib-charuco` command with the expected
+`<project_root>/calib/calib_color.yaml` output path. It can open selected
+folders in the system file manager, but it does not reimplement camera
+capture, calibration solving, board-building, annotation, or dataset workflows.
 
 ## Scientific Contract
 
@@ -216,6 +220,11 @@ printed square edge with a ruler before calibration.
 
 The optional `posetag-gui` dashboard provides the same ChArUco board setup from
 the Stage 1 ChArUco panel and refreshes project status after writing the files.
+The Stage 2 calibration panel then reads the generated metadata, autofills the
+matching board arguments, lets you choose webcam/OpenCV, RealSense, or video
+source settings, shows the `SPACE` / `ENTER` / `q` controls, and prepares a
+copyable `posetag-calib-charuco` command. Refresh the dashboard after
+`calib/calib_color.yaml` appears to update workflow status.
 
 Then calibrate with the same board parameters. Press `SPACE` to capture a
 sample and `ENTER` to solve. The calibration command outputs

--- a/docs/workflows/step1_calibrate_charuco.md
+++ b/docs/workflows/step1_calibrate_charuco.md
@@ -82,10 +82,15 @@ Use `--out_dir <path>` to write the PNG/PDF/YAML somewhere other than
 `--paper-mm WxH`, for example `--paper-mm 210x297`.
 
 The optional `posetag-gui` dashboard exposes this setup as the guided Stage 1
-ChArUco board panel, before the Stage 2 camera-calibration command preview. It
-calls the same package generator as `posetag-gen-charuco`, displays the
-generated PNG/YAML/PDF paths, and refreshes workflow status. It does not start
-camera capture or run `posetag-calib-charuco`.
+ChArUco board panel, then uses the generated metadata in Stage 2 to guide
+camera calibration. The Stage 2 panel autofills `--squares-x`, `--squares-y`,
+`--square-length-mm`, `--marker-length-mm`, and `--dict`, lets you choose
+webcam/OpenCV, RealSense, or video source settings, shows the expected
+`<project_root>/calib/calib_color.yaml` output, and prepares a copyable
+`posetag-calib-charuco` command. It also reports missing metadata, missing
+video path, unavailable RealSense dependency, and missing calibration output
+states. It does not start camera capture, detect ChArUco corners, solve
+calibration, or write calibration YAML itself.
 
 ## Command Examples
 

--- a/src/posetag/gui/main_window.py
+++ b/src/posetag/gui/main_window.py
@@ -29,6 +29,19 @@ from posetag.workflows.charuco_setup import (
     dictionary_choices,
     generate_charuco_board_setup,
 )
+from posetag.workflows.calibration_flow import (
+    CALIBRATION_SOURCE_CHOICES,
+    CALIBRATION_SOURCE_LABELS,
+    SOURCE_OPENCV,
+    SOURCE_REALSENSE,
+    SOURCE_VIDEO,
+    CameraCalibrationConfig,
+    CameraCalibrationReadiness,
+    camera_calibration_config_from_project,
+    inspect_camera_calibration_readiness,
+    inspect_charuco_metadata,
+    normalize_source,
+)
 
 
 def build_main_window(qt: Any, project_root: Path) -> Any:
@@ -559,6 +572,230 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             charuco_layout.addWidget(charuco_note)
             charuco_layout.addLayout(charuco_body)
 
+            self._loaded_calibration_metadata_path: Optional[Path] = None
+            self._loaded_calibration_metadata_mtime: Optional[int] = None
+            self._calibration_card = QtWidgets.QFrame()
+            self._calibration_card.setObjectName("ActionCard")
+            calibration_layout = QtWidgets.QVBoxLayout(self._calibration_card)
+            calibration_layout.setContentsMargins(14, 12, 14, 12)
+            calibration_layout.setSpacing(9)
+
+            calibration_title = QtWidgets.QLabel("Camera calibration guide")
+            calibration_title.setObjectName("CardTitle")
+            calibration_note = QtWidgets.QLabel(
+                "Use the generated ChArUco metadata to prepare a "
+                "posetag-calib-charuco command. Capture and solve still run in "
+                "the existing calibration window."
+            )
+            calibration_note.setObjectName("MutedText")
+            calibration_note.setWordWrap(True)
+
+            self._calibration_source = QtWidgets.QComboBox()
+            for source in CALIBRATION_SOURCE_CHOICES:
+                self._calibration_source.addItem(
+                    CALIBRATION_SOURCE_LABELS[source],
+                    source,
+                )
+            self._calibration_source.setMinimumWidth(180)
+            self._calibration_source.currentIndexChanged.connect(
+                self._calibration_source_changed
+            )
+
+            self._calibration_camera_index = _make_int_spin(0, 99, 0)
+            self._calibration_video_path = QtWidgets.QLineEdit()
+            self._calibration_video_path.setPlaceholderText(
+                "Select calibration video file"
+            )
+            self._calibration_video_path.textChanged.connect(
+                self._update_calibration_flow
+            )
+            calibration_video_browse_button = QtWidgets.QPushButton("Browse")
+            calibration_video_browse_button.clicked.connect(
+                self._browse_calibration_video
+            )
+            self._calibration_video_browse_button = calibration_video_browse_button
+            calibration_video_row = QtWidgets.QHBoxLayout()
+            calibration_video_row.setContentsMargins(0, 0, 0, 0)
+            calibration_video_row.addWidget(self._calibration_video_path, 1)
+            calibration_video_row.addWidget(calibration_video_browse_button)
+            calibration_video_widget = QtWidgets.QWidget()
+            calibration_video_widget.setLayout(calibration_video_row)
+
+            self._calibration_squares_x = _make_int_spin(2, 99, DEFAULT_SQUARES_X)
+            self._calibration_squares_y = _make_int_spin(2, 99, DEFAULT_SQUARES_Y)
+            self._calibration_square_length = _make_float_spin(
+                0.1,
+                1000.0,
+                DEFAULT_SQUARE_LENGTH_MM,
+                " mm",
+            )
+            self._calibration_marker_length = _make_float_spin(
+                0.1,
+                1000.0,
+                DEFAULT_MARKER_LENGTH_MM,
+                " mm",
+            )
+            self._calibration_dictionary = QtWidgets.QComboBox()
+            self._calibration_dictionary.addItems(list(_safe_dictionary_choices()))
+            self._calibration_dictionary.setCurrentText(DEFAULT_DICTIONARY)
+            self._calibration_dictionary.setMinimumWidth(180)
+
+            for field in (
+                self._calibration_camera_index,
+                self._calibration_squares_x,
+                self._calibration_squares_y,
+                self._calibration_square_length,
+                self._calibration_marker_length,
+            ):
+                field.valueChanged.connect(self._update_calibration_flow)
+            self._calibration_dictionary.currentTextChanged.connect(
+                self._update_calibration_flow
+            )
+
+            self._calibration_camera_field = _make_field(
+                "Camera index",
+                self._calibration_camera_index,
+            )
+            self._calibration_video_field = _make_field(
+                "Video path",
+                calibration_video_widget,
+            )
+
+            calibration_grid = QtWidgets.QGridLayout()
+            calibration_grid.setContentsMargins(0, 0, 0, 0)
+            calibration_grid.setHorizontalSpacing(14)
+            calibration_grid.setVerticalSpacing(10)
+            calibration_grid.addWidget(
+                _make_field("Source", self._calibration_source),
+                0,
+                0,
+            )
+            calibration_grid.addWidget(self._calibration_camera_field, 0, 1)
+            calibration_grid.addWidget(self._calibration_video_field, 1, 0, 1, 2)
+            calibration_grid.addWidget(
+                _make_field("Squares X", self._calibration_squares_x),
+                2,
+                0,
+            )
+            calibration_grid.addWidget(
+                _make_field("Squares Y", self._calibration_squares_y),
+                2,
+                1,
+            )
+            calibration_grid.addWidget(
+                _make_field("Square length", self._calibration_square_length),
+                3,
+                0,
+            )
+            calibration_grid.addWidget(
+                _make_field("Marker length", self._calibration_marker_length),
+                3,
+                1,
+            )
+            calibration_grid.addWidget(
+                _make_field("Dictionary", self._calibration_dictionary),
+                4,
+                0,
+                1,
+                2,
+            )
+            calibration_grid.setColumnStretch(0, 1)
+            calibration_grid.setColumnStretch(1, 1)
+
+            self._calibration_metadata = QtWidgets.QLabel(
+                "No ChArUco metadata inspected yet."
+            )
+            self._calibration_metadata.setObjectName("OutputText")
+            self._calibration_metadata.setWordWrap(True)
+            self._calibration_metadata.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            self._calibration_expected_output = QtWidgets.QLabel()
+            self._calibration_expected_output.setObjectName("OutputText")
+            self._calibration_expected_output.setWordWrap(True)
+            self._calibration_expected_output.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            self._calibration_readiness = QtWidgets.QLabel()
+            self._calibration_readiness.setObjectName("OutputText")
+            self._calibration_readiness.setWordWrap(True)
+            self._calibration_readiness.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+
+            self._calibration_command_preview = QtWidgets.QLineEdit()
+            self._calibration_command_preview.setObjectName("CommandPreview")
+            self._calibration_command_preview.setReadOnly(True)
+            self._calibration_command_preview.setPlaceholderText(
+                "Resolve readiness messages before copying a calibration command."
+            )
+            self._calibration_copy_button = QtWidgets.QPushButton("Copy Command")
+            self._calibration_copy_button.clicked.connect(
+                self._copy_calibration_command
+            )
+            self._calibration_copy_feedback = QtWidgets.QLabel()
+            self._calibration_copy_feedback.setObjectName("MutedText")
+            self._calibration_copy_feedback.setWordWrap(True)
+            calibration_command_row = QtWidgets.QHBoxLayout()
+            calibration_command_row.setContentsMargins(0, 0, 0, 0)
+            calibration_command_row.addWidget(self._calibration_command_preview, 1)
+            calibration_command_row.addWidget(self._calibration_copy_button)
+            calibration_command_widget = QtWidgets.QWidget()
+            calibration_command_widget.setLayout(calibration_command_row)
+
+            calibration_controls = QtWidgets.QLabel(
+                "Controls: SPACE adds a sample; ENTER solves calibration; "
+                "q quits without writing calibration output."
+            )
+            calibration_controls.setObjectName("GuidanceText")
+            calibration_controls.setWordWrap(True)
+
+            calibration_refresh_button = QtWidgets.QPushButton("Refresh Status")
+            calibration_refresh_button.setObjectName("SecondaryActionButton")
+            calibration_refresh_button.clicked.connect(self._refresh)
+            calibration_action_row = QtWidgets.QHBoxLayout()
+            calibration_action_row.addWidget(calibration_refresh_button)
+            calibration_action_row.addStretch(1)
+
+            calibration_status_grid = QtWidgets.QGridLayout()
+            calibration_status_grid.setContentsMargins(0, 0, 0, 0)
+            calibration_status_grid.setHorizontalSpacing(12)
+            calibration_status_grid.setVerticalSpacing(8)
+            calibration_status_grid.addWidget(
+                _make_field("Metadata", self._calibration_metadata),
+                0,
+                0,
+            )
+            calibration_status_grid.addWidget(
+                _make_field("Expected output", self._calibration_expected_output),
+                0,
+                1,
+            )
+            calibration_status_grid.addWidget(
+                _make_field("Readiness", self._calibration_readiness),
+                1,
+                0,
+                1,
+                2,
+            )
+            calibration_status_grid.addWidget(
+                _make_field("Command preview", calibration_command_widget),
+                2,
+                0,
+                1,
+                2,
+            )
+            calibration_status_grid.setColumnStretch(0, 1)
+            calibration_status_grid.setColumnStretch(1, 1)
+
+            calibration_layout.addWidget(calibration_title)
+            calibration_layout.addWidget(calibration_note)
+            calibration_layout.addLayout(calibration_grid)
+            calibration_layout.addWidget(calibration_controls)
+            calibration_layout.addLayout(calibration_status_grid)
+            calibration_layout.addWidget(self._calibration_copy_feedback)
+            calibration_layout.addLayout(calibration_action_row)
+
             detail_content = QtWidgets.QWidget()
             detail_content_layout = QtWidgets.QVBoxLayout(detail_content)
             detail_content_layout.setContentsMargins(0, 0, 0, 0)
@@ -567,6 +804,7 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             detail_content_layout.addWidget(self._message_label)
             detail_content_layout.addLayout(cards_grid)
             detail_content_layout.addWidget(self._charuco_card)
+            detail_content_layout.addWidget(self._calibration_card)
             detail_content_layout.addWidget(command_card)
             detail_content_layout.addStretch(1)
 
@@ -656,8 +894,8 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self.setCentralWidget(central)
             self.setStyleSheet(_style_sheet())
             self.statusBar().showMessage(
-                "Dashboard can generate ChArUco board files; "
-                "camera workflows are not executed."
+                "Dashboard can generate ChArUco board files and prepare "
+                "camera-calibration commands."
             )
 
             self._refresh()
@@ -700,6 +938,22 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             )
             if selected:
                 self._charuco_out_dir.setText(selected)
+
+        def _browse_calibration_video(self) -> None:
+            current = self._calibration_video_path.text().strip()
+            start_path = current or str(self._current_project_root())
+            selected, _ = QtWidgets.QFileDialog.getOpenFileName(
+                self,
+                "Select calibration video",
+                start_path,
+                "Video files (*.mp4 *.mov *.avi *.mkv);;All files (*)",
+            )
+            if selected:
+                self._calibration_video_path.setText(selected)
+
+        def _calibration_source_changed(self) -> None:
+            self._render_calibration_source_fields()
+            self._update_calibration_flow()
 
         def _generate_charuco_board(self) -> None:
             self._charuco_generate_button.setEnabled(False)
@@ -867,6 +1121,10 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                 )
             )
             self._charuco_card.setVisible(model.stage_id == 1)
+            self._calibration_card.setVisible(model.stage_id == 2)
+            if model.stage_id == 2:
+                self._sync_calibration_from_project_metadata()
+                self._update_calibration_flow()
             self._render_stage_rail_selection()
 
         def _render_health(self) -> None:
@@ -919,6 +1177,7 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._copy_button.setEnabled(False)
             self._copy_feedback.setText(_command_ready_message(""))
             self._charuco_card.setVisible(False)
+            self._calibration_card.setVisible(False)
             self._render_health()
 
         def _render_stage_rail_selection(self) -> None:
@@ -950,6 +1209,152 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._project_title.setText(f"Project: {title}")
             self._root_status_label.setText(_project_root_hint(root))
             self._open_folder_button.setEnabled(root.is_dir())
+
+        def _sync_calibration_from_project_metadata(self) -> None:
+            metadata_state = inspect_charuco_metadata(self._current_project_root())
+            selected = metadata_state.selected_path
+            mtime = _path_mtime_ns(selected)
+            if (
+                selected == self._loaded_calibration_metadata_path
+                and mtime == self._loaded_calibration_metadata_mtime
+            ):
+                return
+
+            if metadata_state.metadata is None:
+                self._loaded_calibration_metadata_path = selected
+                self._loaded_calibration_metadata_mtime = mtime
+                return
+
+            config = camera_calibration_config_from_project(
+                self._current_project_root(),
+                source=self._calibration_source_value(),
+                camera_index=int(self._calibration_camera_index.value()),
+                video_path=self._calibration_video_path.text().strip() or None,
+            )
+            self._apply_calibration_config(config)
+            self._loaded_calibration_metadata_path = selected
+            self._loaded_calibration_metadata_mtime = mtime
+
+        def _apply_calibration_config(
+            self,
+            config: CameraCalibrationConfig,
+        ) -> None:
+            fields = (
+                self._calibration_squares_x,
+                self._calibration_squares_y,
+                self._calibration_square_length,
+                self._calibration_marker_length,
+                self._calibration_dictionary,
+            )
+            for field in fields:
+                field.blockSignals(True)
+            try:
+                self._calibration_squares_x.setValue(int(config.squares_x))
+                self._calibration_squares_y.setValue(int(config.squares_y))
+                self._calibration_square_length.setValue(
+                    float(config.square_length_mm)
+                )
+                self._calibration_marker_length.setValue(
+                    float(config.marker_length_mm)
+                )
+                dictionary_name = str(config.dictionary_name)
+                if self._calibration_dictionary.findText(dictionary_name) < 0:
+                    self._calibration_dictionary.addItem(dictionary_name)
+                self._calibration_dictionary.setCurrentText(dictionary_name)
+            finally:
+                for field in fields:
+                    field.blockSignals(False)
+
+        def _update_calibration_flow(self) -> None:
+            if not hasattr(self, "_calibration_readiness"):
+                return
+            self._render_calibration_source_fields()
+            readiness = inspect_camera_calibration_readiness(
+                self._calibration_config()
+            )
+            self._calibration_metadata.setText(
+                _format_calibration_metadata(readiness)
+            )
+            self._calibration_expected_output.setText(
+                _format_calibration_expected_output(readiness)
+            )
+            self._calibration_readiness.setText(
+                _format_calibration_readiness(readiness)
+            )
+
+            model = self._model_by_stage_id(self._selected_stage_id)
+            stage_complete = bool(model and model.stage_id == 2 and model.status == "complete")
+            self._calibration_command_preview.setText(readiness.command_preview)
+            self._calibration_command_preview.setCursorPosition(0)
+            self._calibration_copy_button.setEnabled(bool(readiness.command_preview))
+            self._calibration_copy_feedback.setText(
+                _calibration_command_ready_message(
+                    readiness,
+                    stage_complete=stage_complete,
+                )
+            )
+
+            if model is None or model.stage_id != 2:
+                return
+
+            self._command_preview.setText(readiness.command_preview)
+            self._command_preview.setCursorPosition(0)
+            self._copy_button.setEnabled(bool(readiness.command_preview))
+            self._command_note.setText(
+                _calibration_command_card_note(readiness, model)
+            )
+            self._copy_feedback.setText(
+                _calibration_command_ready_message(
+                    readiness,
+                    stage_complete=model.status == "complete",
+                )
+            )
+
+        def _copy_calibration_command(self) -> None:
+            command = self._calibration_command_preview.text()
+            if command:
+                QtWidgets.QApplication.clipboard().setText(command)
+            model = self._model_by_stage_id(self._selected_stage_id)
+            message = _copy_confirmation_message(
+                command,
+                stage_complete=bool(
+                    model and model.stage_id == 2 and model.status == "complete"
+                ),
+            )
+            self._calibration_copy_feedback.setText(message)
+            self.statusBar().showMessage(message, 3000)
+
+        def _render_calibration_source_fields(self) -> None:
+            source = self._calibration_source_value()
+            is_webcam = source == SOURCE_OPENCV
+            is_video = source == SOURCE_VIDEO
+            self._calibration_camera_field.setVisible(is_webcam)
+            self._calibration_video_field.setVisible(is_video)
+            self._calibration_video_path.setEnabled(is_video)
+            self._calibration_video_browse_button.setEnabled(is_video)
+
+        def _calibration_config(self) -> CameraCalibrationConfig:
+            return CameraCalibrationConfig(
+                project_root=self._current_project_root(),
+                source=self._calibration_source_value(),
+                camera_index=int(self._calibration_camera_index.value()),
+                video_path=self._calibration_video_path.text().strip() or None,
+                squares_x=int(self._calibration_squares_x.value()),
+                squares_y=int(self._calibration_squares_y.value()),
+                square_length_mm=float(self._calibration_square_length.value()),
+                marker_length_mm=float(self._calibration_marker_length.value()),
+                dictionary_name=self._calibration_dictionary.currentText(),
+            )
+
+        def _calibration_source_value(self) -> str:
+            data = self._calibration_source.currentData()
+            raw = str(
+                data if data is not None else self._calibration_source.currentText()
+            )
+            try:
+                return normalize_source(raw)
+            except Exception:
+                return SOURCE_OPENCV
 
         def _model_by_stage_id(self, stage_id: int) -> Optional[StageViewModel]:
             for model in self._models:
@@ -1102,6 +1507,45 @@ def _format_charuco_outputs(result: Any) -> str:
     return "\n".join(lines)
 
 
+def _format_calibration_metadata(readiness: CameraCalibrationReadiness) -> str:
+    metadata = readiness.metadata
+    if metadata is None:
+        if readiness.metadata_path is None:
+            return "Missing: <project_root>/calib/boards/charuco_*.yaml"
+        return (
+            f"Found: {_display_path(readiness.metadata_path)}\n"
+            "Could not autofill board parameters from this metadata."
+        )
+
+    return "\n".join(
+        [
+            f"Using: {_display_path(metadata.path)}",
+            f"Board: {metadata.squares_x} x {metadata.squares_y}",
+            f"Square: {metadata.square_length_mm:g} mm",
+            f"Marker: {metadata.marker_length_mm:g} mm",
+            f"Dictionary: {metadata.dictionary_name}",
+        ]
+    )
+
+
+def _format_calibration_expected_output(
+    readiness: CameraCalibrationReadiness,
+) -> str:
+    state = "present" if readiness.output_exists else "missing"
+    return f"{_display_path(readiness.expected_output)}\nStatus: {state}"
+
+
+def _format_calibration_readiness(
+    readiness: CameraCalibrationReadiness,
+) -> str:
+    lines = ["Ready to run." if readiness.ready else "Not ready yet."]
+    if readiness.errors:
+        lines.extend(["", "Errors", *_format_items(readiness.errors)])
+    if readiness.warnings:
+        lines.extend(["", "Warnings", *_format_items(readiness.warnings)])
+    return "\n".join(lines)
+
+
 def _display_path(path: Path) -> str:
     home = Path.home()
     try:
@@ -1195,11 +1639,43 @@ def _copy_confirmation_message(command: str, *, stage_complete: bool = False) ->
     return "No command preview is available for this stage."
 
 
+def _calibration_command_card_note(
+    readiness: CameraCalibrationReadiness,
+    model: StageViewModel,
+) -> str:
+    if not readiness.command_preview:
+        return (
+            "Resolve the calibration readiness messages above before copying a "
+            "posetag-calib-charuco command."
+        )
+    if model.status == "complete":
+        return (
+            "Calibration output already exists. Copy this command only if you "
+            "need to rerun the existing posetag-calib-charuco workflow."
+        )
+    return (
+        "Copy the preview into a terminal. The command opens the existing "
+        "calibration window; SPACE adds samples, ENTER solves, and q quits."
+    )
+
+
+def _calibration_command_ready_message(
+    readiness: CameraCalibrationReadiness,
+    *,
+    stage_complete: bool = False,
+) -> str:
+    if not readiness.command_preview:
+        return "No runnable calibration command is available yet."
+    if stage_complete:
+        return "Calibration output exists. Copy only if you need to rerun it."
+    return "Ready to copy a calibration command."
+
+
 def _project_root_hint(root: Path) -> str:
     if root.is_dir():
         return (
             "Project folder found. Status checks are read-only except Stage 1 "
-            "board generation."
+            "board generation and Stage 2 command preparation."
         )
     if root.exists():
         return "Selected path exists but is not a folder."
@@ -1207,6 +1683,15 @@ def _project_root_hint(root: Path) -> str:
         "Project folder not found. Status checks are read-only; Stage 1 board "
         "generation can create the selected project layout."
     )
+
+
+def _path_mtime_ns(path: Optional[Path]) -> Optional[int]:
+    if path is None:
+        return None
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return None
 
 
 def _pill_style(foreground: str, background: str, border: str) -> str:

--- a/src/posetag/workflows/calibration_flow.py
+++ b/src/posetag/workflows/calibration_flow.py
@@ -1,0 +1,468 @@
+"""GUI-independent readiness helpers for guided camera calibration.
+
+The helpers in this module prepare users to run ``posetag-calib-charuco``
+without moving camera capture, ChArUco detection, calibration solving, or YAML
+writing into GUI code.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Union
+
+import yaml
+
+from posetag.pipelines.charuco_calibration import (
+    CharucoCalibrationError,
+    validate_capture_args,
+)
+from posetag.workflows.charuco_setup import (
+    DEFAULT_DICTIONARY,
+    DEFAULT_MARKER_LENGTH_MM,
+    DEFAULT_SQUARE_LENGTH_MM,
+    DEFAULT_SQUARES_X,
+    DEFAULT_SQUARES_Y,
+)
+
+
+SOURCE_OPENCV = "opencv"
+SOURCE_REALSENSE = "realsense"
+SOURCE_VIDEO = "video"
+CALIBRATION_SOURCE_CHOICES = (SOURCE_OPENCV, SOURCE_REALSENSE, SOURCE_VIDEO)
+CALIBRATION_SOURCE_LABELS = {
+    SOURCE_OPENCV: "webcam/OpenCV",
+    SOURCE_REALSENSE: "RealSense",
+    SOURCE_VIDEO: "video",
+}
+DEFAULT_CAMERA_INDEX = 0
+
+
+class CameraCalibrationFlowError(ValueError):
+    """User-facing calibration guidance error."""
+
+
+@dataclass(frozen=True)
+class CharucoCalibrationMetadata:
+    """Board parameters read from a generated ChArUco metadata YAML."""
+
+    path: Path
+    squares_x: int
+    squares_y: int
+    square_length_mm: float
+    marker_length_mm: float
+    dictionary_name: str
+
+
+@dataclass(frozen=True)
+class CharucoMetadataInspection:
+    """Readiness state for generated ChArUco board metadata."""
+
+    metadata_paths: tuple[Path, ...]
+    selected_path: Optional[Path]
+    metadata: Optional[CharucoCalibrationMetadata]
+    warnings: tuple[str, ...] = ()
+    errors: tuple[str, ...] = ()
+
+    @property
+    def exists(self) -> bool:
+        """Return true when at least one metadata file was found."""
+
+        return bool(self.metadata_paths)
+
+
+@dataclass(frozen=True)
+class CameraCalibrationConfig:
+    """User-facing camera calibration command state."""
+
+    project_root: Union[Path, str]
+    source: str = SOURCE_OPENCV
+    camera_index: int = DEFAULT_CAMERA_INDEX
+    video_path: Optional[Union[Path, str]] = None
+    squares_x: int = DEFAULT_SQUARES_X
+    squares_y: int = DEFAULT_SQUARES_Y
+    square_length_mm: float = DEFAULT_SQUARE_LENGTH_MM
+    marker_length_mm: float = DEFAULT_MARKER_LENGTH_MM
+    dictionary_name: str = DEFAULT_DICTIONARY
+
+
+@dataclass(frozen=True)
+class CameraCalibrationReadiness:
+    """Display-ready readiness result for the guided calibration flow."""
+
+    ready: bool
+    command_preview: str
+    expected_output: Path
+    output_exists: bool
+    metadata_path: Optional[Path]
+    metadata: Optional[CharucoCalibrationMetadata]
+    checked_paths: tuple[Path, ...]
+    warnings: tuple[str, ...]
+    errors: tuple[str, ...]
+
+
+def generated_charuco_metadata_paths(project_root: Union[Path, str]) -> tuple[Path, ...]:
+    """Return generated ChArUco metadata paths without creating directories."""
+
+    boards_dir = Path(project_root).expanduser() / "calib" / "boards"
+    return tuple(
+        sorted(path for path in boards_dir.glob("charuco_*.yaml") if path.is_file())
+    )
+
+
+def inspect_charuco_metadata(
+    project_root: Union[Path, str],
+) -> CharucoMetadataInspection:
+    """Inspect generated ChArUco board metadata under a project root."""
+
+    root = Path(project_root).expanduser()
+    paths = generated_charuco_metadata_paths(root)
+    if not paths:
+        return CharucoMetadataInspection(
+            metadata_paths=(),
+            selected_path=None,
+            metadata=None,
+        )
+
+    selected = _latest_path(paths)
+    try:
+        metadata = load_charuco_metadata(selected)
+    except CameraCalibrationFlowError as exc:
+        return CharucoMetadataInspection(
+            metadata_paths=paths,
+            selected_path=selected,
+            metadata=None,
+            errors=(str(exc),),
+        )
+
+    warnings: tuple[str, ...] = ()
+    if len(paths) > 1:
+        warnings = (
+            f"Found {len(paths)} ChArUco metadata files; using {selected.name}.",
+        )
+
+    return CharucoMetadataInspection(
+        metadata_paths=paths,
+        selected_path=selected,
+        metadata=metadata,
+        warnings=warnings,
+    )
+
+
+def load_charuco_metadata(path: Union[Path, str]) -> CharucoCalibrationMetadata:
+    """Load and validate the board fields needed by calibration."""
+
+    metadata_path = Path(path).expanduser()
+    try:
+        with metadata_path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise CameraCalibrationFlowError(
+            f"Malformed ChArUco metadata YAML: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise CameraCalibrationFlowError(
+            f"Could not read ChArUco metadata: {exc}"
+        ) from exc
+
+    if not isinstance(data, Mapping):
+        raise CameraCalibrationFlowError(
+            "ChArUco metadata YAML must contain a mapping."
+        )
+
+    errors: list[str] = []
+    squares_x = _require_int(data, "squares_x", errors)
+    squares_y = _require_int(data, "squares_y", errors)
+    square_length_mm = _require_float(data, "square_length_mm", errors)
+    marker_length_mm = _require_float(data, "marker_length_mm", errors)
+    dictionary_name = _require_string(data, "dictionary", errors)
+
+    if squares_x is not None and squares_x < 2:
+        errors.append("ChArUco metadata field 'squares_x' must be at least 2.")
+    if squares_y is not None and squares_y < 2:
+        errors.append("ChArUco metadata field 'squares_y' must be at least 2.")
+    if square_length_mm is not None and square_length_mm <= 0:
+        errors.append(
+            "ChArUco metadata field 'square_length_mm' must be positive."
+        )
+    if marker_length_mm is not None and marker_length_mm <= 0:
+        errors.append(
+            "ChArUco metadata field 'marker_length_mm' must be positive."
+        )
+    if (
+        square_length_mm is not None
+        and marker_length_mm is not None
+        and marker_length_mm >= square_length_mm
+    ):
+        errors.append(
+            "ChArUco metadata marker length must be smaller than square length."
+        )
+
+    if errors:
+        raise CameraCalibrationFlowError(" ".join(errors))
+
+    assert squares_x is not None
+    assert squares_y is not None
+    assert square_length_mm is not None
+    assert marker_length_mm is not None
+    assert dictionary_name is not None
+    return CharucoCalibrationMetadata(
+        path=metadata_path,
+        squares_x=squares_x,
+        squares_y=squares_y,
+        square_length_mm=square_length_mm,
+        marker_length_mm=marker_length_mm,
+        dictionary_name=dictionary_name,
+    )
+
+
+def camera_calibration_config_from_project(
+    project_root: Union[Path, str],
+    *,
+    source: str = SOURCE_OPENCV,
+    camera_index: int = DEFAULT_CAMERA_INDEX,
+    video_path: Optional[Union[Path, str]] = None,
+) -> CameraCalibrationConfig:
+    """Build a calibration config, autofilling board fields from metadata."""
+
+    metadata = inspect_charuco_metadata(project_root).metadata
+    if metadata is None:
+        return CameraCalibrationConfig(
+            project_root=project_root,
+            source=source,
+            camera_index=camera_index,
+            video_path=video_path,
+        )
+    return CameraCalibrationConfig(
+        project_root=project_root,
+        source=source,
+        camera_index=camera_index,
+        video_path=video_path,
+        squares_x=metadata.squares_x,
+        squares_y=metadata.squares_y,
+        square_length_mm=metadata.square_length_mm,
+        marker_length_mm=metadata.marker_length_mm,
+        dictionary_name=metadata.dictionary_name,
+    )
+
+
+def inspect_camera_calibration_readiness(
+    config: CameraCalibrationConfig,
+    *,
+    realsense_available: Optional[bool] = None,
+) -> CameraCalibrationReadiness:
+    """Return command and readiness state for guided camera calibration."""
+
+    root = Path(config.project_root).expanduser()
+    metadata_state = inspect_charuco_metadata(root)
+    expected_output = root / "calib" / "calib_color.yaml"
+    checked_paths = _path_tuple(
+        [
+            root / "calib" / "boards",
+            *metadata_state.metadata_paths,
+            expected_output,
+        ]
+    )
+    warnings = list(metadata_state.warnings)
+    errors = list(metadata_state.errors)
+
+    if not metadata_state.metadata_paths:
+        errors.append(
+            "Missing ChArUco board metadata. Generate the board first so the "
+            "calibration parameters match the printed target."
+        )
+
+    if not expected_output.exists():
+        warnings.append(
+            f"Calibration output is missing: {expected_output}"
+        )
+
+    try:
+        source = normalize_source(config.source)
+    except CameraCalibrationFlowError as exc:
+        errors.append(str(exc))
+        source = SOURCE_OPENCV
+    try:
+        validate_capture_args(
+            source,
+            _video_arg(config.video_path),
+            _realsense_module_token(realsense_available),
+        )
+    except CharucoCalibrationError as exc:
+        errors.append(str(exc))
+
+    command_preview = ""
+    if not errors:
+        try:
+            command_preview = build_camera_calibration_command(config)
+        except CameraCalibrationFlowError as exc:
+            errors.append(str(exc))
+
+    return CameraCalibrationReadiness(
+        ready=not errors,
+        command_preview=command_preview,
+        expected_output=expected_output,
+        output_exists=expected_output.exists(),
+        metadata_path=metadata_state.selected_path,
+        metadata=metadata_state.metadata,
+        checked_paths=checked_paths,
+        warnings=tuple(warnings),
+        errors=tuple(errors),
+    )
+
+
+def build_camera_calibration_command(config: CameraCalibrationConfig) -> str:
+    """Build a copyable ``posetag-calib-charuco`` command from GUI state."""
+
+    source = normalize_source(config.source)
+    video = _video_arg(config.video_path)
+    if source == SOURCE_VIDEO and video is None:
+        raise CameraCalibrationFlowError(
+            "--video path is required when --source=video"
+        )
+
+    parts: list[str] = [
+        "posetag-calib-charuco",
+        "--project_root",
+        str(Path(config.project_root).expanduser()),
+        "--source",
+        source,
+    ]
+    if source == SOURCE_OPENCV:
+        parts.extend(["--cam", str(int(config.camera_index))])
+    elif source == SOURCE_VIDEO:
+        assert video is not None
+        parts.extend(["--video", video])
+
+    parts.extend(
+        [
+            "--squares-x",
+            str(int(config.squares_x)),
+            "--squares-y",
+            str(int(config.squares_y)),
+            "--square-length-mm",
+            _format_number(config.square_length_mm),
+            "--marker-length-mm",
+            _format_number(config.marker_length_mm),
+            "--dict",
+            str(config.dictionary_name).strip(),
+        ]
+    )
+    return shlex.join(parts)
+
+
+def normalize_source(source: str) -> str:
+    """Normalize a user-facing calibration source value."""
+
+    normalized = str(source).strip().lower()
+    aliases = {
+        "webcam": SOURCE_OPENCV,
+        "webcam/opencv": SOURCE_OPENCV,
+        "opencv webcam": SOURCE_OPENCV,
+        "opencv": SOURCE_OPENCV,
+        "realsense": SOURCE_REALSENSE,
+        "intel realsense": SOURCE_REALSENSE,
+        "video": SOURCE_VIDEO,
+        "video file": SOURCE_VIDEO,
+    }
+    try:
+        return aliases[normalized]
+    except KeyError as exc:
+        raise CameraCalibrationFlowError(
+            "Calibration source must be one of: "
+            + ", ".join(CALIBRATION_SOURCE_CHOICES)
+            + "."
+        ) from exc
+
+
+def realsense_dependency_available() -> bool:
+    """Return whether ``pyrealsense2`` is importable in the current environment."""
+
+    return importlib.util.find_spec("pyrealsense2") is not None
+
+
+def _latest_path(paths: tuple[Path, ...]) -> Path:
+    return max(paths, key=lambda path: (path.stat().st_mtime_ns, path.name))
+
+
+def _path_tuple(paths: Iterable[Path]) -> tuple[Path, ...]:
+    return tuple(dict.fromkeys(paths))
+
+
+def _realsense_module_token(realsense_available: Optional[bool]) -> Any:
+    available = (
+        realsense_dependency_available()
+        if realsense_available is None
+        else bool(realsense_available)
+    )
+    return object() if available else None
+
+
+def _video_arg(video_path: Optional[Union[Path, str]]) -> Optional[str]:
+    if video_path is None:
+        return None
+    text = str(video_path).strip()
+    if not text:
+        return None
+    return str(Path(text).expanduser())
+
+
+def _require_int(
+    data: Mapping[str, Any],
+    field: str,
+    errors: list[str],
+) -> Optional[int]:
+    value = data.get(field)
+    if isinstance(value, bool):
+        errors.append(f"ChArUco metadata field {field!r} must be an integer.")
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        errors.append(f"ChArUco metadata field {field!r} must be an integer.")
+        return None
+    if isinstance(value, float) and not value.is_integer():
+        errors.append(f"ChArUco metadata field {field!r} must be an integer.")
+        return None
+    return parsed
+
+
+def _require_float(
+    data: Mapping[str, Any],
+    field: str,
+    errors: list[str],
+) -> Optional[float]:
+    value = data.get(field)
+    if isinstance(value, bool):
+        errors.append(f"ChArUco metadata field {field!r} must be numeric.")
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        errors.append(f"ChArUco metadata field {field!r} must be numeric.")
+        return None
+    if not math.isfinite(parsed):
+        errors.append(f"ChArUco metadata field {field!r} must be finite.")
+        return None
+    return parsed
+
+
+def _require_string(
+    data: Mapping[str, Any],
+    field: str,
+    errors: list[str],
+) -> Optional[str]:
+    value = data.get(field)
+    if not isinstance(value, str) or not value.strip():
+        errors.append(
+            f"ChArUco metadata field {field!r} must be a non-empty string."
+        )
+        return None
+    return value.strip()
+
+
+def _format_number(value: float) -> str:
+    return f"{float(value):g}"

--- a/src/posetag/workflows/calibration_flow.py
+++ b/src/posetag/workflows/calibration_flow.py
@@ -18,6 +18,7 @@ import yaml
 
 from posetag.pipelines.charuco_calibration import (
     CharucoCalibrationError,
+    get_dictionary,
     validate_capture_args,
 )
 from posetag.workflows.charuco_setup import (
@@ -293,6 +294,7 @@ def inspect_camera_calibration_readiness(
         )
     except CharucoCalibrationError as exc:
         errors.append(str(exc))
+    errors.extend(_camera_calibration_board_errors(config))
 
     command_preview = ""
     if not errors:
@@ -323,6 +325,7 @@ def build_camera_calibration_command(config: CameraCalibrationConfig) -> str:
         raise CameraCalibrationFlowError(
             "--video path is required when --source=video"
         )
+    _validate_camera_calibration_board(config)
 
     parts: list[str] = [
         "posetag-calib-charuco",
@@ -408,6 +411,85 @@ def _video_arg(video_path: Optional[Union[Path, str]]) -> Optional[str]:
     if not text:
         return None
     return str(Path(text).expanduser())
+
+
+def _validate_camera_calibration_board(config: CameraCalibrationConfig) -> None:
+    errors = _camera_calibration_board_errors(config)
+    if errors:
+        raise CameraCalibrationFlowError(" ".join(errors))
+
+
+def _camera_calibration_board_errors(
+    config: CameraCalibrationConfig,
+) -> list[str]:
+    errors: list[str] = []
+    squares_x = _coerce_int(config.squares_x, "--squares-x", errors)
+    squares_y = _coerce_int(config.squares_y, "--squares-y", errors)
+    square_length_mm = _coerce_float(
+        config.square_length_mm,
+        "--square-length-mm",
+        errors,
+    )
+    marker_length_mm = _coerce_float(
+        config.marker_length_mm,
+        "--marker-length-mm",
+        errors,
+    )
+    dictionary_name = str(config.dictionary_name).strip()
+
+    if squares_x is not None and squares_x < 2:
+        errors.append("--squares-x must be at least 2.")
+    if squares_y is not None and squares_y < 2:
+        errors.append("--squares-y must be at least 2.")
+    if square_length_mm is not None and square_length_mm <= 0:
+        errors.append("--square-length-mm must be a positive millimetre value.")
+    if marker_length_mm is not None and marker_length_mm <= 0:
+        errors.append("--marker-length-mm must be a positive millimetre value.")
+    if (
+        square_length_mm is not None
+        and marker_length_mm is not None
+        and marker_length_mm >= square_length_mm
+    ):
+        errors.append("--marker-length-mm must be smaller than --square-length-mm.")
+    if not dictionary_name:
+        errors.append("--dict must be a non-empty ArUco dictionary name.")
+    else:
+        try:
+            get_dictionary(dictionary_name)
+        except CharucoCalibrationError as exc:
+            errors.append(str(exc))
+
+    return errors
+
+
+def _coerce_int(value: Any, label: str, errors: list[str]) -> Optional[int]:
+    if isinstance(value, bool):
+        errors.append(f"{label} must be an integer.")
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        errors.append(f"{label} must be an integer.")
+        return None
+    if isinstance(value, float) and not value.is_integer():
+        errors.append(f"{label} must be an integer.")
+        return None
+    return parsed
+
+
+def _coerce_float(value: Any, label: str, errors: list[str]) -> Optional[float]:
+    if isinstance(value, bool):
+        errors.append(f"{label} must be numeric.")
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        errors.append(f"{label} must be numeric.")
+        return None
+    if not math.isfinite(parsed):
+        errors.append(f"{label} must be finite.")
+        return None
+    return parsed
 
 
 def _require_int(

--- a/tests/test_workflow_calibration_flow.py
+++ b/tests/test_workflow_calibration_flow.py
@@ -103,6 +103,25 @@ class WorkflowCalibrationFlowTests(unittest.TestCase):
         self.assertNotIn("--cam", command)
         self.assertNotIn("--video", command)
 
+    def test_command_construction_rejects_invalid_board_lengths(self) -> None:
+        with self.assertRaisesRegex(ValueError, "marker-length-mm"):
+            build_camera_calibration_command(
+                CameraCalibrationConfig(
+                    project_root="project",
+                    square_length_mm=10.0,
+                    marker_length_mm=20.0,
+                )
+            )
+
+    def test_command_construction_rejects_unsupported_dictionary(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unsupported ArUco dictionary"):
+            build_camera_calibration_command(
+                CameraCalibrationConfig(
+                    project_root="project",
+                    dictionary_name="NOT_A_DICT",
+                )
+            )
+
     def test_readiness_reports_missing_metadata_before_command(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
@@ -134,6 +153,45 @@ class WorkflowCalibrationFlowTests(unittest.TestCase):
         self.assertIn("--squares-x 3 --squares-y 5", result.command_preview)
         self.assertFalse(result.output_exists)
         self.assertIn(result.expected_output, result.checked_paths)
+
+    def test_readiness_rejects_edited_invalid_board_lengths(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_metadata(project_root)
+
+            result = inspect_camera_calibration_readiness(
+                CameraCalibrationConfig(
+                    project_root=project_root,
+                    square_length_mm=10.0,
+                    marker_length_mm=20.0,
+                ),
+                realsense_available=True,
+            )
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.command_preview, "")
+        self.assertTrue(
+            any("marker-length-mm" in error for error in result.errors)
+        )
+
+    def test_readiness_rejects_edited_unsupported_dictionary(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_metadata(project_root)
+
+            result = inspect_camera_calibration_readiness(
+                CameraCalibrationConfig(
+                    project_root=project_root,
+                    dictionary_name="NOT_A_DICT",
+                ),
+                realsense_available=True,
+            )
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.command_preview, "")
+        self.assertTrue(
+            any("Unsupported ArUco dictionary" in error for error in result.errors)
+        )
 
     def test_readiness_rejects_video_without_path(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_workflow_calibration_flow.py
+++ b/tests/test_workflow_calibration_flow.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import time
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import yaml
+
+from posetag.workflows.calibration_flow import (
+    SOURCE_OPENCV,
+    SOURCE_REALSENSE,
+    SOURCE_VIDEO,
+    CameraCalibrationConfig,
+    build_camera_calibration_command,
+    camera_calibration_config_from_project,
+    generated_charuco_metadata_paths,
+    inspect_camera_calibration_readiness,
+    inspect_charuco_metadata,
+    load_charuco_metadata,
+)
+
+
+class WorkflowCalibrationFlowTests(unittest.TestCase):
+    def test_metadata_autofills_calibration_config(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            metadata_path = _write_metadata(
+                project_root,
+                squares_x=4,
+                squares_y=6,
+                square_length_mm=25.5,
+                marker_length_mm=18.5,
+                dictionary="6X6_250",
+            )
+
+            metadata = load_charuco_metadata(metadata_path)
+            config = camera_calibration_config_from_project(project_root)
+
+        self.assertEqual(metadata.squares_x, 4)
+        self.assertEqual(metadata.squares_y, 6)
+        self.assertEqual(metadata.square_length_mm, 25.5)
+        self.assertEqual(metadata.marker_length_mm, 18.5)
+        self.assertEqual(metadata.dictionary_name, "6X6_250")
+        self.assertEqual(config.squares_x, 4)
+        self.assertEqual(config.squares_y, 6)
+        self.assertEqual(config.square_length_mm, 25.5)
+        self.assertEqual(config.marker_length_mm, 18.5)
+        self.assertEqual(config.dictionary_name, "6X6_250")
+
+    def test_command_construction_quotes_paths_and_uses_webcam_fields(self) -> None:
+        command = build_camera_calibration_command(
+            CameraCalibrationConfig(
+                project_root=Path("/tmp/PoseTag project"),
+                source=SOURCE_OPENCV,
+                camera_index=2,
+                squares_x=4,
+                squares_y=6,
+                square_length_mm=25.5,
+                marker_length_mm=18.5,
+                dictionary_name="6X6_250",
+            )
+        )
+
+        self.assertIn("posetag-calib-charuco", command)
+        self.assertIn("'/tmp/PoseTag project'", command)
+        self.assertIn("--source opencv --cam 2", command)
+        self.assertIn("--squares-x 4 --squares-y 6", command)
+        self.assertIn("--square-length-mm 25.5", command)
+        self.assertIn("--marker-length-mm 18.5", command)
+        self.assertIn("--dict 6X6_250", command)
+
+    def test_video_command_requires_video_path(self) -> None:
+        with self.assertRaisesRegex(ValueError, "--video path is required"):
+            build_camera_calibration_command(
+                CameraCalibrationConfig(
+                    project_root="project",
+                    source=SOURCE_VIDEO,
+                    video_path="",
+                )
+            )
+
+        command = build_camera_calibration_command(
+            CameraCalibrationConfig(
+                project_root="project",
+                source=SOURCE_VIDEO,
+                video_path="sample clips/calib.mp4",
+            )
+        )
+
+        self.assertIn("--source video --video 'sample clips/calib.mp4'", command)
+        self.assertNotIn("--cam", command)
+
+    def test_realsense_command_omits_webcam_and_video_fields(self) -> None:
+        command = build_camera_calibration_command(
+            CameraCalibrationConfig(
+                project_root="project",
+                source=SOURCE_REALSENSE,
+            )
+        )
+
+        self.assertIn("--source realsense", command)
+        self.assertNotIn("--cam", command)
+        self.assertNotIn("--video", command)
+
+    def test_readiness_reports_missing_metadata_before_command(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            result = inspect_camera_calibration_readiness(
+                CameraCalibrationConfig(project_root=project_root),
+                realsense_available=True,
+            )
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.command_preview, "")
+        self.assertTrue(
+            any("Missing ChArUco board metadata" in error for error in result.errors)
+        )
+        self.assertIn("Calibration output is missing", "\n".join(result.warnings))
+
+    def test_readiness_builds_command_when_metadata_exists(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            metadata_path = _write_metadata(project_root)
+
+            result = inspect_camera_calibration_readiness(
+                camera_calibration_config_from_project(project_root),
+                realsense_available=True,
+            )
+
+        self.assertTrue(result.ready)
+        self.assertEqual(result.metadata_path, metadata_path)
+        self.assertIn("posetag-calib-charuco", result.command_preview)
+        self.assertIn("--squares-x 3 --squares-y 5", result.command_preview)
+        self.assertFalse(result.output_exists)
+        self.assertIn(result.expected_output, result.checked_paths)
+
+    def test_readiness_rejects_video_without_path(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_metadata(project_root)
+
+            result = inspect_camera_calibration_readiness(
+                camera_calibration_config_from_project(
+                    project_root,
+                    source=SOURCE_VIDEO,
+                ),
+                realsense_available=True,
+            )
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.command_preview, "")
+        self.assertTrue(any("--video path is required" in e for e in result.errors))
+
+    def test_readiness_reports_unavailable_realsense_dependency(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_metadata(project_root)
+
+            result = inspect_camera_calibration_readiness(
+                camera_calibration_config_from_project(
+                    project_root,
+                    source=SOURCE_REALSENSE,
+                ),
+                realsense_available=False,
+            )
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.command_preview, "")
+        self.assertTrue(any("pyrealsense2 is not available" in e for e in result.errors))
+
+    def test_latest_metadata_is_selected_when_multiple_exist(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            first = _write_metadata(project_root, dictionary="5X5_50")
+            time.sleep(0.001)
+            second = _write_metadata(project_root, dictionary="7X7_100")
+
+            inspection = inspect_charuco_metadata(project_root)
+            paths = generated_charuco_metadata_paths(project_root)
+
+        self.assertEqual(paths, tuple(sorted([first, second])))
+        self.assertEqual(inspection.selected_path, second)
+        self.assertIsNotNone(inspection.metadata)
+        self.assertEqual(inspection.metadata.dictionary_name, "7X7_100")
+        self.assertTrue(inspection.warnings)
+
+    def test_malformed_metadata_blocks_readiness(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            metadata_path = (
+                project_root
+                / "calib"
+                / "boards"
+                / "charuco_3x5_square50mm_marker37mm_7X7_50_A4_300dpi.yaml"
+            )
+            metadata_path.parent.mkdir(parents=True)
+            metadata_path.write_text("squares_x: 3\n", encoding="utf-8")
+
+            result = inspect_camera_calibration_readiness(
+                CameraCalibrationConfig(project_root=project_root),
+                realsense_available=True,
+            )
+
+        self.assertFalse(result.ready)
+        self.assertTrue(any("squares_y" in error for error in result.errors))
+        self.assertEqual(result.command_preview, "")
+
+
+def _write_metadata(
+    project_root: Path,
+    *,
+    squares_x: int = 3,
+    squares_y: int = 5,
+    square_length_mm: float = 50.0,
+    marker_length_mm: float = 37.0,
+    dictionary: str = "7X7_50",
+) -> Path:
+    path = (
+        project_root
+        / "calib"
+        / "boards"
+        / (
+            f"charuco_{squares_x}x{squares_y}_square{square_length_mm:g}mm_"
+            f"marker{marker_length_mm:g}mm_{dictionary}_A4_300dpi.yaml"
+        )
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "squares_x": squares_x,
+                "squares_y": squares_y,
+                "square_length_mm": square_length_mm,
+                "marker_length_mm": marker_length_mm,
+                "dictionary": dictionary,
+                "paper": "A4",
+                "dpi": 300,
+                "png": path.with_suffix(".png").name,
+                "notes": "Print at 100% / Actual Size.",
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In readiness for safely wiring camera calibration into the PoseTag GUI, this PR adds the guided Stage 2 calibration readiness and command flow.

Closes #58.

Summary:
- Add GUI-independent camera-calibration readiness helpers for ChArUco metadata loading, board-parameter autofill, source validation, and posetag-calib-charuco command construction.
- Add the Stage 2 GUI calibration guide with source selection, webcam/video fields, metadata/output/readiness display, controls guidance, refresh, and copyable command preview.
- Update README and Step 1 workflow docs to describe the guided GUI calibration flow without changing the calibration engine.
- Add hardware-free tests for metadata autofill, command construction, and readiness/failure states.

Validation:
- python3 -m unittest discover -s tests -v
- python3 -m compileall -q src utils tests
- git diff --check

Residual risk:
- PySide6 is not installed in this local environment, so the Qt window was visually checked from the provided screenshot rather than launched locally. The GUI helper and workflow tests pass without hardware.