### PR TITLE
Add guided GUI calibration launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,11 +113,18 @@ capture, annotation, dataset collection, and review/export. In Stage 1 it can
 generate the ChArUco board PNG, PDF, and metadata YAML using the same package
 helper as `posetag-gen-charuco`. In Stage 2 it reads the generated ChArUco
 metadata, autofills the calibration board parameters, lets you choose webcam,
-RealSense, or video source settings, and prepares a copyable
-`posetag-calib-charuco` command with the expected
+RealSense, or video source settings, and can launch the existing
+`posetag-calib-charuco` workflow with a `Run Calibration` button when
+readiness checks pass. The panel keeps a copyable command fallback, streams
+process output into a compact log, and watches for the expected
 `<project_root>/calib/calib_color.yaml` output path. It can open selected
-folders in the system file manager, but it does not reimplement camera
-capture, calibration solving, board-building, annotation, or dataset workflows.
+folders in the system file manager. The calibration capture window also shows
+state-driven guidance based on detected ChArUco corners and accepted sample
+coverage, such as moving the board toward missing frame edges/corners or
+changing distance. Guided auto-capture saves good frames as the board covers
+the grid, while `SPACE` remains available as a manual override. The GUI does
+not reimplement camera capture, calibration solving, board-building,
+annotation, or dataset workflows.
 
 ## Scientific Contract
 
@@ -222,12 +229,27 @@ The optional `posetag-gui` dashboard provides the same ChArUco board setup from
 the Stage 1 ChArUco panel and refreshes project status after writing the files.
 The Stage 2 calibration panel then reads the generated metadata, autofills the
 matching board arguments, lets you choose webcam/OpenCV, RealSense, or video
-source settings, shows the `SPACE` / `ENTER` / `q` controls, and prepares a
-copyable `posetag-calib-charuco` command. Refresh the dashboard after
-`calib/calib_color.yaml` appears to update workflow status.
+source settings, shows the guided auto-capture / `SPACE` / `ENTER` / `q`
+controls, and can run the existing calibration command as a child process. The
+OpenCV calibration window still owns capture and solving: guided auto-capture
+saves good frames as the board covers missing grid cells, `SPACE` manually adds
+a sample, `ENTER` solves, and `q` quits. During capture, PoseTag overlays
+deterministic guidance derived from the current ChArUco observation and
+accepted sample coverage, rather than randomly rotating prompts. The Stage 2
+panel exposes coverage rows, coverage columns, and samples-per-cell controls,
+and passes those settings to the same command shown in the copy-command
+preview. It refreshes status after the process exits or after
+`calib/calib_color.yaml` appears, and it only marks the launch successful when
+that YAML passes the current status/schema checks. When the calibration YAML is
+present, the right panel shows a parsed calibration result summary with image
+size, RMS, intrinsics, distortion, output path, and latest run snapshot, while
+keeping raw YAML available through an explicit view/open action.
 
-Then calibrate with the same board parameters. Press `SPACE` to capture a
-sample and `ENTER` to solve. The calibration command outputs
+Then calibrate with the same board parameters. Move the board through the
+coverage grid; guided auto-capture saves useful samples and `SPACE` can still
+force a manual sample. Press `ENTER` to solve once the guidance says coverage
+looks good. The
+calibration command outputs
 `calib_color.yaml` containing `fx`, `fy`, `cx`, `cy`, distortion, image size,
 and reprojection RMS. With `--project_root`, the latest calibration defaults to
 `<root>/calib/calib_color.yaml`. Each run also stores raw calibration samples
@@ -845,7 +867,8 @@ are:
 - `posetag-capture-face` -> face-shot capture
 - `posetag-annotate` -> single, batch, and browse annotation flows
 - `posetag-collect` -> dataset capture
-- `posetag-gui` -> optional read-only workflow status dashboard
+- `posetag-gui` -> optional workflow dashboard for status, ChArUco board
+  setup, and guided calibration launch
 - `python3 -m gen_keypoints` -> canonical keypoint generation
 - `python3 -m view_keypoints` -> mesh/keypoint visualisation
 

--- a/docs/workflows/step1_calibrate_charuco.md
+++ b/docs/workflows/step1_calibrate_charuco.md
@@ -87,10 +87,42 @@ camera calibration. The Stage 2 panel autofills `--squares-x`, `--squares-y`,
 `--square-length-mm`, `--marker-length-mm`, and `--dict`, lets you choose
 webcam/OpenCV, RealSense, or video source settings, shows the expected
 `<project_root>/calib/calib_color.yaml` output, and prepares a copyable
-`posetag-calib-charuco` command. It also reports missing metadata, missing
-video path, unavailable RealSense dependency, and missing calibration output
-states. It does not start camera capture, detect ChArUco corners, solve
-calibration, or write calibration YAML itself.
+`posetag-calib-charuco` command. When readiness checks pass, the panel can also
+launch the existing calibration command with `Run Calibration` using the same
+Python environment as the GUI. The launch keeps a process state indicator,
+streams stdout/stderr into a compact log, and refreshes status when the process
+exits or when `calib/calib_color.yaml` appears. Success is based on the
+expected YAML passing the current status/schema checks, not only the child
+process exit code. It does not detect ChArUco corners, solve calibration, or
+write calibration YAML itself; those remain in the existing calibration
+workflow and OpenCV window.
+
+The OpenCV calibration window provides state-driven capture guidance while the
+workflow is running. It summarizes detected ChArUco corners into frame coverage
+and scale-diversity state, then prompts for a measured next action such as
+moving the board toward a missing corner/edge, changing board distance, or
+pressing `ENTER` once coverage is balanced. Guided auto-capture is enabled by
+default: it saves a frame only when the current observation improves grid
+coverage, adds useful scale diversity, or helps balance the remaining required
+sample count. These prompts and capture decisions are deterministic; they are
+selected from current observations and accepted samples rather than rotated
+randomly.
+
+The Stage 2 GUI exposes coverage rows, coverage columns, and samples-per-cell
+controls. The same settings are included in the copyable command preview and in
+the `Run Calibration` child-process launch.
+
+When `calib/calib_color.yaml` exists, Stage 2 shows a parsed calibration result
+summary in the right panel instead of making users read raw YAML by default.
+The summary includes validity, image size, model, reprojection RMS, intrinsics,
+distortion coefficients, output path, and latest run snapshot. Use `View Raw`
+or `Open YAML` when the exact artifact is needed for debugging or
+reproducibility.
+
+Native in-app camera/video rendering is intentionally deferred to issue #61.
+Do not dock or embed the OpenCV HighGUI window into Qt; the future native
+calibration canvas should share package-level calibration runtime logic while
+preserving the CLI/OpenCV fallback.
 
 ## Command Examples
 
@@ -153,6 +185,26 @@ The same board arguments are used by `posetag-gen-charuco` and
 The command fails before opening hardware if the dictionary name is not
 supported by the installed OpenCV build.
 
+## Manual GUI Launch Check
+
+The GUI launch path is hardware-dependent and is not covered by automated unit
+tests. To check it manually:
+
+```bash
+python3 -m pip install -e ".[gui]"
+posetag-gui --project_root my_project
+```
+
+Generate or select a ChArUco metadata YAML in Stage 1, open Stage 2, choose the
+source, and press `Run Calibration` once the readiness panel says it is ready.
+The button is disabled while the child process is running. Use the OpenCV
+calibration window exactly as the CLI uses it: guided auto-capture saves good
+samples as you move the board through the grid, `SPACE` adds a manual sample,
+`ENTER` solves, and `q` quits. Confirm the OpenCV preview shows guidance text
+and a coverage grid with collected cells turning green, the GUI log receives
+process output, and Stage 2 refreshes after
+`<project_root>/calib/calib_color.yaml` appears.
+
 The generation command fails clearly if:
 
 - the dictionary name is not supported by the installed OpenCV build
@@ -165,13 +217,43 @@ The generation command fails clearly if:
 
 ## Controls
 
-- `SPACE`: save the current frame as a calibration sample when enough ChArUco
-  corners are detected.
+- Guided auto-capture: save good frames as they improve coverage, scale
+  diversity, or balanced sample count.
+- `SPACE`: force-save the current frame as a manual calibration sample when
+  enough ChArUco corners are detected.
 - `ENTER`: solve calibration from the collected samples.
 - `q`: quit cleanly without solving or writing a calibration YAML.
 
 Use diverse views: move and tilt the board so it appears across the frame,
 including near corners and edges, while avoiding blur and glare.
+
+Guided capture options:
+
+- `--coverage-grid 3x3`: split the image into target regions for coverage
+  guidance. Rectangular grids such as `4x5` are accepted.
+- `--samples-per-cell 1`: require at least this many accepted samples in each
+  grid cell before coverage is considered complete.
+- `--no-guided-auto`: keep the guidance overlay but disable automatic sample
+  saving.
+- `--guided-auto-cooldown 8`: wait this many frames after each guided automatic
+  sample before another guided sample can be saved.
+- `--auto --auto-interval N`: legacy timed auto-sampling fallback; guided
+  auto-capture is preferred.
+
+The preview window now makes that guidance explicit:
+
+- If no board is detected, bring the ChArUco board fully into view.
+- If too few corners are detected, move closer, hold still, or reduce glare.
+- If the center is over-represented, move the board toward the next missing
+  edge or corner.
+- If frame coverage is balanced but all samples are at one apparent scale,
+  change the board distance.
+- Once coverage, scale diversity, and sample count are sufficient, press
+  `ENTER` to solve.
+
+The guidance and auto-capture policy decide when to add existing detected
+ChArUco corners to the sample set. They do not change the OpenCV calibration
+solver, accepted calibration YAML schema, units, or coordinate conventions.
 
 ## Project Directory Side Effects
 

--- a/src/posetag/cli/charuco.py
+++ b/src/posetag/cli/charuco.py
@@ -5,3 +5,7 @@ def main(argv=None):
     from utils.charuco_calibrate import main as _main
 
     return _main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/posetag/gui/main_window.py
+++ b/src/posetag/gui/main_window.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import html
 from pathlib import Path
 from typing import Any, Optional
 
@@ -30,17 +31,30 @@ from posetag.workflows.charuco_setup import (
     generate_charuco_board_setup,
 )
 from posetag.workflows.calibration_flow import (
+    CALIBRATION_PROCESS_NOT_STARTED,
     CALIBRATION_SOURCE_CHOICES,
     CALIBRATION_SOURCE_LABELS,
+    DEFAULT_GUIDED_AUTO_COOLDOWN,
+    DEFAULT_SAMPLES_PER_CELL,
     SOURCE_OPENCV,
     SOURCE_REALSENSE,
     SOURCE_VIDEO,
     CameraCalibrationConfig,
+    CameraCalibrationFlowError,
+    CameraCalibrationOutputSummary,
+    CameraCalibrationProcessState,
     CameraCalibrationReadiness,
+    build_camera_calibration_launch,
     camera_calibration_config_from_project,
+    calibration_process_failed,
+    calibration_process_not_started,
+    calibration_process_running,
+    inspect_camera_calibration_output,
     inspect_camera_calibration_readiness,
     inspect_charuco_metadata,
     normalize_source,
+    read_camera_calibration_yaml_text,
+    summarize_camera_calibration_process_result,
 )
 
 
@@ -224,6 +238,19 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._models: tuple[StageViewModel, ...] = ()
             self._selected_stage_id = 0
             self._stage_widgets: dict[int, Any] = {}
+            self._calibration_process: Any = None
+            self._calibration_process_state = calibration_process_not_started()
+            self._calibration_running_project_root: Optional[Path] = None
+            self._calibration_running_expected_output: Optional[Path] = None
+            self._calibration_previous_output_mtime_ns: Optional[int] = None
+            self._calibration_output_existed_at_launch = False
+            self._calibration_output_seen = False
+
+            self._calibration_output_timer = QtCore.QTimer(self)
+            self._calibration_output_timer.setInterval(1000)
+            self._calibration_output_timer.timeout.connect(
+                self._poll_calibration_output
+            )
 
             self.setWindowTitle("PoseTag Workflow Dashboard")
 
@@ -639,6 +666,17 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._calibration_dictionary.addItems(list(_safe_dictionary_choices()))
             self._calibration_dictionary.setCurrentText(DEFAULT_DICTIONARY)
             self._calibration_dictionary.setMinimumWidth(180)
+            self._calibration_grid_rows = _make_int_spin(1, 9, 3)
+            self._calibration_grid_cols = _make_int_spin(1, 9, 3)
+            self._calibration_samples_per_cell = _make_int_spin(
+                1,
+                20,
+                DEFAULT_SAMPLES_PER_CELL,
+            )
+            self._calibration_guided_auto = QtWidgets.QCheckBox(
+                "Guided auto-capture"
+            )
+            self._calibration_guided_auto.setChecked(True)
 
             for field in (
                 self._calibration_camera_index,
@@ -646,9 +684,15 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                 self._calibration_squares_y,
                 self._calibration_square_length,
                 self._calibration_marker_length,
+                self._calibration_grid_rows,
+                self._calibration_grid_cols,
+                self._calibration_samples_per_cell,
             ):
                 field.valueChanged.connect(self._update_calibration_flow)
             self._calibration_dictionary.currentTextChanged.connect(
+                self._update_calibration_flow
+            )
+            self._calibration_guided_auto.stateChanged.connect(
                 self._update_calibration_flow
             )
 
@@ -699,6 +743,22 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                 1,
                 2,
             )
+            calibration_grid.addWidget(
+                _make_field("Coverage rows", self._calibration_grid_rows),
+                5,
+                0,
+            )
+            calibration_grid.addWidget(
+                _make_field("Coverage cols", self._calibration_grid_cols),
+                5,
+                1,
+            )
+            calibration_grid.addWidget(
+                _make_field("Samples / cell", self._calibration_samples_per_cell),
+                6,
+                0,
+            )
+            calibration_grid.addWidget(self._calibration_guided_auto, 6, 1)
             calibration_grid.setColumnStretch(0, 1)
             calibration_grid.setColumnStretch(1, 1)
 
@@ -733,6 +793,9 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._calibration_copy_button.clicked.connect(
                 self._copy_calibration_command
             )
+            self._calibration_run_button = QtWidgets.QPushButton("Run Calibration")
+            self._calibration_run_button.setObjectName("PrimaryActionButton")
+            self._calibration_run_button.clicked.connect(self._run_calibration)
             self._calibration_copy_feedback = QtWidgets.QLabel()
             self._calibration_copy_feedback.setObjectName("MutedText")
             self._calibration_copy_feedback.setWordWrap(True)
@@ -744,8 +807,9 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             calibration_command_widget.setLayout(calibration_command_row)
 
             calibration_controls = QtWidgets.QLabel(
-                "Controls: SPACE adds a sample; ENTER solves calibration; "
-                "q quits without writing calibration output."
+                "Controls: guided auto-capture saves useful samples; SPACE "
+                "manually adds a sample; ENTER solves calibration; q quits "
+                "without writing calibration output."
             )
             calibration_controls.setObjectName("GuidanceText")
             calibration_controls.setWordWrap(True)
@@ -753,7 +817,22 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             calibration_refresh_button = QtWidgets.QPushButton("Refresh Status")
             calibration_refresh_button.setObjectName("SecondaryActionButton")
             calibration_refresh_button.clicked.connect(self._refresh)
+            self._calibration_process_state_label = QtWidgets.QLabel()
+            self._calibration_process_state_label.setObjectName("OutputText")
+            self._calibration_process_state_label.setWordWrap(True)
+            self._calibration_process_state_label.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            self._calibration_log = QtWidgets.QPlainTextEdit()
+            self._calibration_log.setObjectName("CalibrationLog")
+            self._calibration_log.setReadOnly(True)
+            self._calibration_log.setMaximumHeight(118)
+            self._calibration_log.setPlaceholderText(
+                "Calibration stdout/stderr will appear here after launch."
+            )
+            self._calibration_log.document().setMaximumBlockCount(250)
             calibration_action_row = QtWidgets.QHBoxLayout()
+            calibration_action_row.addWidget(self._calibration_run_button)
             calibration_action_row.addWidget(calibration_refresh_button)
             calibration_action_row.addStretch(1)
 
@@ -781,6 +860,20 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             calibration_status_grid.addWidget(
                 _make_field("Command preview", calibration_command_widget),
                 2,
+                0,
+                1,
+                2,
+            )
+            calibration_status_grid.addWidget(
+                _make_field("Process state", self._calibration_process_state_label),
+                3,
+                0,
+                1,
+                2,
+            )
+            calibration_status_grid.addWidget(
+                _make_field("Process log", self._calibration_log),
+                4,
                 0,
                 1,
                 2,
@@ -856,16 +949,76 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                 QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
             )
 
-            self._health_panel = QtWidgets.QFrame()
-            self._health_panel.setObjectName("HealthPanel")
-            self._health_panel.setMinimumWidth(280)
-            self._health_panel.setMaximumWidth(340)
-            health_layout = QtWidgets.QVBoxLayout(self._health_panel)
+            self._calibration_result_label = QtWidgets.QLabel()
+            self._calibration_result_label.setObjectName("HealthSectionBody")
+            self._calibration_result_label.setTextFormat(
+                QtCore.Qt.TextFormat.RichText
+            )
+            self._calibration_result_label.setWordWrap(True)
+            self._calibration_result_label.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            self._open_calibration_yaml_button = QtWidgets.QPushButton("Open YAML")
+            self._open_calibration_yaml_button.setObjectName("SecondaryActionButton")
+            self._open_calibration_yaml_button.clicked.connect(
+                self._open_calibration_yaml
+            )
+            self._view_calibration_yaml_button = QtWidgets.QPushButton("View Raw")
+            self._view_calibration_yaml_button.setObjectName("SecondaryActionButton")
+            self._view_calibration_yaml_button.clicked.connect(
+                self._view_calibration_yaml
+            )
+            self._copy_calibration_summary_button = QtWidgets.QPushButton(
+                "Copy Summary"
+            )
+            self._copy_calibration_summary_button.setObjectName(
+                "SecondaryActionButton"
+            )
+            self._copy_calibration_summary_button.clicked.connect(
+                self._copy_calibration_summary
+            )
+            self._calibration_result_actions = QtWidgets.QWidget()
+            calibration_result_actions_layout = QtWidgets.QVBoxLayout(
+                self._calibration_result_actions
+            )
+            calibration_result_actions_layout.setContentsMargins(0, 0, 0, 0)
+            calibration_result_actions_layout.setSpacing(6)
+            calibration_result_actions_layout.addWidget(
+                self._open_calibration_yaml_button
+            )
+            calibration_result_actions_layout.addWidget(
+                self._view_calibration_yaml_button
+            )
+            calibration_result_actions_layout.addWidget(
+                self._copy_calibration_summary_button
+            )
+            self._calibration_result_divider = _divider(QtWidgets)
+            self._project_health_title = QtWidgets.QLabel("Project Health")
+            self._project_health_title.setObjectName("HealthSectionTitle")
+
+            health_content = QtWidgets.QFrame()
+            health_content.setObjectName("HealthPanel")
+            health_layout = QtWidgets.QVBoxLayout(health_content)
             health_layout.setContentsMargins(16, 16, 16, 16)
             health_layout.setSpacing(10)
-            health_title = QtWidgets.QLabel("Project Health")
-            health_title.setObjectName("PanelTitle")
-            health_layout.addWidget(health_title)
+
+            self._health_panel = QtWidgets.QScrollArea()
+            self._health_panel.setObjectName("HealthScroll")
+            self._health_panel.setMinimumWidth(280)
+            self._health_panel.setMaximumWidth(340)
+            self._health_panel.setWidgetResizable(True)
+            self._health_panel.setFrameShape(QtWidgets.QFrame.Shape.NoFrame)
+            self._health_panel.setHorizontalScrollBarPolicy(
+                QtCore.Qt.ScrollBarPolicy.ScrollBarAlwaysOff
+            )
+            self._health_panel.setWidget(health_content)
+            self._side_panel_title = QtWidgets.QLabel("Project Health")
+            self._side_panel_title.setObjectName("PanelTitle")
+            health_layout.addWidget(self._side_panel_title)
+            health_layout.addWidget(self._calibration_result_label)
+            health_layout.addWidget(self._calibration_result_actions)
+            health_layout.addWidget(self._calibration_result_divider)
+            health_layout.addWidget(self._project_health_title)
             health_layout.addWidget(self._health_status_label)
             health_layout.addWidget(self._health_message_label)
             health_layout.addWidget(self._health_counts_label)
@@ -1030,6 +1183,68 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             )
             self.statusBar().showMessage(message, 4000)
 
+        def _open_calibration_yaml(self) -> None:
+            summary = inspect_camera_calibration_output(self._current_project_root())
+            if not summary.exists:
+                message = "Calibration YAML is not available to open."
+                self.statusBar().showMessage(message, 4000)
+                return
+
+            opened = QtGui.QDesktopServices.openUrl(
+                QtCore.QUrl.fromLocalFile(str(summary.path.resolve()))
+            )
+            message = "Opened calibration YAML." if opened else "Could not open YAML."
+            self.statusBar().showMessage(message, 4000)
+
+        def _view_calibration_yaml(self) -> None:
+            summary = inspect_camera_calibration_output(self._current_project_root())
+            if not summary.exists:
+                message = "Calibration YAML is not available to view."
+                self.statusBar().showMessage(message, 4000)
+                return
+            try:
+                raw_text = read_camera_calibration_yaml_text(summary.path)
+            except CameraCalibrationFlowError as exc:
+                self.statusBar().showMessage(str(exc), 5000)
+                return
+
+            dialog = QtWidgets.QDialog(self)
+            dialog.setWindowTitle("Calibration YAML")
+            dialog.resize(760, 560)
+            layout = QtWidgets.QVBoxLayout(dialog)
+            layout.setContentsMargins(12, 12, 12, 12)
+            layout.setSpacing(8)
+            path_label = QtWidgets.QLabel(_display_path(summary.path))
+            path_label.setObjectName("MutedText")
+            path_label.setWordWrap(True)
+            editor = QtWidgets.QPlainTextEdit()
+            editor.setObjectName("CalibrationYamlView")
+            editor.setReadOnly(True)
+            editor.setPlainText(raw_text)
+            close_button = QtWidgets.QPushButton("Close")
+            close_button.clicked.connect(dialog.accept)
+            button_row = QtWidgets.QHBoxLayout()
+            button_row.addStretch(1)
+            button_row.addWidget(close_button)
+            layout.addWidget(path_label)
+            layout.addWidget(editor, 1)
+            layout.addLayout(button_row)
+            dialog.exec()
+
+        def _copy_calibration_summary(self) -> None:
+            summary = inspect_camera_calibration_output(self._current_project_root())
+            if not summary.exists:
+                message = "Calibration summary is not available to copy."
+                self.statusBar().showMessage(message, 4000)
+                return
+            QtWidgets.QApplication.clipboard().setText(
+                _format_calibration_result_summary(summary)
+            )
+            self.statusBar().showMessage(
+                "Copied calibration summary to the clipboard.",
+                3000,
+            )
+
         def _refresh(self) -> None:
             root = Path(self._root_input.text()).expanduser()
             self._render_project_context(root)
@@ -1125,6 +1340,7 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             if model.stage_id == 2:
                 self._sync_calibration_from_project_metadata()
                 self._update_calibration_flow()
+            self._render_side_panel_calibration_result()
             self._render_stage_rail_selection()
 
         def _render_health(self) -> None:
@@ -1149,6 +1365,30 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._health_next_body.setText(
                 f"{health.next_stage_label}\n\n{health.next_action}"
             )
+            self._render_side_panel_calibration_result()
+
+        def _render_side_panel_calibration_result(self) -> None:
+            show_calibration = self._selected_stage_id == 2
+            self._side_panel_title.setText(
+                "Calibration Result" if show_calibration else "Project Health"
+            )
+            self._calibration_result_label.setVisible(show_calibration)
+            self._calibration_result_actions.setVisible(show_calibration)
+            self._calibration_result_divider.setVisible(show_calibration)
+            self._project_health_title.setVisible(show_calibration)
+            if not show_calibration:
+                return
+
+            summary = inspect_camera_calibration_output(self._current_project_root())
+            self._calibration_result_label.setText(
+                _format_calibration_result_summary_html(summary)
+            )
+            for button in (
+                self._open_calibration_yaml_button,
+                self._view_calibration_yaml_button,
+                self._copy_calibration_summary_button,
+            ):
+                button.setEnabled(summary.exists)
 
         def _render_error(self, root: Path, exc: Exception) -> None:
             self._render_project_context(root)
@@ -1283,7 +1523,9 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             )
 
             model = self._model_by_stage_id(self._selected_stage_id)
-            stage_complete = bool(model and model.stage_id == 2 and model.status == "complete")
+            stage_complete = bool(
+                model and model.stage_id == 2 and model.status == "complete"
+            )
             self._calibration_command_preview.setText(readiness.command_preview)
             self._calibration_command_preview.setCursorPosition(0)
             self._calibration_copy_button.setEnabled(bool(readiness.command_preview))
@@ -1292,6 +1534,20 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                     readiness,
                     stage_complete=stage_complete,
                 )
+            )
+            if (
+                self._calibration_process_state.state
+                == CALIBRATION_PROCESS_NOT_STARTED
+            ):
+                self._set_calibration_process_state(
+                    calibration_process_not_started(readiness.expected_output)
+                )
+            process_running = self._calibration_process_is_running()
+            self._calibration_run_button.setEnabled(
+                readiness.ready and not process_running
+            )
+            self._calibration_run_button.setText(
+                _calibration_run_button_label(self._calibration_process_state)
             )
 
             if model is None or model.stage_id != 2:
@@ -1324,6 +1580,182 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._calibration_copy_feedback.setText(message)
             self.statusBar().showMessage(message, 3000)
 
+        def _run_calibration(self) -> None:
+            if self._calibration_process_is_running():
+                message = "Calibration is already running."
+                self.statusBar().showMessage(message, 3000)
+                return
+
+            config = self._calibration_config()
+            readiness = inspect_camera_calibration_readiness(config)
+            if not readiness.ready:
+                message = "Resolve calibration readiness messages before running."
+                self._calibration_copy_feedback.setText(message)
+                self.statusBar().showMessage(message, 5000)
+                self._update_calibration_flow()
+                return
+
+            try:
+                launch = build_camera_calibration_launch(config)
+            except Exception as exc:
+                message = f"Could not prepare calibration launch: {exc}"
+                self._set_calibration_process_state(
+                    calibration_process_failed(
+                        message,
+                        expected_output=readiness.expected_output,
+                    )
+                )
+                self._append_calibration_log(f"[gui] {message}")
+                self.statusBar().showMessage(message, 6000)
+                self._update_calibration_flow()
+                return
+
+            process = QtCore.QProcess(self)
+            process.setProgram(launch.program)
+            process.setArguments(list(launch.arguments))
+            process.setProcessChannelMode(
+                QtCore.QProcess.ProcessChannelMode.SeparateChannels
+            )
+            if hasattr(QtCore, "QProcessEnvironment"):
+                env = QtCore.QProcessEnvironment.systemEnvironment()
+                env.insert("PYTHONUNBUFFERED", "1")
+                process.setProcessEnvironment(env)
+            process.readyReadStandardOutput.connect(self._read_calibration_stdout)
+            process.readyReadStandardError.connect(self._read_calibration_stderr)
+            process.finished.connect(self._calibration_process_finished)
+            process.errorOccurred.connect(self._calibration_process_error)
+
+            self._calibration_process = process
+            self._calibration_running_project_root = self._current_project_root()
+            self._calibration_running_expected_output = launch.expected_output
+            self._calibration_output_existed_at_launch = (
+                launch.expected_output.exists()
+            )
+            self._calibration_previous_output_mtime_ns = _path_mtime_ns(
+                launch.expected_output
+            )
+            self._calibration_output_seen = self._calibration_output_existed_at_launch
+            self._calibration_log.clear()
+            self._append_calibration_log(f"$ {launch.display_command}")
+            self._append_calibration_log(
+                "[gui] Launching with the current Python interpreter."
+            )
+            self._set_calibration_process_state(
+                calibration_process_running(launch.expected_output)
+            )
+            self._calibration_output_timer.start()
+            self._update_calibration_flow()
+            process.start()
+            self.statusBar().showMessage("Calibration process started.", 4000)
+
+        def _read_calibration_stdout(self) -> None:
+            process = self._calibration_process
+            if process is None:
+                return
+            self._append_calibration_output(process.readAllStandardOutput(), "")
+
+        def _read_calibration_stderr(self) -> None:
+            process = self._calibration_process
+            if process is None:
+                return
+            self._append_calibration_output(process.readAllStandardError(), "stderr")
+
+        def _calibration_process_finished(
+            self,
+            exit_code: int,
+            exit_status: Any,
+        ) -> None:
+            self._read_calibration_stdout()
+            self._read_calibration_stderr()
+            root = (
+                self._calibration_running_project_root
+                or self._current_project_root()
+            )
+            expected_output = self._calibration_running_expected_output
+            crashed = exit_status == QtCore.QProcess.ExitStatus.CrashExit
+            state = summarize_camera_calibration_process_result(
+                root,
+                exit_code=int(exit_code),
+                crashed=crashed,
+                expected_output=expected_output,
+                previous_output_mtime_ns=self._calibration_previous_output_mtime_ns,
+                require_output_update=self._calibration_output_existed_at_launch,
+            )
+            self._calibration_process = None
+            self._calibration_output_timer.stop()
+            self._set_calibration_process_state(state)
+            self._append_calibration_log(f"[gui] {state.message}")
+            self._refresh()
+            self.statusBar().showMessage(state.message, 7000)
+
+        def _calibration_process_error(self, error: Any) -> None:
+            process = self._calibration_process
+            error_name = _qt_enum_name(error)
+            detail = process.errorString() if process is not None else error_name
+            self._append_calibration_log(f"[gui] Process error: {detail}")
+            failed_to_start = QtCore.QProcess.ProcessError.FailedToStart
+            if error != failed_to_start:
+                return
+
+            state = calibration_process_failed(
+                f"Calibration process failed to start: {detail}",
+                expected_output=self._calibration_running_expected_output,
+            )
+            self._calibration_process = None
+            self._calibration_output_timer.stop()
+            self._set_calibration_process_state(state)
+            self._update_calibration_flow()
+            self.statusBar().showMessage(state.message, 7000)
+
+        def _poll_calibration_output(self) -> None:
+            target = self._calibration_running_expected_output
+            if target is None or self._calibration_output_seen:
+                return
+            if not target.exists():
+                return
+            self._calibration_output_seen = True
+            self._append_calibration_log(
+                f"[gui] Detected calibration output: {_display_path(target)}"
+            )
+            self._refresh()
+
+        def _append_calibration_output(self, data: Any, prefix: str) -> None:
+            text = bytes(data).decode("utf-8", errors="replace")
+            if not text:
+                return
+            if prefix:
+                for line in text.rstrip().splitlines():
+                    self._append_calibration_log(f"[{prefix}] {line}")
+            else:
+                self._append_calibration_log(text.rstrip())
+
+        def _append_calibration_log(self, text: str) -> None:
+            if not text:
+                return
+            self._calibration_log.appendPlainText(text)
+            scrollbar = self._calibration_log.verticalScrollBar()
+            scrollbar.setValue(scrollbar.maximum())
+
+        def _set_calibration_process_state(
+            self,
+            state: CameraCalibrationProcessState,
+        ) -> None:
+            self._calibration_process_state = state
+            if hasattr(self, "_calibration_process_state_label"):
+                self._calibration_process_state_label.setText(
+                    _format_calibration_process_state(state)
+                )
+            if hasattr(self, "_calibration_run_button"):
+                self._calibration_run_button.setText(
+                    _calibration_run_button_label(state)
+                )
+
+        def _calibration_process_is_running(self) -> bool:
+            process = self._calibration_process
+            if process is None:
+                return False
+            return process.state() != QtCore.QProcess.ProcessState.NotRunning
+
         def _render_calibration_source_fields(self) -> None:
             source = self._calibration_source_value()
             is_webcam = source == SOURCE_OPENCV
@@ -1344,6 +1776,13 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                 square_length_mm=float(self._calibration_square_length.value()),
                 marker_length_mm=float(self._calibration_marker_length.value()),
                 dictionary_name=self._calibration_dictionary.currentText(),
+                coverage_grid=(
+                    f"{int(self._calibration_grid_rows.value())}x"
+                    f"{int(self._calibration_grid_cols.value())}"
+                ),
+                samples_per_cell=int(self._calibration_samples_per_cell.value()),
+                guided_auto=bool(self._calibration_guided_auto.isChecked()),
+                guided_auto_cooldown=DEFAULT_GUIDED_AUTO_COOLDOWN,
             )
 
         def _calibration_source_value(self) -> str:
@@ -1546,6 +1985,166 @@ def _format_calibration_readiness(
     return "\n".join(lines)
 
 
+def _format_calibration_process_state(
+    state: CameraCalibrationProcessState,
+) -> str:
+    lines = [state.label, "", state.message]
+    if state.expected_output is not None:
+        lines.extend(["", f"Expected output: {_display_path(state.expected_output)}"])
+    if state.exit_code is not None:
+        lines.append(f"Exit code: {state.exit_code}")
+    return "\n".join(lines)
+
+
+def _format_calibration_result_summary(
+    summary: CameraCalibrationOutputSummary,
+) -> str:
+    if not summary.exists:
+        return "\n".join(
+            [
+                "No calibration YAML yet.",
+                "",
+                "Expected output",
+                _display_path(summary.path),
+            ]
+        )
+
+    lines = [
+        "Calibration valid" if summary.valid else "Calibration needs attention",
+        summary.message,
+        "",
+        "Output",
+        _display_path(summary.path),
+    ]
+    if summary.image_width is not None and summary.image_height is not None:
+        lines.extend(
+            [
+                "",
+                "Image size",
+                f"{summary.image_width} x {summary.image_height}",
+            ]
+        )
+    if summary.model:
+        lines.extend(["", "Model", summary.model])
+    if summary.reproj_rms is not None:
+        lines.extend(["", "RMS", f"{summary.reproj_rms:.3f} px"])
+    if summary.camera_params is not None:
+        fx, fy, cx, cy = summary.camera_params
+        lines.extend(
+            [
+                "",
+                "Intrinsics",
+                f"fx={fx:.3f}",
+                f"fy={fy:.3f}",
+                f"cx={cx:.3f}",
+                f"cy={cy:.3f}",
+            ]
+        )
+    if summary.distortion_coefficients:
+        distortion = "  ".join(
+            f"{name}={value:.6g}"
+            for name, value in summary.distortion_coefficients
+        )
+        lines.extend(["", "Distortion", distortion])
+    if summary.latest_run_dir is not None:
+        lines.extend(["", "Run snapshot", _display_path(summary.latest_run_dir)])
+    return "\n".join(lines)
+
+
+def _format_calibration_result_summary_html(
+    summary: CameraCalibrationOutputSummary,
+) -> str:
+    if not summary.exists:
+        return "".join(
+            [
+                "<div>No calibration YAML yet.</div>",
+                _result_block_html("Expected output", _display_path(summary.path)),
+            ]
+        )
+
+    lines = [
+        (
+            "<div><b>"
+            + html.escape(
+                "Calibration valid"
+                if summary.valid
+                else "Calibration needs attention"
+            )
+            + "</b></div>"
+        ),
+        f"<div>{html.escape(summary.message)}</div>",
+        _result_block_html("Output", _display_path(summary.path)),
+    ]
+    if summary.image_width is not None and summary.image_height is not None:
+        lines.append(
+            _result_block_html(
+                "Image size",
+                f"{summary.image_width} x {summary.image_height}",
+            )
+        )
+    if summary.model:
+        lines.append(_result_block_html("Model", summary.model))
+    if summary.reproj_rms is not None:
+        lines.append(_result_block_html("RMS", f"{summary.reproj_rms:.3f} px"))
+    if summary.camera_params is not None:
+        fx, fy, cx, cy = summary.camera_params
+        lines.append(
+            _result_block_html(
+                "Intrinsics",
+                "<br>".join(
+                    html.escape(value)
+                    for value in (
+                        f"fx={fx:.3f}",
+                        f"fy={fy:.3f}",
+                        f"cx={cx:.3f}",
+                        f"cy={cy:.3f}",
+                    )
+                ),
+                already_escaped=True,
+            )
+        )
+    if summary.distortion_coefficients:
+        distortion = "  ".join(
+            f"{name}={value:.6g}"
+            for name, value in summary.distortion_coefficients
+        )
+        lines.append(_result_block_html("Distortion", distortion))
+    if summary.latest_run_dir is not None:
+        lines.append(
+            _result_block_html("Run snapshot", _display_path(summary.latest_run_dir))
+        )
+    return "".join(lines)
+
+
+def _result_block_html(
+    label: str,
+    value: str,
+    *,
+    already_escaped: bool = False,
+) -> str:
+    rendered_value = value if already_escaped else html.escape(value)
+    return (
+        "<p style='margin:10px 0 0 0;'>"
+        "<span style='color:#405367; font-weight:600;'>"
+        f"{html.escape(label)}</span><br>"
+        "<span style='font-family:\"Menlo\", \"Consolas\", "
+        "\"Courier New\", monospace;'>"
+        f"{rendered_value}</span></p>"
+    )
+
+
+def _calibration_run_button_label(state: CameraCalibrationProcessState) -> str:
+    if state.running:
+        return "Calibration Running..."
+    if state.success:
+        return "Run Calibration Again"
+    return "Run Calibration"
+
+
+def _qt_enum_name(value: Any) -> str:
+    return str(getattr(value, "name", value))
+
+
 def _display_path(path: Path) -> str:
     home = Path.home()
     try:
@@ -1654,8 +2253,10 @@ def _calibration_command_card_note(
             "need to rerun the existing posetag-calib-charuco workflow."
         )
     return (
-        "Copy the preview into a terminal. The command opens the existing "
-        "calibration window; SPACE adds samples, ENTER solves, and q quits."
+        "Run Calibration starts the existing calibration workflow; Copy Command "
+        "keeps the terminal fallback. Guided auto-capture saves useful samples; "
+        "SPACE manually adds a sample, ENTER solves, and q quits in the OpenCV "
+        "window."
     )
 
 
@@ -1668,7 +2269,7 @@ def _calibration_command_ready_message(
         return "No runnable calibration command is available yet."
     if stage_complete:
         return "Calibration output exists. Copy only if you need to rerun it."
-    return "Ready to copy a calibration command."
+    return "Ready to run or copy a calibration command."
 
 
 def _project_root_hint(root: Path) -> str:
@@ -1738,6 +2339,16 @@ QLineEdit#CommandPreview {
     font-family: "Menlo", "Consolas", "Courier New", monospace;
     font-size: 12px;
 }
+QPlainTextEdit#CalibrationLog,
+QPlainTextEdit#CalibrationYamlView {
+    color: #263545;
+    background: #f7fafc;
+    border: 1px solid #d4e1ea;
+    border-radius: 6px;
+    padding: 7px;
+    font-family: "Menlo", "Consolas", "Courier New", monospace;
+    font-size: 11px;
+}
 QScrollArea#DetailScroll {
     background: transparent;
     border: none;
@@ -1773,12 +2384,24 @@ QPushButton#SecondaryActionButton {
     background: #49697f;
     border-color: #365467;
 }
-QFrame#HeaderPanel,
-QFrame#RailPanel,
-QFrame#HealthPanel {
+QFrame#HeaderPanel {
     background: #fbfdff;
     border: 1px solid #dfe9f1;
     border-radius: 8px;
+}
+QFrame#RailPanel {
+    background: #f2f7fb;
+    border: 1px solid #d8e5ee;
+    border-radius: 8px;
+}
+QFrame#HealthPanel {
+    background: #f6fafc;
+    border: 1px solid #d8e5ee;
+    border-radius: 8px;
+}
+QScrollArea#HealthScroll {
+    background: transparent;
+    border: none;
 }
 QFrame#Card {
     background: #fbfdff;
@@ -1876,8 +2499,8 @@ QLabel#CharucoPreviewCanvas {
 }
 QLabel#HealthCounts {
     color: #263545;
-    background: #f6f9fc;
-    border: 1px solid #d9e5ee;
+    background: #eef5f9;
+    border: 1px solid #d3e1ea;
     border-radius: 7px;
     padding: 9px 10px;
 }

--- a/src/posetag/workflows/calibration_flow.py
+++ b/src/posetag/workflows/calibration_flow.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import importlib.util
 import math
 import shlex
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Union
@@ -21,6 +22,8 @@ from posetag.pipelines.charuco_calibration import (
     get_dictionary,
     validate_capture_args,
 )
+from posetag.pipelines.make_board import MakeBoardError, load_calibration_yaml
+from posetag.workflows.calibration_guidance import parse_grid_shape
 from posetag.workflows.charuco_setup import (
     DEFAULT_DICTIONARY,
     DEFAULT_MARKER_LENGTH_MM,
@@ -28,6 +31,7 @@ from posetag.workflows.charuco_setup import (
     DEFAULT_SQUARES_X,
     DEFAULT_SQUARES_Y,
 )
+from posetag.workflows.status import WorkflowStatus, inspect_camera_calibration
 
 
 SOURCE_OPENCV = "opencv"
@@ -40,6 +44,13 @@ CALIBRATION_SOURCE_LABELS = {
     SOURCE_VIDEO: "video",
 }
 DEFAULT_CAMERA_INDEX = 0
+DEFAULT_COVERAGE_GRID = "3x3"
+DEFAULT_SAMPLES_PER_CELL = 1
+DEFAULT_GUIDED_AUTO_COOLDOWN = 8
+CALIBRATION_PROCESS_NOT_STARTED = "not_started"
+CALIBRATION_PROCESS_RUNNING = "running"
+CALIBRATION_PROCESS_FINISHED = "finished"
+CALIBRATION_PROCESS_FAILED_CANCELLED = "failed_cancelled"
 
 
 class CameraCalibrationFlowError(ValueError):
@@ -88,6 +99,10 @@ class CameraCalibrationConfig:
     square_length_mm: float = DEFAULT_SQUARE_LENGTH_MM
     marker_length_mm: float = DEFAULT_MARKER_LENGTH_MM
     dictionary_name: str = DEFAULT_DICTIONARY
+    coverage_grid: str = DEFAULT_COVERAGE_GRID
+    samples_per_cell: int = DEFAULT_SAMPLES_PER_CELL
+    guided_auto: bool = True
+    guided_auto_cooldown: int = DEFAULT_GUIDED_AUTO_COOLDOWN
 
 
 @dataclass(frozen=True)
@@ -103,6 +118,46 @@ class CameraCalibrationReadiness:
     checked_paths: tuple[Path, ...]
     warnings: tuple[str, ...]
     errors: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CameraCalibrationLaunchSpec:
+    """Editable-install-safe process launch details for calibration."""
+
+    program: str
+    arguments: tuple[str, ...]
+    display_command: str
+    expected_output: Path
+
+
+@dataclass(frozen=True)
+class CameraCalibrationProcessState:
+    """GUI-independent calibration child-process state."""
+
+    state: str
+    label: str
+    message: str
+    running: bool = False
+    success: bool = False
+    expected_output: Optional[Path] = None
+    exit_code: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class CameraCalibrationOutputSummary:
+    """Parsed status for an existing calibration YAML artifact."""
+
+    path: Path
+    exists: bool
+    valid: bool
+    message: str
+    image_width: Optional[int] = None
+    image_height: Optional[int] = None
+    model: Optional[str] = None
+    reproj_rms: Optional[float] = None
+    camera_params: Optional[tuple[float, float, float, float]] = None
+    distortion_coefficients: tuple[tuple[str, float], ...] = ()
+    latest_run_dir: Optional[Path] = None
 
 
 def generated_charuco_metadata_paths(project_root: Union[Path, str]) -> tuple[Path, ...]:
@@ -295,6 +350,7 @@ def inspect_camera_calibration_readiness(
     except CharucoCalibrationError as exc:
         errors.append(str(exc))
     errors.extend(_camera_calibration_board_errors(config))
+    errors.extend(_camera_calibration_guidance_errors(config))
 
     command_preview = ""
     if not errors:
@@ -319,6 +375,35 @@ def inspect_camera_calibration_readiness(
 def build_camera_calibration_command(config: CameraCalibrationConfig) -> str:
     """Build a copyable ``posetag-calib-charuco`` command from GUI state."""
 
+    return shlex.join(
+        ("posetag-calib-charuco", *build_camera_calibration_arguments(config))
+    )
+
+
+def build_camera_calibration_launch(
+    config: CameraCalibrationConfig,
+    *,
+    python_executable: Optional[Union[Path, str]] = None,
+) -> CameraCalibrationLaunchSpec:
+    """Build process launch details for the existing calibration workflow."""
+
+    arguments = build_camera_calibration_arguments(config)
+    executable = str(python_executable) if python_executable else sys.executable
+    return CameraCalibrationLaunchSpec(
+        program=executable,
+        arguments=("-m", "posetag.cli.charuco", *arguments),
+        display_command=build_camera_calibration_command(config),
+        expected_output=Path(config.project_root).expanduser()
+        / "calib"
+        / "calib_color.yaml",
+    )
+
+
+def build_camera_calibration_arguments(
+    config: CameraCalibrationConfig,
+) -> tuple[str, ...]:
+    """Build argv items for ``posetag-calib-charuco`` without a shell."""
+
     source = normalize_source(config.source)
     video = _video_arg(config.video_path)
     if source == SOURCE_VIDEO and video is None:
@@ -326,9 +411,11 @@ def build_camera_calibration_command(config: CameraCalibrationConfig) -> str:
             "--video path is required when --source=video"
         )
     _validate_camera_calibration_board(config)
+    coverage_grid, samples_per_cell, guided_auto_cooldown = (
+        _validate_camera_calibration_guidance(config)
+    )
 
     parts: list[str] = [
-        "posetag-calib-charuco",
         "--project_root",
         str(Path(config.project_root).expanduser()),
         "--source",
@@ -352,9 +439,193 @@ def build_camera_calibration_command(config: CameraCalibrationConfig) -> str:
             _format_number(config.marker_length_mm),
             "--dict",
             str(config.dictionary_name).strip(),
+            "--coverage-grid",
+            coverage_grid,
+            "--samples-per-cell",
+            str(samples_per_cell),
+            "--guided-auto-cooldown",
+            str(guided_auto_cooldown),
         ]
     )
-    return shlex.join(parts)
+    if not bool(config.guided_auto):
+        parts.append("--no-guided-auto")
+    return tuple(parts)
+
+
+def calibration_process_not_started(
+    expected_output: Optional[Union[Path, str]] = None,
+) -> CameraCalibrationProcessState:
+    """Return the initial calibration process state."""
+
+    return CameraCalibrationProcessState(
+        state=CALIBRATION_PROCESS_NOT_STARTED,
+        label="not started",
+        message="Calibration has not been launched from this dashboard session.",
+        expected_output=_optional_path(expected_output),
+    )
+
+
+def calibration_process_running(
+    expected_output: Union[Path, str],
+) -> CameraCalibrationProcessState:
+    """Return the active calibration process state."""
+
+    target = Path(expected_output).expanduser()
+    return CameraCalibrationProcessState(
+        state=CALIBRATION_PROCESS_RUNNING,
+        label="running",
+        message=(
+            "Calibration is running in the existing OpenCV window. Guided "
+            "auto-capture saves useful samples; SPACE manually adds a sample, "
+            "ENTER solves, and q quits."
+        ),
+        running=True,
+        expected_output=target,
+    )
+
+
+def calibration_process_failed(
+    message: str,
+    *,
+    expected_output: Optional[Union[Path, str]] = None,
+    exit_code: Optional[int] = None,
+) -> CameraCalibrationProcessState:
+    """Return a failed/cancelled calibration process state."""
+
+    return CameraCalibrationProcessState(
+        state=CALIBRATION_PROCESS_FAILED_CANCELLED,
+        label="failed/cancelled",
+        message=message,
+        expected_output=_optional_path(expected_output),
+        exit_code=exit_code,
+    )
+
+
+def summarize_camera_calibration_process_result(
+    project_root: Union[Path, str],
+    *,
+    exit_code: int,
+    crashed: bool = False,
+    expected_output: Optional[Union[Path, str]] = None,
+    previous_output_mtime_ns: Optional[int] = None,
+    require_output_update: bool = False,
+) -> CameraCalibrationProcessState:
+    """Summarize process completion using the calibration YAML status checks."""
+
+    root = Path(project_root).expanduser()
+    target = _optional_path(expected_output) or root / "calib" / "calib_color.yaml"
+    stage = inspect_camera_calibration(root)
+    output_exists = target.exists()
+    output_updated = (
+        not require_output_update
+        or _path_mtime_ns(target) != previous_output_mtime_ns
+    )
+    if (
+        exit_code == 0
+        and not crashed
+        and output_exists
+        and output_updated
+        and stage.status == WorkflowStatus.COMPLETE
+    ):
+        return CameraCalibrationProcessState(
+            state=CALIBRATION_PROCESS_FINISHED,
+            label="finished",
+            message=(
+                "Calibration finished and calib/calib_color.yaml passed the "
+                "current status checks."
+            ),
+            success=True,
+            expected_output=target,
+            exit_code=exit_code,
+        )
+
+    if crashed:
+        message = "Calibration process crashed or was cancelled."
+    elif exit_code != 0:
+        message = f"Calibration process exited with code {exit_code}."
+    elif output_exists and not output_updated:
+        message = (
+            "Calibration process exited, but calib/calib_color.yaml was not "
+            "updated during this launch."
+        )
+    else:
+        message = (
+            "Calibration process exited, but calib/calib_color.yaml is missing "
+            "or did not pass the current status checks."
+        )
+
+    detail = _process_status_detail(stage)
+    if detail:
+        message = f"{message} {detail}"
+    return calibration_process_failed(
+        message,
+        expected_output=target,
+        exit_code=exit_code,
+    )
+
+
+def inspect_camera_calibration_output(
+    project_root: Union[Path, str],
+    *,
+    expected_output: Optional[Union[Path, str]] = None,
+) -> CameraCalibrationOutputSummary:
+    """Return parsed calibration result fields for GUI/result summaries."""
+
+    root = Path(project_root).expanduser()
+    target = _optional_path(expected_output) or root / "calib" / "calib_color.yaml"
+    if not target.exists():
+        return CameraCalibrationOutputSummary(
+            path=target,
+            exists=False,
+            valid=False,
+            message=f"Calibration output is missing: {target}",
+            latest_run_dir=_latest_calibration_run_dir(root),
+        )
+
+    try:
+        data = _load_yaml_mapping(target)
+        calibration = load_calibration_yaml(target)
+    except (CameraCalibrationFlowError, MakeBoardError) as exc:
+        return CameraCalibrationOutputSummary(
+            path=target,
+            exists=True,
+            valid=False,
+            message=str(exc),
+            latest_run_dir=_latest_calibration_run_dir(root),
+        )
+
+    stage = inspect_camera_calibration(root)
+    valid = stage.status == WorkflowStatus.COMPLETE
+    message = (
+        stage.message
+        if valid
+        else (_process_status_detail(stage) or stage.message)
+    )
+    return CameraCalibrationOutputSummary(
+        path=target,
+        exists=True,
+        valid=valid,
+        message=message,
+        image_width=_optional_int(data.get("image_width")),
+        image_height=_optional_int(data.get("image_height")),
+        model=_optional_string(data.get("model")),
+        reproj_rms=_optional_float(data.get("reproj_rms")),
+        camera_params=tuple(float(value) for value in calibration.camera_params),
+        distortion_coefficients=_distortion_coefficients(data),
+        latest_run_dir=_latest_calibration_run_dir(root),
+    )
+
+
+def read_camera_calibration_yaml_text(path: Union[Path, str]) -> str:
+    """Read calibration YAML text for a raw artifact view."""
+
+    target = Path(path).expanduser()
+    try:
+        return target.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise CameraCalibrationFlowError(
+            f"Could not read calibration YAML: {exc}"
+        ) from exc
 
 
 def normalize_source(source: str) -> str:
@@ -391,8 +662,93 @@ def _latest_path(paths: tuple[Path, ...]) -> Path:
     return max(paths, key=lambda path: (path.stat().st_mtime_ns, path.name))
 
 
+def _latest_calibration_run_dir(project_root: Path) -> Optional[Path]:
+    runs_dir = project_root / "calib" / "runs"
+    if not runs_dir.is_dir():
+        return None
+    run_dirs = tuple(path for path in runs_dir.iterdir() if path.is_dir())
+    if not run_dirs:
+        return None
+    return _latest_path(run_dirs)
+
+
 def _path_tuple(paths: Iterable[Path]) -> tuple[Path, ...]:
     return tuple(dict.fromkeys(paths))
+
+
+def _optional_path(path: Optional[Union[Path, str]]) -> Optional[Path]:
+    if path is None:
+        return None
+    return Path(path).expanduser()
+
+
+def _path_mtime_ns(path: Path) -> Optional[int]:
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return None
+
+
+def _process_status_detail(stage: Any) -> str:
+    details = tuple(stage.errors or stage.warnings or (stage.message,))
+    return " ".join(str(detail) for detail in details if str(detail).strip())
+
+
+def _load_yaml_mapping(path: Path) -> Mapping[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise CameraCalibrationFlowError(
+            f"Malformed calibration YAML: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise CameraCalibrationFlowError(
+            f"Could not read calibration YAML: {exc}"
+        ) from exc
+    if not isinstance(data, Mapping):
+        raise CameraCalibrationFlowError("Calibration YAML must contain a mapping.")
+    return data
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_float(value: Any) -> Optional[float]:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed):
+        return None
+    return parsed
+
+
+def _optional_string(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    return text or None
+
+
+def _distortion_coefficients(data: Mapping[str, Any]) -> tuple[tuple[str, float], ...]:
+    distortion = data.get("distortion_coefficients")
+    if not isinstance(distortion, Mapping):
+        return ()
+    values: list[tuple[str, float]] = []
+    for name in ("k1", "k2", "p1", "p2", "k3"):
+        parsed = _optional_float(distortion.get(name))
+        if parsed is not None:
+            values.append((name, parsed))
+    return tuple(values)
 
 
 def _realsense_module_token(realsense_available: Optional[bool]) -> Any:
@@ -417,6 +773,20 @@ def _validate_camera_calibration_board(config: CameraCalibrationConfig) -> None:
     errors = _camera_calibration_board_errors(config)
     if errors:
         raise CameraCalibrationFlowError(" ".join(errors))
+
+
+def _validate_camera_calibration_guidance(
+    config: CameraCalibrationConfig,
+) -> tuple[str, int, int]:
+    errors = _camera_calibration_guidance_errors(config)
+    if errors:
+        raise CameraCalibrationFlowError(" ".join(errors))
+    rows, cols = parse_grid_shape(config.coverage_grid)
+    return (
+        f"{rows}x{cols}",
+        int(config.samples_per_cell),
+        int(config.guided_auto_cooldown),
+    )
 
 
 def _camera_calibration_board_errors(
@@ -459,6 +829,32 @@ def _camera_calibration_board_errors(
         except CharucoCalibrationError as exc:
             errors.append(str(exc))
 
+    return errors
+
+
+def _camera_calibration_guidance_errors(
+    config: CameraCalibrationConfig,
+) -> list[str]:
+    errors: list[str] = []
+    try:
+        parse_grid_shape(config.coverage_grid)
+    except ValueError as exc:
+        errors.append(str(exc))
+
+    samples_per_cell = _coerce_int(
+        config.samples_per_cell,
+        "--samples-per-cell",
+        errors,
+    )
+    guided_auto_cooldown = _coerce_int(
+        config.guided_auto_cooldown,
+        "--guided-auto-cooldown",
+        errors,
+    )
+    if samples_per_cell is not None and samples_per_cell < 1:
+        errors.append("--samples-per-cell must be at least 1.")
+    if guided_auto_cooldown is not None and guided_auto_cooldown < 0:
+        errors.append("--guided-auto-cooldown must be zero or greater.")
     return errors
 
 

--- a/src/posetag/workflows/calibration_guidance.py
+++ b/src/posetag/workflows/calibration_guidance.py
@@ -1,0 +1,572 @@
+"""State-driven guidance for ChArUco calibration capture.
+
+The helpers here are intentionally independent of OpenCV windows and Qt. They
+summarize detected ChArUco observations, accepted samples, and coverage gaps so
+the calibration UI can show deterministic guidance instead of rotating generic
+tips.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+
+
+CELL_LABELS = {
+    "top-left": "top-left corner",
+    "top-center": "top edge",
+    "top-right": "top-right corner",
+    "middle-left": "left edge",
+    "center": "center",
+    "middle-right": "right edge",
+    "bottom-left": "bottom-left corner",
+    "bottom-center": "bottom edge",
+    "bottom-right": "bottom-right corner",
+}
+DEFAULT_GRID_SHAPE = (3, 3)
+CELL_PRIORITY = (
+    "top-left",
+    "top-right",
+    "bottom-left",
+    "bottom-right",
+    "top-center",
+    "middle-left",
+    "middle-right",
+    "bottom-center",
+    "center",
+)
+SCALE_LABELS = {
+    "far": "far",
+    "medium": "medium distance",
+    "near": "close",
+}
+
+
+@dataclass(frozen=True)
+class CalibrationObservation:
+    """Measured state for one frame containing ChArUco corners."""
+
+    image_width: int
+    image_height: int
+    corner_count: int
+    center_x: float
+    center_y: float
+    min_x: float
+    min_y: float
+    max_x: float
+    max_y: float
+    area_fraction: float
+    cell: str
+    row: int
+    col: int
+    grid_shape: tuple[int, int]
+    scale_bucket: str
+    has_enough_corners: bool
+    clipped: bool
+
+
+@dataclass(frozen=True)
+class CalibrationRecommendation:
+    """User-facing next action derived from measured calibration state."""
+
+    code: str
+    message: str
+    detail: str
+    target_cell: Optional[str] = None
+    ready_to_solve: bool = False
+
+
+@dataclass(frozen=True)
+class AutoCaptureDecision:
+    """Decision for automatic capture of the current calibration frame."""
+
+    should_capture: bool
+    reason: str
+    message: str
+
+
+@dataclass(frozen=True)
+class CalibrationGuidanceState:
+    """Deterministic guidance summary for the current capture state."""
+
+    current_observation: Optional[CalibrationObservation]
+    sample_count: int
+    required_samples: int
+    grid_shape: tuple[int, int]
+    samples_per_cell: int
+    all_cells: tuple[str, ...]
+    covered_cells: tuple[str, ...]
+    missing_cells: tuple[str, ...]
+    cell_sample_counts: tuple[tuple[str, int], ...]
+    scale_buckets: tuple[str, ...]
+    recommendation: CalibrationRecommendation
+
+    @property
+    def coverage_count(self) -> int:
+        """Return the number of covered image-space grid cells."""
+
+        return len(self.covered_cells)
+
+
+def parse_grid_shape(value: object) -> tuple[int, int]:
+    """Parse a user-facing grid shape such as ``3x3`` or ``4``."""
+
+    text = str(value).strip().lower()
+    try:
+        if "x" in text:
+            left, right = text.split("x", 1)
+            rows = int(left)
+            cols = int(right)
+        else:
+            rows = cols = int(text)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "--coverage-grid must be an integer or ROWSxCOLS, for example 3x3."
+        ) from exc
+    if rows < 1 or cols < 1:
+        raise ValueError("--coverage-grid values must be positive.")
+    if rows > 9 or cols > 9:
+        raise ValueError("--coverage-grid is limited to 9x9 for readable guidance.")
+    return rows, cols
+
+
+def observation_from_charuco_corners(
+    corners: object,
+    image_size: tuple[int, int],
+    *,
+    min_corners: int,
+    grid_shape: tuple[int, int] = DEFAULT_GRID_SHAPE,
+) -> Optional[CalibrationObservation]:
+    """Summarize detected ChArUco corners as normalized frame metrics."""
+
+    if corners is None:
+        return None
+
+    width, height = int(image_size[0]), int(image_size[1])
+    if width <= 0 or height <= 0:
+        raise ValueError("image_size must contain positive width and height.")
+    grid = _normalize_grid_shape(grid_shape)
+
+    points = np.asarray(corners, dtype=float).reshape(-1, 2)
+    if points.size == 0:
+        return None
+
+    xs = points[:, 0]
+    ys = points[:, 1]
+    min_x = float(xs.min())
+    max_x = float(xs.max())
+    min_y = float(ys.min())
+    max_y = float(ys.max())
+    center_x = _clamp01(float(xs.mean()) / float(width))
+    center_y = _clamp01(float(ys.mean()) / float(height))
+    box_width = max(0.0, max_x - min_x)
+    box_height = max(0.0, max_y - min_y)
+    area_fraction = _clamp01((box_width * box_height) / float(width * height))
+    corner_count = int(points.shape[0])
+
+    row, col = _row_col_for(center_x, center_y, grid)
+    return CalibrationObservation(
+        image_width=width,
+        image_height=height,
+        corner_count=corner_count,
+        center_x=center_x,
+        center_y=center_y,
+        min_x=_clamp01(min_x / float(width)),
+        min_y=_clamp01(min_y / float(height)),
+        max_x=_clamp01(max_x / float(width)),
+        max_y=_clamp01(max_y / float(height)),
+        area_fraction=area_fraction,
+        cell=_cell_id(row, col, grid),
+        row=row,
+        col=col,
+        grid_shape=grid,
+        scale_bucket=_scale_bucket(area_fraction),
+        has_enough_corners=corner_count >= int(min_corners),
+        clipped=_is_clipped(min_x, min_y, max_x, max_y, width, height),
+    )
+
+
+def analyze_calibration_guidance(
+    current_observation: Optional[CalibrationObservation],
+    accepted_observations: Iterable[CalibrationObservation],
+    *,
+    min_samples: int,
+    grid_shape: tuple[int, int] = DEFAULT_GRID_SHAPE,
+    samples_per_cell: int = 1,
+    auto_capture: bool = False,
+) -> CalibrationGuidanceState:
+    """Return coverage state and next instruction for calibration capture."""
+
+    grid = _normalize_grid_shape(grid_shape)
+    per_cell = max(1, int(samples_per_cell))
+    all_cells = cell_priority(grid)
+    required_samples = max(10, int(min_samples), len(all_cells) * per_cell)
+    accepted = tuple(
+        observation
+        for observation in accepted_observations
+        if observation.has_enough_corners and not observation.clipped
+    )
+    counts = _cell_counts(accepted, all_cells)
+    covered_cells = tuple(cell for cell, count in counts if count >= per_cell)
+    missing_cells = tuple(
+        cell for cell, count in counts if count < per_cell
+    )
+    scale_buckets = tuple(
+        bucket
+        for bucket in ("far", "medium", "near")
+        if bucket in {obs.scale_bucket for obs in accepted}
+    )
+
+    recommendation = _recommendation(
+        current_observation=current_observation,
+        accepted=accepted,
+        missing_cells=missing_cells,
+        scale_buckets=scale_buckets,
+        required_samples=required_samples,
+        auto_capture=auto_capture,
+    )
+
+    return CalibrationGuidanceState(
+        current_observation=current_observation,
+        sample_count=len(accepted),
+        required_samples=required_samples,
+        grid_shape=grid,
+        samples_per_cell=per_cell,
+        all_cells=all_cells,
+        covered_cells=covered_cells,
+        missing_cells=missing_cells,
+        cell_sample_counts=counts,
+        scale_buckets=scale_buckets,
+        recommendation=recommendation,
+    )
+
+
+def auto_capture_decision(
+    state: CalibrationGuidanceState,
+    *,
+    cooldown_frames_remaining: int = 0,
+) -> AutoCaptureDecision:
+    """Return whether the current frame should be saved automatically."""
+
+    observation = state.current_observation
+    if observation is None:
+        return AutoCaptureDecision(False, "no_detection", "No board detected.")
+    if not observation.has_enough_corners:
+        return AutoCaptureDecision(
+            False,
+            "too_few_corners",
+            "Waiting for more detected ChArUco corners.",
+        )
+    if observation.clipped:
+        return AutoCaptureDecision(
+            False,
+            "clipped",
+            "Waiting until the board is not clipped by the frame.",
+        )
+    if cooldown_frames_remaining > 0:
+        return AutoCaptureDecision(
+            False,
+            "cooldown",
+            "Waiting briefly before another automatic sample.",
+        )
+
+    counts = dict(state.cell_sample_counts)
+    if counts.get(observation.cell, 0) < state.samples_per_cell:
+        return AutoCaptureDecision(
+            True,
+            "covers_missing_cell",
+            f"Auto-capturing coverage for {cell_label(observation.cell, state.grid_shape)}.",
+        )
+
+    if state.missing_cells:
+        return AutoCaptureDecision(
+            False,
+            "waiting_for_missing_cell",
+            "Move to an uncovered grid cell before saving another sample.",
+        )
+
+    if observation.scale_bucket not in state.scale_buckets:
+        return AutoCaptureDecision(
+            True,
+            "adds_scale_diversity",
+            "Auto-capturing this distance to improve scale diversity.",
+        )
+
+    if state.sample_count < state.required_samples:
+        balanced_target = max(
+            state.samples_per_cell,
+            math.ceil(state.required_samples / max(1, len(state.all_cells))),
+        )
+        current_count = counts.get(observation.cell, 0)
+        if current_count < balanced_target or current_count <= min(counts.values()):
+            return AutoCaptureDecision(
+                True,
+                "balances_cell_samples",
+                (
+                    "Auto-capturing another balanced view for "
+                    f"{cell_label(observation.cell, state.grid_shape)}."
+                ),
+            )
+
+    return AutoCaptureDecision(
+        False,
+        "no_new_coverage",
+        "Move to an uncovered grid cell or change distance.",
+    )
+
+
+def guidance_overlay_lines(state: CalibrationGuidanceState) -> tuple[str, ...]:
+    """Return compact lines suitable for an OpenCV overlay or GUI log."""
+
+    scales = ", ".join(SCALE_LABELS[bucket] for bucket in state.scale_buckets)
+    if not scales:
+        scales = "none yet"
+    return (
+        f"Guide: {state.recommendation.message}",
+        f"Coverage: {state.coverage_count}/{len(state.all_cells)} cells | "
+        f"Samples: {state.sample_count}/{state.required_samples}",
+        f"Scale diversity: {scales}",
+    )
+
+
+def cell_priority(grid_shape: tuple[int, int] = DEFAULT_GRID_SHAPE) -> tuple[str, ...]:
+    """Return deterministic cell traversal order for a guidance grid."""
+
+    grid = _normalize_grid_shape(grid_shape)
+    if grid == DEFAULT_GRID_SHAPE:
+        return CELL_PRIORITY
+
+    rows, cols = grid
+    cells = [_cell_id(row, col, grid) for row in range(rows) for col in range(cols)]
+    return tuple(
+        sorted(
+            cells,
+            key=lambda cell: (
+                _cell_priority_ring(cell, grid),
+                _cell_priority_corner_rank(cell, grid),
+                cell,
+            ),
+        )
+    )
+
+
+def cell_label(cell: str, grid_shape: tuple[int, int] = DEFAULT_GRID_SHAPE) -> str:
+    """Return a human-readable label for a grid cell."""
+
+    grid = _normalize_grid_shape(grid_shape)
+    if grid == DEFAULT_GRID_SHAPE and cell in CELL_LABELS:
+        return CELL_LABELS[cell]
+    row, col = _row_col_from_cell(cell, grid)
+    return f"row {row + 1}, column {col + 1}"
+
+
+def _recommendation(
+    *,
+    current_observation: Optional[CalibrationObservation],
+    accepted: Sequence[CalibrationObservation],
+    missing_cells: tuple[str, ...],
+    scale_buckets: tuple[str, ...],
+    required_samples: int,
+    auto_capture: bool,
+) -> CalibrationRecommendation:
+    if current_observation is None:
+        return CalibrationRecommendation(
+            code="searching",
+            message="Bring the ChArUco board fully into view.",
+            detail="No ChArUco corners are currently detected.",
+        )
+
+    if not current_observation.has_enough_corners:
+        return CalibrationRecommendation(
+            code="too_few_corners",
+            message="Move closer or reduce glare until more corners are detected.",
+            detail=(
+                f"Only {current_observation.corner_count} ChArUco corners are "
+                "visible in the current frame."
+            ),
+        )
+
+    if current_observation.clipped:
+        return CalibrationRecommendation(
+            code="clipped",
+            message="Move the board slightly inward so it is not clipped.",
+            detail="Detected corners are too close to the image border.",
+        )
+
+    if not accepted:
+        message = (
+            "Hold steady for automatic first sample."
+            if auto_capture
+            else "Press SPACE to save this clear first sample."
+        )
+        return CalibrationRecommendation(
+            code="first_sample",
+            message=message,
+            detail="The board is detected clearly enough to begin calibration.",
+            target_cell=current_observation.cell,
+        )
+
+    if current_observation.cell in missing_cells:
+        label = cell_label(current_observation.cell, current_observation.grid_shape)
+        message = (
+            f"Hold near the {label} for automatic capture."
+            if auto_capture
+            else f"Hold near the {label} and press SPACE."
+        )
+        return CalibrationRecommendation(
+            code="accept_target_cell",
+            message=message,
+            detail="This view covers an under-sampled part of the frame.",
+            target_cell=current_observation.cell,
+        )
+
+    if missing_cells:
+        target = missing_cells[0]
+        label = cell_label(target, current_observation.grid_shape)
+        return CalibrationRecommendation(
+            code="move_to_missing_cell",
+            message=f"Move the board toward the {label}.",
+            detail="Calibration coverage is still missing this frame region.",
+            target_cell=target,
+        )
+
+    if len(scale_buckets) < 2:
+        return _scale_recommendation(current_observation)
+
+    if len(accepted) < required_samples:
+        return CalibrationRecommendation(
+            code="collect_more",
+            message="Collect more views while varying tilt and distance.",
+            detail=(
+                "Frame coverage looks balanced, but more accepted samples are "
+                "needed before solving."
+            ),
+        )
+
+    return CalibrationRecommendation(
+        code="ready_to_solve",
+        message="Coverage looks good. Press ENTER to solve.",
+        detail="Accepted samples cover the frame with useful scale diversity.",
+        ready_to_solve=True,
+    )
+
+
+def _scale_recommendation(
+    current_observation: CalibrationObservation,
+) -> CalibrationRecommendation:
+    if current_observation.scale_bucket == "far":
+        message = "Move the board closer for a larger view."
+    elif current_observation.scale_bucket == "near":
+        message = "Move the board farther away for a smaller view."
+    else:
+        message = "Change distance: capture one closer or farther view."
+    return CalibrationRecommendation(
+        code="change_distance",
+        message=message,
+        detail="Coverage is balanced, but scale diversity is still low.",
+    )
+
+
+def _cell_counts(
+    observations: Sequence[CalibrationObservation],
+    all_cells: Sequence[str],
+) -> tuple[tuple[str, int], ...]:
+    counts = {cell: 0 for cell in all_cells}
+    for observation in observations:
+        counts[observation.cell] = counts.get(observation.cell, 0) + 1
+    return tuple((cell, counts[cell]) for cell in all_cells)
+
+
+def _row_col_for(
+    center_x: float,
+    center_y: float,
+    grid_shape: tuple[int, int],
+) -> tuple[int, int]:
+    rows, cols = grid_shape
+    col = min(cols - 1, int(_clamp01(center_x) * cols))
+    row = min(rows - 1, int(_clamp01(center_y) * rows))
+    return row, col
+
+
+def _cell_id(row: int, col: int, grid_shape: tuple[int, int]) -> str:
+    if grid_shape == DEFAULT_GRID_SHAPE:
+        row_name = ("top", "middle", "bottom")[row]
+        col_name = ("left", "center", "right")[col]
+        if row_name == "middle" and col_name == "center":
+            return "center"
+        return f"{row_name}-{col_name}"
+    return f"r{row + 1}c{col + 1}"
+
+
+def _row_col_from_cell(cell: str, grid_shape: tuple[int, int]) -> tuple[int, int]:
+    if grid_shape == DEFAULT_GRID_SHAPE:
+        if cell == "center":
+            return 1, 1
+        row_name, col_name = cell.split("-", 1)
+        return (
+            {"top": 0, "middle": 1, "bottom": 2}[row_name],
+            {"left": 0, "center": 1, "right": 2}[col_name],
+        )
+    if not (cell.startswith("r") and "c" in cell):
+        raise ValueError(f"Invalid grid cell {cell!r}.")
+    row_text, col_text = cell[1:].split("c", 1)
+    row = int(row_text) - 1
+    col = int(col_text) - 1
+    rows, cols = grid_shape
+    if row < 0 or row >= rows or col < 0 or col >= cols:
+        raise ValueError(f"Grid cell {cell!r} is outside {rows}x{cols}.")
+    return row, col
+
+
+def _cell_priority_ring(cell: str, grid_shape: tuple[int, int]) -> int:
+    row, col = _row_col_from_cell(cell, grid_shape)
+    rows, cols = grid_shape
+    return min(row, col, rows - 1 - row, cols - 1 - col)
+
+
+def _cell_priority_corner_rank(cell: str, grid_shape: tuple[int, int]) -> int:
+    row, col = _row_col_from_cell(cell, grid_shape)
+    rows, cols = grid_shape
+    corners = ((0, 0), (0, cols - 1), (rows - 1, 0), (rows - 1, cols - 1))
+    try:
+        return corners.index((row, col))
+    except ValueError:
+        return 4
+
+
+def _normalize_grid_shape(grid_shape: tuple[int, int]) -> tuple[int, int]:
+    rows, cols = int(grid_shape[0]), int(grid_shape[1])
+    if rows < 1 or cols < 1:
+        raise ValueError("grid_shape values must be positive.")
+    return rows, cols
+
+
+def _scale_bucket(area_fraction: float) -> str:
+    if area_fraction < 0.04:
+        return "far"
+    if area_fraction >= 0.16:
+        return "near"
+    return "medium"
+
+
+def _is_clipped(
+    min_x: float,
+    min_y: float,
+    max_x: float,
+    max_y: float,
+    width: int,
+    height: int,
+) -> bool:
+    return (
+        min_x <= 1.0
+        or min_y <= 1.0
+        or max_x >= float(width - 2)
+        or max_y >= float(height - 2)
+    )
+
+
+def _clamp01(value: float) -> float:
+    return min(1.0, max(0.0, value))

--- a/tests/test_step1_charuco_calibration.py
+++ b/tests/test_step1_charuco_calibration.py
@@ -53,6 +53,20 @@ class CharucoCalibrationStep1Tests(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("Colour ChArUco calibration", result.stdout)
 
+    def test_module_invocation_help_resolves_for_gui_launch(self) -> None:
+        env = os.environ.copy()
+        env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1] / "src")
+        result = subprocess.run(
+            [sys.executable, "-m", "posetag.cli.charuco", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Colour ChArUco calibration", result.stdout)
+
     def test_direct_legacy_script_help_resolves_from_checkout(self) -> None:
         result = subprocess.run(
             [sys.executable, "utils/charuco_calibrate.py", "--help"],
@@ -233,6 +247,64 @@ class CharucoCalibrationStep1Tests(unittest.TestCase):
         args = charuco_calibrate.parse_args([])
 
         self.assertEqual(args.min_corners, 4)
+
+    def test_guided_capture_arguments_validate_to_grid_shape(self) -> None:
+        args = charuco_calibrate.parse_args(
+            [
+                "--coverage-grid",
+                "4x5",
+                "--samples-per-cell",
+                "2",
+                "--guided-auto-cooldown",
+                "3",
+                "--no-guided-auto",
+            ]
+        )
+
+        charuco_calibrate._validate_guided_capture_args(args)
+
+        self.assertEqual(args.coverage_grid_shape, (4, 5))
+        self.assertEqual(args.samples_per_cell, 2)
+        self.assertEqual(args.guided_auto_cooldown, 3)
+        self.assertFalse(args.guided_auto)
+
+    def test_invalid_guided_capture_args_fail_before_project_artifacts(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            env = {
+                "HOME": str(base / "home"),
+                "XDG_CONFIG_HOME": str(base / ".config"),
+            }
+
+            with patch.dict(os.environ, env, clear=False):
+                with self.assertRaises(SystemExit) as ctx:
+                    charuco_cli.main(
+                        [
+                            "--project_root",
+                            str(project_root),
+                            "--coverage-grid",
+                            "0x3",
+                        ]
+                    )
+
+            self.assertIn("--coverage-grid values must be positive", str(ctx.exception))
+            self.assertFalse((project_root / "calib").exists())
+
+    def test_guided_minimum_samples_reflect_grid_and_samples_per_cell(self) -> None:
+        args = charuco_calibrate.parse_args(
+            [
+                "--coverage-grid",
+                "4x4",
+                "--samples-per-cell",
+                "2",
+                "--min-samples",
+                "10",
+            ]
+        )
+        charuco_calibrate._validate_guided_capture_args(args)
+
+        self.assertEqual(charuco_calibrate._minimum_required_samples(args), 32)
 
     def test_project_io_preparation_creates_calibration_layout(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/tests/test_workflow_calibration_flow.py
+++ b/tests/test_workflow_calibration_flow.py
@@ -8,16 +8,27 @@ from tempfile import TemporaryDirectory
 import yaml
 
 from posetag.workflows.calibration_flow import (
+    CALIBRATION_PROCESS_FAILED_CANCELLED,
+    CALIBRATION_PROCESS_FINISHED,
     SOURCE_OPENCV,
     SOURCE_REALSENSE,
     SOURCE_VIDEO,
     CameraCalibrationConfig,
+    build_camera_calibration_arguments,
     build_camera_calibration_command,
+    build_camera_calibration_launch,
     camera_calibration_config_from_project,
     generated_charuco_metadata_paths,
+    inspect_camera_calibration_output,
     inspect_camera_calibration_readiness,
     inspect_charuco_metadata,
     load_charuco_metadata,
+    read_camera_calibration_yaml_text,
+    summarize_camera_calibration_process_result,
+)
+from posetag.pipelines.charuco_calibration import (
+    build_calibration_yaml,
+    write_calibration_yaml,
 )
 
 
@@ -69,6 +80,66 @@ class WorkflowCalibrationFlowTests(unittest.TestCase):
         self.assertIn("--square-length-mm 25.5", command)
         self.assertIn("--marker-length-mm 18.5", command)
         self.assertIn("--dict 6X6_250", command)
+
+    def test_launch_spec_uses_current_python_module_and_argument_list(self) -> None:
+        launch = build_camera_calibration_launch(
+            CameraCalibrationConfig(
+                project_root=Path("/tmp/PoseTag project"),
+                source=SOURCE_VIDEO,
+                video_path="sample clips/calib.mp4",
+                squares_x=4,
+                squares_y=6,
+                square_length_mm=25.5,
+                marker_length_mm=18.5,
+                dictionary_name="6X6_250",
+            ),
+            python_executable="/opt/posetag/python",
+        )
+
+        self.assertEqual(launch.program, "/opt/posetag/python")
+        self.assertEqual(launch.arguments[:2], ("-m", "posetag.cli.charuco"))
+        self.assertIn("--video", launch.arguments)
+        self.assertIn("sample clips/calib.mp4", launch.arguments)
+        self.assertNotIn("posetag-calib-charuco", launch.arguments)
+        self.assertIn("posetag-calib-charuco", launch.display_command)
+        self.assertEqual(
+            launch.expected_output,
+            Path("/tmp/PoseTag project") / "calib" / "calib_color.yaml",
+        )
+
+    def test_argument_construction_returns_shell_free_argv_items(self) -> None:
+        arguments = build_camera_calibration_arguments(
+            CameraCalibrationConfig(
+                project_root="project with spaces",
+                source=SOURCE_OPENCV,
+                camera_index=3,
+            )
+        )
+
+        self.assertEqual(arguments[0:2], ("--project_root", "project with spaces"))
+        self.assertIn("--cam", arguments)
+        self.assertIn("3", arguments)
+        self.assertIn("--coverage-grid", arguments)
+        self.assertIn("3x3", arguments)
+
+    def test_argument_construction_includes_guided_capture_options(self) -> None:
+        arguments = build_camera_calibration_arguments(
+            CameraCalibrationConfig(
+                project_root="project",
+                coverage_grid="4x5",
+                samples_per_cell=2,
+                guided_auto=False,
+                guided_auto_cooldown=5,
+            )
+        )
+
+        self.assertIn("--coverage-grid", arguments)
+        self.assertIn("4x5", arguments)
+        self.assertIn("--samples-per-cell", arguments)
+        self.assertIn("2", arguments)
+        self.assertIn("--guided-auto-cooldown", arguments)
+        self.assertIn("5", arguments)
+        self.assertIn("--no-guided-auto", arguments)
 
     def test_video_command_requires_video_path(self) -> None:
         with self.assertRaisesRegex(ValueError, "--video path is required"):
@@ -122,6 +193,23 @@ class WorkflowCalibrationFlowTests(unittest.TestCase):
                 )
             )
 
+    def test_command_construction_rejects_invalid_guided_capture_options(self) -> None:
+        with self.assertRaisesRegex(ValueError, "--coverage-grid"):
+            build_camera_calibration_command(
+                CameraCalibrationConfig(
+                    project_root="project",
+                    coverage_grid="0x3",
+                )
+            )
+
+        with self.assertRaisesRegex(ValueError, "--samples-per-cell"):
+            build_camera_calibration_command(
+                CameraCalibrationConfig(
+                    project_root="project",
+                    samples_per_cell=0,
+                )
+            )
+
     def test_readiness_reports_missing_metadata_before_command(self) -> None:
         with TemporaryDirectory() as tmpdir:
             project_root = Path(tmpdir) / "project"
@@ -153,6 +241,23 @@ class WorkflowCalibrationFlowTests(unittest.TestCase):
         self.assertIn("--squares-x 3 --squares-y 5", result.command_preview)
         self.assertFalse(result.output_exists)
         self.assertIn(result.expected_output, result.checked_paths)
+
+    def test_readiness_rejects_invalid_guided_capture_options(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_metadata(project_root)
+
+            result = inspect_camera_calibration_readiness(
+                CameraCalibrationConfig(
+                    project_root=project_root,
+                    coverage_grid="bad",
+                ),
+                realsense_available=True,
+            )
+
+        self.assertFalse(result.ready)
+        self.assertEqual(result.command_preview, "")
+        self.assertTrue(any("--coverage-grid" in error for error in result.errors))
 
     def test_readiness_rejects_edited_invalid_board_lengths(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -264,6 +369,122 @@ class WorkflowCalibrationFlowTests(unittest.TestCase):
         self.assertTrue(any("squares_y" in error for error in result.errors))
         self.assertEqual(result.command_preview, "")
 
+    def test_process_result_requires_valid_calibration_yaml_for_success(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+
+            state = summarize_camera_calibration_process_result(
+                project_root,
+                exit_code=0,
+            )
+
+        self.assertEqual(state.state, CALIBRATION_PROCESS_FINISHED)
+        self.assertTrue(state.success)
+        self.assertIn("passed", state.message)
+
+    def test_process_result_does_not_treat_old_yaml_as_failed_rerun_success(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib_path = project_root / "calib" / "calib_color.yaml"
+            _write_calibration(calib_path)
+            previous_mtime = calib_path.stat().st_mtime_ns
+
+            state = summarize_camera_calibration_process_result(
+                project_root,
+                exit_code=0,
+                previous_output_mtime_ns=previous_mtime,
+                require_output_update=True,
+            )
+
+        self.assertEqual(state.state, CALIBRATION_PROCESS_FAILED_CANCELLED)
+        self.assertFalse(state.success)
+        self.assertIn("not updated", state.message)
+
+    def test_process_result_failed_when_exit_nonzero_even_with_valid_yaml(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+
+            state = summarize_camera_calibration_process_result(
+                project_root,
+                exit_code=2,
+            )
+
+        self.assertEqual(state.state, CALIBRATION_PROCESS_FAILED_CANCELLED)
+        self.assertFalse(state.success)
+        self.assertIn("code 2", state.message)
+
+    def test_process_result_failed_when_zero_exit_without_valid_yaml(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+
+            state = summarize_camera_calibration_process_result(
+                project_root,
+                exit_code=0,
+            )
+
+        self.assertEqual(state.state, CALIBRATION_PROCESS_FAILED_CANCELLED)
+        self.assertFalse(state.success)
+        self.assertIn("missing", state.message)
+
+    def test_process_result_failed_when_yaml_schema_is_invalid(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib_path = project_root / "calib" / "calib_color.yaml"
+            calib_path.parent.mkdir(parents=True)
+            calib_path.write_text("not_camera_matrix: true\n", encoding="utf-8")
+
+            state = summarize_camera_calibration_process_result(
+                project_root,
+                exit_code=0,
+            )
+
+        self.assertEqual(state.state, CALIBRATION_PROCESS_FAILED_CANCELLED)
+        self.assertFalse(state.success)
+        self.assertIn("did not pass", state.message)
+
+    def test_output_summary_parses_valid_calibration_yaml(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib_path = project_root / "calib" / "calib_color.yaml"
+            _write_calibration(calib_path)
+            run_dir = project_root / "calib" / "runs" / "2026-05-29T08-19-06Z"
+            run_dir.mkdir(parents=True)
+
+            summary = inspect_camera_calibration_output(project_root)
+
+        self.assertTrue(summary.exists)
+        self.assertTrue(summary.valid)
+        self.assertEqual(summary.path, calib_path)
+        self.assertEqual(summary.image_width, 640)
+        self.assertEqual(summary.image_height, 480)
+        self.assertEqual(summary.model, "plumb_bob")
+        self.assertEqual(summary.reproj_rms, 0.12)
+        self.assertEqual(summary.camera_params, (600.0, 610.0, 320.0, 240.0))
+        self.assertIn(("k1", 0.0), summary.distortion_coefficients)
+        self.assertEqual(summary.latest_run_dir, run_dir)
+
+    def test_output_summary_reports_missing_calibration_yaml(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+
+            summary = inspect_camera_calibration_output(project_root)
+
+        self.assertFalse(summary.exists)
+        self.assertFalse(summary.valid)
+        self.assertIn("missing", summary.message)
+
+    def test_read_calibration_yaml_text_returns_raw_artifact(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            calib_path = Path(tmpdir) / "calib_color.yaml"
+            _write_calibration(calib_path)
+
+            text = read_camera_calibration_yaml_text(calib_path)
+
+        self.assertIn("camera_matrix", text)
+        self.assertIn("reproj_rms", text)
+
 
 def _write_metadata(
     project_root: Path,
@@ -301,6 +522,22 @@ def _write_metadata(
         encoding="utf-8",
     )
     return path
+
+
+def _write_calibration(path: Path) -> None:
+    data = build_calibration_yaml(
+        image_width=640,
+        image_height=480,
+        camera_matrix=[
+            [600.0, 0.0, 320.0],
+            [0.0, 610.0, 240.0],
+            [0.0, 0.0, 1.0],
+        ],
+        distortion_coefficients=[[0.0, 0.0, 0.0, 0.0, 0.0]],
+        reproj_rms=0.12,
+        notes="Synthetic calibration for process-state tests.",
+    )
+    write_calibration_yaml(path, data)
 
 
 if __name__ == "__main__":

--- a/tests/test_workflow_calibration_guidance.py
+++ b/tests/test_workflow_calibration_guidance.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from posetag.workflows.calibration_guidance import (
+    CELL_PRIORITY,
+    analyze_calibration_guidance,
+    auto_capture_decision,
+    cell_label,
+    guidance_overlay_lines,
+    observation_from_charuco_corners,
+    parse_grid_shape,
+)
+
+
+class CalibrationGuidanceTests(unittest.TestCase):
+    def test_observation_maps_corners_to_cell_and_scale_bucket(self) -> None:
+        observation = _observation(0.5, 0.5, size=0.28)
+
+        self.assertIsNotNone(observation)
+        assert observation is not None
+        self.assertEqual(observation.cell, "center")
+        self.assertEqual(observation.scale_bucket, "medium")
+        self.assertTrue(observation.has_enough_corners)
+        self.assertFalse(observation.clipped)
+        self.assertAlmostEqual(observation.center_x, 0.5)
+        self.assertAlmostEqual(observation.center_y, 0.5)
+
+    def test_no_detection_prompts_user_to_bring_board_into_view(self) -> None:
+        state = analyze_calibration_guidance(
+            None,
+            (),
+            min_samples=30,
+        )
+
+        self.assertEqual(state.recommendation.code, "searching")
+        self.assertIn("fully into view", state.recommendation.message)
+
+    def test_too_few_corners_prompts_closer_or_better_lighting(self) -> None:
+        observation = observation_from_charuco_corners(
+            _corners(0.5, 0.5, size=0.28, count=3),
+            (900, 900),
+            min_corners=4,
+        )
+
+        state = analyze_calibration_guidance(
+            observation,
+            (),
+            min_samples=30,
+        )
+
+        self.assertEqual(state.recommendation.code, "too_few_corners")
+        self.assertIn("Move closer", state.recommendation.message)
+
+    def test_first_clear_view_prompts_first_sample(self) -> None:
+        current = _observation(0.5, 0.5)
+
+        state = analyze_calibration_guidance(
+            current,
+            (),
+            min_samples=30,
+        )
+
+        self.assertEqual(state.recommendation.code, "first_sample")
+        self.assertIn("Press SPACE", state.recommendation.message)
+
+    def test_guided_auto_changes_first_sample_prompt(self) -> None:
+        current = _observation(0.5, 0.5)
+
+        state = analyze_calibration_guidance(
+            current,
+            (),
+            min_samples=30,
+            auto_capture=True,
+        )
+
+        self.assertEqual(state.recommendation.code, "first_sample")
+        self.assertIn("automatic", state.recommendation.message)
+
+    def test_missing_frame_region_drives_specific_next_prompt(self) -> None:
+        accepted = (_observation(0.5, 0.5),)
+        current = _observation(0.5, 0.5)
+
+        state = analyze_calibration_guidance(
+            current,
+            accepted,
+            min_samples=30,
+        )
+
+        self.assertEqual(state.recommendation.code, "move_to_missing_cell")
+        self.assertEqual(state.recommendation.target_cell, "top-left")
+        self.assertIn("top-left corner", state.recommendation.message)
+
+    def test_current_missing_region_prompts_user_to_accept_sample(self) -> None:
+        accepted = (_observation(0.5, 0.5),)
+        current = _observation(0.16, 0.16)
+
+        state = analyze_calibration_guidance(
+            current,
+            accepted,
+            min_samples=30,
+        )
+
+        self.assertEqual(state.recommendation.code, "accept_target_cell")
+        self.assertEqual(state.recommendation.target_cell, "top-left")
+        self.assertIn("press SPACE", state.recommendation.message)
+
+    def test_balanced_coverage_but_low_scale_diversity_prompts_distance_change(self) -> None:
+        accepted = tuple(_observation_for_cell(cell, size=0.28) for cell in CELL_PRIORITY)
+        current = _observation(0.5, 0.5, size=0.28)
+
+        state = analyze_calibration_guidance(
+            current,
+            accepted,
+            min_samples=9,
+        )
+
+        self.assertEqual(state.coverage_count, 9)
+        self.assertEqual(state.recommendation.code, "change_distance")
+        self.assertIn("distance", state.recommendation.message)
+
+    def test_balanced_samples_and_scale_diversity_mark_ready_to_solve(self) -> None:
+        accepted = [
+            *(_observation_for_cell(cell, size=0.28) for cell in CELL_PRIORITY),
+            _observation(0.5, 0.5, size=0.45),
+        ]
+        current = _observation(0.5, 0.5, size=0.45)
+
+        state = analyze_calibration_guidance(
+            current,
+            accepted,
+            min_samples=10,
+        )
+
+        self.assertEqual(state.coverage_count, 9)
+        self.assertEqual(state.sample_count, 10)
+        self.assertTrue(state.recommendation.ready_to_solve)
+        self.assertIn("Press ENTER", state.recommendation.message)
+
+    def test_overlay_lines_include_coverage_samples_and_recommendation(self) -> None:
+        current = _observation(0.5, 0.5)
+        state = analyze_calibration_guidance(
+            current,
+            (),
+            min_samples=30,
+        )
+
+        lines = guidance_overlay_lines(state)
+
+        self.assertEqual(len(lines), 3)
+        self.assertIn("Guide:", lines[0])
+        self.assertIn("Coverage: 0/9", lines[1])
+        self.assertIn("Samples: 0/30", lines[1])
+
+    def test_parse_grid_shape_accepts_square_and_rectangular_values(self) -> None:
+        self.assertEqual(parse_grid_shape("4"), (4, 4))
+        self.assertEqual(parse_grid_shape("4x5"), (4, 5))
+
+    def test_parse_grid_shape_rejects_invalid_values(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ROWSxCOLS"):
+            parse_grid_shape("wide")
+        with self.assertRaisesRegex(ValueError, "positive"):
+            parse_grid_shape("0x3")
+
+    def test_non_default_grid_maps_observation_to_generic_cell(self) -> None:
+        observation = observation_from_charuco_corners(
+            _corners(0.75, 0.25, size=0.12),
+            (900, 900),
+            min_corners=4,
+            grid_shape=(4, 4),
+        )
+
+        self.assertIsNotNone(observation)
+        assert observation is not None
+        self.assertEqual(observation.cell, "r2c4")
+        self.assertEqual(observation.row, 1)
+        self.assertEqual(observation.col, 3)
+        self.assertEqual(cell_label(observation.cell, (4, 4)), "row 2, column 4")
+
+    def test_samples_per_cell_controls_coverage_completion(self) -> None:
+        current = _observation(0.5, 0.5)
+        accepted = (_observation(0.5, 0.5),)
+
+        state = analyze_calibration_guidance(
+            current,
+            accepted,
+            min_samples=10,
+            samples_per_cell=2,
+        )
+
+        self.assertNotIn("center", state.covered_cells)
+        self.assertIn("center", state.missing_cells)
+
+    def test_auto_capture_accepts_current_undercovered_cell(self) -> None:
+        current = _observation(0.5, 0.5)
+        state = analyze_calibration_guidance(
+            current,
+            (),
+            min_samples=30,
+            auto_capture=True,
+        )
+
+        decision = auto_capture_decision(state)
+
+        self.assertTrue(decision.should_capture)
+        self.assertEqual(decision.reason, "covers_missing_cell")
+
+    def test_auto_capture_respects_cooldown(self) -> None:
+        current = _observation(0.5, 0.5)
+        state = analyze_calibration_guidance(
+            current,
+            (),
+            min_samples=30,
+            auto_capture=True,
+        )
+
+        decision = auto_capture_decision(state, cooldown_frames_remaining=3)
+
+        self.assertFalse(decision.should_capture)
+        self.assertEqual(decision.reason, "cooldown")
+
+    def test_auto_capture_waits_for_missing_cells_before_extra_samples(self) -> None:
+        current = _observation(0.5, 0.5)
+        state = analyze_calibration_guidance(
+            current,
+            (_observation(0.5, 0.5),),
+            min_samples=30,
+            auto_capture=True,
+        )
+
+        decision = auto_capture_decision(state)
+
+        self.assertFalse(decision.should_capture)
+        self.assertEqual(decision.reason, "waiting_for_missing_cell")
+
+    def test_auto_capture_adds_scale_diversity_after_coverage(self) -> None:
+        accepted = tuple(_observation_for_cell(cell, size=0.28) for cell in CELL_PRIORITY)
+        current = _observation(0.5, 0.5, size=0.45)
+        state = analyze_calibration_guidance(
+            current,
+            accepted,
+            min_samples=9,
+            auto_capture=True,
+        )
+
+        decision = auto_capture_decision(state)
+
+        self.assertTrue(decision.should_capture)
+        self.assertEqual(decision.reason, "adds_scale_diversity")
+
+    def test_auto_capture_balances_samples_until_required_count(self) -> None:
+        accepted = [
+            *(_observation_for_cell(cell, size=0.28) for cell in CELL_PRIORITY),
+            _observation(0.5, 0.5, size=0.45),
+        ]
+        current = _observation(0.5, 0.5, size=0.45)
+        state = analyze_calibration_guidance(
+            current,
+            accepted,
+            min_samples=30,
+            auto_capture=True,
+        )
+
+        decision = auto_capture_decision(state)
+
+        self.assertTrue(decision.should_capture)
+        self.assertEqual(decision.reason, "balances_cell_samples")
+
+
+def _observation(
+    center_x: float,
+    center_y: float,
+    *,
+    size: float = 0.28,
+):
+    return observation_from_charuco_corners(
+        _corners(center_x, center_y, size=size),
+        (900, 900),
+        min_corners=4,
+    )
+
+
+def _observation_for_cell(cell: str, *, size: float = 0.28):
+    centers = {
+        "top-left": (0.16, 0.16),
+        "top-center": (0.5, 0.16),
+        "top-right": (0.84, 0.16),
+        "middle-left": (0.16, 0.5),
+        "center": (0.5, 0.5),
+        "middle-right": (0.84, 0.5),
+        "bottom-left": (0.16, 0.84),
+        "bottom-center": (0.5, 0.84),
+        "bottom-right": (0.84, 0.84),
+    }
+    center = centers[cell]
+    return _observation(center[0], center[1], size=size)
+
+
+def _corners(
+    center_x: float,
+    center_y: float,
+    *,
+    size: float,
+    count: int = 4,
+):
+    half = size / 2.0
+    points = [
+        (center_x - half, center_y - half),
+        (center_x + half, center_y - half),
+        (center_x - half, center_y + half),
+        (center_x + half, center_y + half),
+        (center_x, center_y - half),
+        (center_x + half, center_y),
+    ][:count]
+    return np.asarray(
+        [[[x * 900.0, y * 900.0]] for x, y in points],
+        dtype=np.float32,
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_gui.py
+++ b/tests/test_workflow_gui.py
@@ -22,6 +22,10 @@ from posetag.gui.main_window import (
     _command_card_title,
     _command_ready_message,
     _copy_confirmation_message,
+    _calibration_run_button_label,
+    _format_calibration_result_summary,
+    _format_calibration_result_summary_html,
+    _format_calibration_process_state,
     _format_charuco_outputs,
     _format_health_counts,
     _health_status_style,
@@ -34,6 +38,11 @@ from posetag.gui.main_window import (
     _stage_rail_number_style,
     _stage_status_chip_style,
     _style_sheet,
+)
+from posetag.workflows.calibration_flow import (
+    CameraCalibrationOutputSummary,
+    calibration_process_not_started,
+    calibration_process_running,
 )
 from posetag.gui.models import inspect_project_view, project_health_view
 from posetag.workflows.commands import command_preview
@@ -306,8 +315,12 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertIn("QFrame#HeaderPanel", style)
         self.assertIn("QFrame#RailPanel", style)
         self.assertIn("QFrame#HealthPanel", style)
+        self.assertIn("QScrollArea#HealthScroll", style)
+        self.assertIn("background: #f2f7fb", style)
+        self.assertIn("background: #f6fafc", style)
         self.assertIn("QLabel#StageTitle", style)
         self.assertIn("QLineEdit#CommandPreview", style)
+        self.assertIn("QPlainTextEdit#CalibrationLog", style)
         self.assertIn("QLabel#HealthMessage", style)
         self.assertIn("QLabel#HealthSectionTitle", style)
         self.assertIn("QLabel#HealthSectionBody", style)
@@ -316,6 +329,7 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertIn("QLabel#RailStageDot", style)
         self.assertIn("QLabel#RailStageStatus", style)
         self.assertIn("QLabel#CharucoPreviewCanvas", style)
+        self.assertIn("QPlainTextEdit#CalibrationYamlView", style)
         self.assertIn("monospace", style)
         self.assertIn("font-weight: 800", style)
         self.assertIn("border-left: 3px solid #54708a", style)
@@ -335,6 +349,52 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertIn("PNG:    board.png", summary)
         self.assertIn("YAML:   board.yaml", summary)
         self.assertIn("PDF:    not requested", summary)
+
+    def test_calibration_process_state_text_and_run_button_labels(self) -> None:
+        expected_output = Path("/tmp/project/calib/calib_color.yaml")
+        idle = calibration_process_not_started(expected_output)
+        running = calibration_process_running(expected_output)
+
+        self.assertEqual(_calibration_run_button_label(idle), "Run Calibration")
+        self.assertEqual(
+            _calibration_run_button_label(running),
+            "Calibration Running...",
+        )
+        self.assertIn("not started", _format_calibration_process_state(idle))
+        self.assertIn("Expected output:", _format_calibration_process_state(idle))
+        self.assertIn("Guided auto-capture", _format_calibration_process_state(running))
+
+    def test_calibration_result_summary_is_human_readable(self) -> None:
+        summary = CameraCalibrationOutputSummary(
+            path=Path("/tmp/project/calib/calib_color.yaml"),
+            exists=True,
+            valid=True,
+            message="Colour-camera calibration YAML exists and passed schema checks.",
+            image_width=640,
+            image_height=480,
+            model="plumb_bob",
+            reproj_rms=0.1234,
+            camera_params=(600.0, 610.0, 320.0, 240.0),
+            distortion_coefficients=(("k1", -0.1), ("k2", 0.02)),
+            latest_run_dir=Path("/tmp/project/calib/runs/2026-05-29T08-19-06Z"),
+        )
+
+        text = _format_calibration_result_summary(summary)
+
+        self.assertIn("Calibration valid", text)
+        self.assertIn("640 x 480", text)
+        self.assertIn("RMS", text)
+        self.assertIn("0.123 px", text)
+        self.assertIn("fx=600.000", text)
+        self.assertIn("k1=-0.1", text)
+        self.assertIn("Run snapshot", text)
+
+        html = _format_calibration_result_summary_html(summary)
+
+        self.assertIn("font-family", html)
+        self.assertIn("Menlo", html)
+        self.assertIn("fx=600.000", html)
+        self.assertIn("Calibration valid", html)
 
     def test_health_panel_counts_and_status_are_compact(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/utils/charuco_calibrate.py
+++ b/utils/charuco_calibrate.py
@@ -66,6 +66,13 @@ try:
         validate_capture_args,
         write_calibration_yaml,
     )
+    from posetag.workflows.calibration_guidance import (  # type: ignore
+        analyze_calibration_guidance,
+        auto_capture_decision,
+        guidance_overlay_lines,
+        observation_from_charuco_corners,
+        parse_grid_shape,
+    )
 except ModuleNotFoundError:
     _ensure_checkout_import_paths()
     from posetag.pipelines.charuco_calibration import (  # type: ignore
@@ -75,6 +82,13 @@ except ModuleNotFoundError:
         prepare_project_io,
         validate_capture_args,
         write_calibration_yaml,
+    )
+    from posetag.workflows.calibration_guidance import (  # type: ignore
+        analyze_calibration_guidance,
+        auto_capture_decision,
+        guidance_overlay_lines,
+        observation_from_charuco_corners,
+        parse_grid_shape,
     )
 
 
@@ -89,9 +103,11 @@ def build_parser():
         formatter_class=_HelpFmt,
         epilog=(
             "Controls:\n"
-            "  SPACE  add sample    ENTER  solve    q  quit\n\n"
+            "  SPACE  add manual sample    ENTER  solve    q  quit\n\n"
             "Tips:\n"
             "  - Print the board at 100% and pass correct --square-length-mm / --marker-length-mm.\n"
+            "  - Guided auto-capture saves samples as you cover frame grid cells.\n"
+            "  - Follow the preview guidance to cover frame edges/corners and vary distance.\n"
             "  - For OpenCV webcams, requested --width/--height are best-effort; the YAML records actual size."
         ),
     )
@@ -112,7 +128,16 @@ def build_parser():
     ap.add_argument("--min-corners", type=int, default=4,
                     help="min ChArUco corners per sample; values below 4 are promoted to 4")
     ap.add_argument("--min-samples", type=int, default=30, help="min accepted samples before solve")
-    ap.add_argument("--auto", action="store_true")
+    ap.add_argument("--guided-auto", action=argparse.BooleanOptionalAction, default=True,
+                    help="Automatically save good frames that improve guided coverage.")
+    ap.add_argument("--coverage-grid", type=str, default="3x3",
+                    help="Frame coverage grid for guided capture, e.g. 3x3 or 4x4.")
+    ap.add_argument("--samples-per-cell", type=int, default=1,
+                    help="Minimum accepted samples required in each coverage grid cell.")
+    ap.add_argument("--guided-auto-cooldown", type=int, default=8,
+                    help="Frames to wait after a guided automatic sample.")
+    ap.add_argument("--auto", action="store_true",
+                    help="Legacy timed auto-sampling fallback; guided auto is preferred.")
     ap.add_argument("--auto-interval", type=int, default=10)
     ap.add_argument("--source", choices=["opencv", "realsense", "video"], default="opencv",
                     help="Camera source: generic OpenCV webcam (default), Intel RealSense, or a video file")
@@ -267,9 +292,162 @@ def calibrate_from_charuco(samples_corners, samples_ids, board, image_size):
     return rms, K, dist, rvecs, tvecs
 
 
+def _draw_guidance_overlay(vis, guidance_state):
+    """Render state-driven calibration guidance in the OpenCV preview."""
+
+    y = 120
+    for line in guidance_overlay_lines(guidance_state):
+        cv2.putText(
+            vis,
+            line[:92],
+            (20, y),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.55,
+            (255, 255, 255),
+            3,
+        )
+        cv2.putText(
+            vis,
+            line[:92],
+            (20, y),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.55,
+            (20, 60, 20),
+            1,
+        )
+        y += 26
+
+    _draw_guidance_grid(vis, guidance_state)
+
+
+def _draw_guidance_grid(vis, guidance_state):
+    height, width = vis.shape[:2]
+    rows, cols = guidance_state.grid_shape
+    longest_side = max(rows, cols)
+    cell_size = max(16, min(28, int(min(width, height) * 0.2 / longest_side)))
+    grid_width = cell_size * cols
+    x0 = max(20, width - grid_width - 20)
+    y0 = 20
+    covered = set(guidance_state.covered_cells)
+    target = guidance_state.recommendation.target_cell
+    current = (
+        guidance_state.current_observation.cell
+        if guidance_state.current_observation is not None
+        else None
+    )
+
+    for cell in guidance_state.all_cells:
+        row, col = _guidance_cell_row_col(cell, guidance_state.grid_shape)
+        x1 = x0 + col * cell_size
+        y1 = y0 + row * cell_size
+        x2 = x1 + cell_size
+        y2 = y1 + cell_size
+        if cell in covered:
+            cv2.rectangle(vis, (x1 + 2, y1 + 2), (x2 - 2, y2 - 2), (0, 80, 35), -1)
+        if cell == target:
+            color = (0, 220, 255)
+            thickness = 2
+        elif cell == current:
+            color = (255, 180, 0)
+            thickness = 2
+        elif cell in covered:
+            color = (0, 170, 70)
+            thickness = 1
+        else:
+            color = (150, 150, 150)
+            thickness = 1
+        cv2.rectangle(vis, (x1, y1), (x2, y2), color, thickness)
+
+
+def _guidance_cell_row_col(cell: str, grid_shape: tuple[int, int]) -> tuple[int, int]:
+    if grid_shape == (3, 3) and cell == "center":
+        return 1, 1
+    if grid_shape == (3, 3) and "-" in cell:
+        row_name, col_name = cell.split("-", 1)
+        row = {"top": 0, "middle": 1, "bottom": 2}[row_name]
+        col = {"left": 0, "center": 1, "right": 2}[col_name]
+        return row, col
+    if cell.startswith("r") and "c" in cell:
+        row_text, col_text = cell[1:].split("c", 1)
+        return int(row_text) - 1, int(col_text) - 1
+    raise ValueError(f"Unsupported guidance cell: {cell}")
+
+
+def _guidance_observation(ch_corners, args):
+    return observation_from_charuco_corners(
+        ch_corners,
+        (int(args.width), int(args.height)),
+        min_corners=int(args.min_corners),
+        grid_shape=args.coverage_grid_shape,
+    )
+
+
+def _validate_guided_capture_args(args) -> None:
+    try:
+        args.coverage_grid_shape = parse_grid_shape(args.coverage_grid)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if args.samples_per_cell < 1:
+        raise SystemExit("--samples-per-cell must be at least 1.")
+    if args.guided_auto_cooldown < 0:
+        raise SystemExit("--guided-auto-cooldown must be zero or greater.")
+
+
+def _minimum_required_samples(args) -> int:
+    rows, cols = args.coverage_grid_shape
+    return max(10, int(args.min_samples), rows * cols * int(args.samples_per_cell))
+
+
+def _save_calibration_sample(
+    *,
+    ch_corners,
+    ch_ids,
+    color,
+    images_dir: Path,
+    samples_corners: list,
+    samples_ids: list,
+    saved_images: list[str],
+    guidance_observation,
+    guidance_observations: list,
+    accepted_guidance_samples: list[dict],
+    reason: str,
+    label: str,
+) -> Path:
+    samples_corners.append(ch_corners.copy())
+    samples_ids.append(ch_ids.copy())
+    if guidance_observation is not None:
+        guidance_observations.append(guidance_observation)
+
+    sample_index = len(samples_corners)
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S_%f")
+    img_filename = images_dir / f"calib_{ts}_{sample_index:03d}.png"
+    cv2.imwrite(str(img_filename), color)
+    saved_images.append(str(img_filename))
+
+    record = {
+        "index": sample_index,
+        "file": str(img_filename),
+        "reason": reason,
+        "auto": reason != "manual",
+        "corner_count": int(len(ch_corners)),
+    }
+    if guidance_observation is not None:
+        record.update(
+            cell=guidance_observation.cell,
+            row=int(guidance_observation.row) + 1,
+            col=int(guidance_observation.col) + 1,
+            grid=list(guidance_observation.grid_shape),
+            scale_bucket=guidance_observation.scale_bucket,
+        )
+    accepted_guidance_samples.append(record)
+    print(f"[+] {label} {sample_index} ({len(ch_corners)} corners) -> {img_filename}")
+    return img_filename
+
+
 def main(argv=None):
     """CLI entry point: capture frames, collect ChArUco corners, calibrate, and write YAML."""
     args = parse_args(argv)
+    _validate_guided_capture_args(args)
 
     try:
         validate_capture_args(args.source, args.video, rs)
@@ -307,10 +485,19 @@ def main(argv=None):
 
     # ----- Capture loop -----
     samples_corners, samples_ids = [], []
+    guidance_observations = []
+    accepted_guidance_samples: list[dict] = []
     saved_images: list[str] = []
     auto_tick = 0
+    guided_auto_cooldown = 0
 
-    print("[i] Move/tilt the board; SPACE=add, ENTER=solve, q=quit")
+    if args.guided_auto:
+        print(
+            "[i] Guided auto-capture is on; move the board through highlighted "
+            "grid cells. SPACE=manual add, ENTER=solve, q=quit"
+        )
+    else:
+        print("[i] Move the board around the frame; SPACE=add, ENTER=solve, q=quit")
     try:
         first = True
         while True:
@@ -350,40 +537,112 @@ def main(argv=None):
                 aruco.drawDetectedCornersCharuco(vis, ch_corners, ch_ids)
 
             good = ch_corners is not None and ch_ids is not None and len(ch_corners) >= args.min_corners
+            guidance_observation = _guidance_observation(ch_corners, args)
+            guidance_state = analyze_calibration_guidance(
+                guidance_observation,
+                guidance_observations,
+                min_samples=args.min_samples,
+                grid_shape=args.coverage_grid_shape,
+                samples_per_cell=args.samples_per_cell,
+                auto_capture=args.guided_auto,
+            )
+            guided_decision = (
+                auto_capture_decision(
+                    guidance_state,
+                    cooldown_frames_remaining=guided_auto_cooldown,
+                )
+                if args.guided_auto
+                else None
+            )
             cv2.putText(vis, f"samples={len(samples_corners)}", (20, 40),
                         cv2.FONT_HERSHEY_SIMPLEX, 1, (0, 255, 255), 2)
             cv2.putText(vis, "BOARD: OK" if good else "BOARD: not ready", (20, 80),
                         cv2.FONT_HERSHEY_SIMPLEX, 0.9, (0, 200, 0) if good else (0, 0, 255), 2)
+            _draw_guidance_overlay(vis, guidance_state)
             cv2.imshow("ChArUco Calibration", vis)
             k = cv2.waitKey(1) & 0xFF
 
-            if args.auto and good:
-                auto_tick += 1
-                if auto_tick % args.auto_interval == 0:
-                    samples_corners.append(ch_corners.copy()); samples_ids.append(ch_ids.copy())
-                    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-                    img_filename = images_dir / f"calib_{ts}.png"
-                    cv2.imwrite(str(img_filename), color); saved_images.append(str(img_filename))
-                    print(f"[+] auto sample {len(samples_corners)} ({len(ch_corners)} corners) -> {img_filename}")
-            elif k == ord(' '):
-                if good:
-                    samples_corners.append(ch_corners.copy()); samples_ids.append(ch_ids.copy())
-                    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-                    img_filename = images_dir / f"calib_{ts}.png"
-                    cv2.imwrite(str(img_filename), color); saved_images.append(str(img_filename))
-                    print(f"[+] sample {len(samples_corners)} ({len(ch_corners)} corners) -> {img_filename}")
-                else:
-                    print("[!] not enough corners; get closer / reduce glare / tilt more.")
-            elif k == 13:
+            if k == 13:
                 break
-            elif k == ord('q'):
+            if k == ord('q'):
                 print("[i] quit requested; exiting without calibration.")
                 return 0
+
+            saved_sample = False
+            if k == ord(' '):
+                if good:
+                    _save_calibration_sample(
+                        ch_corners=ch_corners,
+                        ch_ids=ch_ids,
+                        color=color,
+                        images_dir=images_dir,
+                        samples_corners=samples_corners,
+                        samples_ids=samples_ids,
+                        saved_images=saved_images,
+                        guidance_observation=guidance_observation,
+                        guidance_observations=guidance_observations,
+                        accepted_guidance_samples=accepted_guidance_samples,
+                        reason="manual",
+                        label="sample",
+                    )
+                    saved_sample = True
+                else:
+                    print("[!] not enough corners; get closer / reduce glare / tilt more.")
+            elif good and guided_decision is not None and guided_decision.should_capture:
+                _save_calibration_sample(
+                    ch_corners=ch_corners,
+                    ch_ids=ch_ids,
+                    color=color,
+                    images_dir=images_dir,
+                    samples_corners=samples_corners,
+                    samples_ids=samples_ids,
+                    saved_images=saved_images,
+                    guidance_observation=guidance_observation,
+                    guidance_observations=guidance_observations,
+                    accepted_guidance_samples=accepted_guidance_samples,
+                    reason=guided_decision.reason,
+                    label="guided sample",
+                )
+                guided_auto_cooldown = args.guided_auto_cooldown
+                saved_sample = True
+            elif args.auto and good:
+                auto_tick += 1
+                if auto_tick % args.auto_interval == 0:
+                    _save_calibration_sample(
+                        ch_corners=ch_corners,
+                        ch_ids=ch_ids,
+                        color=color,
+                        images_dir=images_dir,
+                        samples_corners=samples_corners,
+                        samples_ids=samples_ids,
+                        saved_images=saved_images,
+                        guidance_observation=guidance_observation,
+                        guidance_observations=guidance_observations,
+                        accepted_guidance_samples=accepted_guidance_samples,
+                        reason="legacy_timed_auto",
+                        label="auto sample",
+                    )
+                    saved_sample = True
+
+            if saved_sample:
+                if args.guided_auto:
+                    guided_auto_cooldown = args.guided_auto_cooldown
+                next_guidance = analyze_calibration_guidance(
+                    guidance_observation,
+                    guidance_observations,
+                    min_samples=args.min_samples,
+                    grid_shape=args.coverage_grid_shape,
+                    samples_per_cell=args.samples_per_cell,
+                    auto_capture=args.guided_auto,
+                )
+                print(f"[guide] {next_guidance.recommendation.message}")
+            elif guided_auto_cooldown > 0:
+                guided_auto_cooldown -= 1
     finally:
         _stop()
         cv2.destroyAllWindows()
 
-    need = max(10, args.min_samples)
+    need = _minimum_required_samples(args)
     if len(samples_corners) < need:
         raise SystemExit(f"Need at least {need} good samples; got {len(samples_corners)}.")
 
@@ -400,9 +659,9 @@ def main(argv=None):
     print(f"[i] using {len(filtered_corners)}/{len(samples_corners)} samples "
           f"(dropped {len(samples_corners) - len(filtered_corners)} < {REQUIRED} corners)")
 
-    if len(filtered_corners) < max(10, args.min_samples):
+    if len(filtered_corners) < need:
         raise SystemExit(f"Not enough valid samples after filtering: "
-                         f"{len(filtered_corners)} < {max(10, args.min_samples)}")
+                         f"{len(filtered_corners)} < {need}")
 
     img_size = (args.width, args.height)
     ret, K, dist, rvecs, tvecs = calibrate_from_charuco(
@@ -440,8 +699,14 @@ def main(argv=None):
         board=dict(squares_x=args.squares_x, squares_y=args.squares_y,
                    square_length_mm=args.square_length_mm, marker_length_mm=args.marker_length_mm,
                    dict=args.dict),
-        thresholds=dict(min_corners=args.min_corners, min_samples=args.min_samples, auto=args.auto,
+        thresholds=dict(min_corners=args.min_corners, min_samples=args.min_samples,
+                        required_samples=need, auto=args.auto,
                         auto_interval=args.auto_interval),
+        guidance=dict(coverage_grid=list(args.coverage_grid_shape),
+                      samples_per_cell=args.samples_per_cell,
+                      guided_auto=args.guided_auto,
+                      guided_auto_cooldown=args.guided_auto_cooldown,
+                      accepted_samples=accepted_guidance_samples),
         image_size=dict(width=args.width, height=args.height),
         samples=dict(count=len(saved_images), files=saved_images),
         reproj_rms=float(ret),


### PR DESCRIPTION
Closes #60.

This PR adds the Stage 2 GUI launch path for the existing `posetag-calib-charuco` workflow while keeping calibration capture, ChArUco detection, solving, and YAML writing in the existing engine. It also adds state-driven guided auto-capture inside the OpenCV calibration workflow so users are directed through frame coverage instead of collecting arbitrary samples.

Summary:
- Add a Stage 2 `Run Calibration` action backed by `QProcess` argument lists and an editable-install-safe `python -m posetag.cli.charuco` launch path.
- Preserve the copy-command fallback, process state display, stdout/stderr log, output polling, and success based on valid `calib/calib_color.yaml` status/schema checks.
- Add deterministic calibration guidance helpers in `posetag.workflows`, including configurable coverage grids, samples-per-cell, scale-diversity prompts, and coverage-gated auto-capture decisions.
- Render guidance, sample counts, and coverage cells in the existing OpenCV calibration window while preserving `SPACE`, `ENTER`, and `q` controls.
- Add a Stage 2 calibration-result side panel that summarizes the validated YAML, with raw YAML available through explicit open/view actions.
- Document manual hardware-dependent testing and create follow-up issue #61 for a future native Qt calibration canvas rather than embedding the OpenCV window.

Validation:
- `python3 -m unittest discover -s tests -v`
- `python3 -m compileall -q src utils tests`
- `git diff --check`

Residual risks / manual checks:
- PySide6 is not installed in this local environment, so I could not smoke-open the actual Qt window here. Hardware-free GUI/helper tests passed.
- Live camera behavior still needs manual validation with a physical ChArUco board, including the OpenCV preview, guided auto-capture, process log streaming, and status refresh after `calib/calib_color.yaml` appears.
- Native in-app camera/video rendering is intentionally deferred to #61; this PR does not dock or embed the OpenCV HighGUI window.