### PR TITLE
Validate capture-face workflow outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,12 +525,18 @@ Faces may use different tag sizes; each face YAML stores its own `tag_size_m`.
 
 Once per-face boards and the tag registry exist, the next step is to capture
 wide shots of each face with detections overlaid. These images and metadata are
-later used to solve the board-to-object transform.
+later used to solve the board-to-object transform. This step records reference
+images and provenance only; annotation, board-to-object transforms, dataset
+collection, and pose estimation happen later.
+
+Detailed workflow notes: [`docs/workflows/step3_capture_face.md`](docs/workflows/step3_capture_face.md)
 
 **Quick start**
 
 ```bash
-posetag-capture-face --object_name connection_plate_white
+posetag-capture-face --project_root my_project \
+  --source opencv --cam 0 \
+  --object_name connection_plate_white
 # Optional UI sizing
 #   --panel_w 560
 #   --recent_w 480
@@ -542,9 +548,13 @@ posetag-capture-face --object_name connection_plate_white
 **Other sources**
 
 ```bash
+posetag-capture-face --project_root my_project --source realsense --object_name connection_plate_white
 posetag-capture-face --source opencv --cam 0 --object_name connection_plate_white
 posetag-capture-face --source video --video sample.mp4 --object_name connection_plate_white
 ```
+
+The command's legacy default source is `realsense`; use `--source opencv` for a
+regular USB webcam or laptop camera.
 
 **Notes**
 
@@ -553,10 +563,16 @@ posetag-capture-face --source video --video sample.mp4 --object_name connection_
 - `--manifest` appends rows to `<root>/shots/manifest.csv`
 - `--calib` and `--registry` default to
   `<root>/calib/calib_color.yaml` and `<root>/boards/tag_registry.yaml`
+- The registry must reference readable board YAML files created by
+  `posetag-make-board`.
+- Missing calibration, missing or malformed registries, missing board YAML
+  references, unknown object selections, missing `--video`, unreadable videos,
+  and unavailable RealSense support fail clearly before capture artifacts are
+  written.
 
 **Workflow in the viewer**
 
-- `o` picker with `↑/↓` or `W/S/K/J`, `Enter` to select
+- `o` picker with arrow keys or `W/S/K/J`, `Enter` to select
 - `a` auto-side on or off
 - `f` cycle faces when auto mode is off
 - `ENTER` save, with double-press within 3 seconds to force a save if expected
@@ -583,8 +599,10 @@ shots/
       <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_meta.json
 ```
 
-`*_meta.json` includes camera intrinsics, detected and expected IDs, face YAML,
-and save paths.
+`*_meta.json` includes object identity, side, face YAML, expected and detected
+tag IDs, validation status, camera intrinsics, image size, timestamp, and save
+paths. `shots/manifest.csv` appends one row per saved shot with the same core
+provenance fields.
 
 **Alternative layouts**
 

--- a/README.md
+++ b/README.md
@@ -565,10 +565,10 @@ regular USB webcam or laptop camera.
   `<root>/calib/calib_color.yaml` and `<root>/boards/tag_registry.yaml`
 - The registry must reference readable board YAML files created by
   `posetag-make-board`.
-- Missing calibration, missing or malformed registries, missing board YAML
-  references, unknown object selections, missing `--video`, unreadable videos,
-  and unavailable RealSense support fail clearly before capture artifacts are
-  written.
+- Missing calibration, missing or malformed registries, incomplete registry
+  membership, missing board YAML references, unknown object selections, missing
+  `--video`, unreadable videos, and unavailable RealSense support fail clearly
+  before capture artifacts are written.
 
 **Workflow in the viewer**
 

--- a/STEP3_CAPTURE_FACE_REPORT.md
+++ b/STEP3_CAPTURE_FACE_REPORT.md
@@ -44,6 +44,9 @@ annotation. It does not compute board-to-object transforms, dataset outputs, or
 - Missing, malformed, and empty tag registries fail before preview.
 - Registry references to missing board YAML files fail before preview.
 - Registry object/tag mismatches against board YAML files fail before preview.
+- Registry membership that omits tag IDs from a referenced board YAML fails
+  before preview, so `expected_tag_ids` cannot be under-reported from stale
+  registry entries.
 - Unknown `--object_name` selections fail before preview.
 - Video EOF exits cleanly instead of hanging.
 - `ESC` exits cleanly without writing capture outputs.
@@ -61,7 +64,7 @@ python3 -m unittest tests.test_step3_capture_face -v
 Result:
 
 ```text
-16 tests passed
+18 tests passed
 ```
 
 ```bash
@@ -71,7 +74,7 @@ python3 -m unittest discover -s tests -v
 Result:
 
 ```text
-218 tests passed
+220 tests passed
 ```
 
 ```bash

--- a/STEP3_CAPTURE_FACE_REPORT.md
+++ b/STEP3_CAPTURE_FACE_REPORT.md
@@ -1,0 +1,175 @@
+# Step 3 Capture-Face Validation Report
+
+Date: 2026-05-29
+
+Issue: #37, `[workflow] Validate Step 3: capture face shots`
+
+Branch: `feature/37-capture-face-validation`
+
+## Current Implementation Summary
+
+`posetag-capture-face` is the canonical public command for Step 3. The entry
+point remains a thin wrapper over the legacy top-level `src/capture_face.py`
+interactive OpenCV viewer.
+
+Step 3 consumes:
+
+- Step 1 colour-camera calibration, usually `calib/calib_color.yaml`
+- Step 2 board YAML files
+- Step 2 tag registry, usually `boards/tag_registry.yaml`
+
+Step 3 writes:
+
+- raw face-shot PNGs
+- annotated face-shot PNGs with detected tag overlays
+- one metadata JSON file per saved shot
+- a CSV manifest row per saved shot
+
+The workflow records object/face identity and image provenance for later
+annotation. It does not compute board-to-object transforms, dataset outputs, or
+6-DoF poses.
+
+## What Was Fixed
+
+- `posetag-capture-face --help` now resolves from the canonical CLI wrapper
+  without opening optional camera/tag dependencies.
+- The canonical CLI wrapper accepts an optional `argv`, matching the tested
+  pattern used by other PoseTag CLI wrappers.
+- Missing `--video` with `--source video` fails clearly.
+- Missing video paths fail before capture artifacts are created.
+- Existing but unreadable video files fail before capture artifacts are
+  created.
+- Missing `pyrealsense2` for `--source realsense` fails clearly.
+- Missing and malformed calibration YAML fail before camera/video preview.
+- Missing, malformed, and empty tag registries fail before preview.
+- Registry references to missing board YAML files fail before preview.
+- Registry object/tag mismatches against board YAML files fail before preview.
+- Unknown `--object_name` selections fail before preview.
+- Video EOF exits cleanly instead of hanging.
+- `ESC` exits cleanly without writing capture outputs.
+- The optional `pyrealsense2` import in capture utilities no longer breaks
+  fresh installs that do not include the RealSense extra.
+- Pure validation, path, registered-face, metadata, and manifest helpers now
+  live in `posetag.pipelines.capture_face`.
+
+## Commands Tested
+
+```bash
+python3 -m unittest tests.test_step3_capture_face -v
+```
+
+Result:
+
+```text
+16 tests passed
+```
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+Result:
+
+```text
+218 tests passed
+```
+
+```bash
+python3 -m compileall -q src utils tests
+```
+
+Result: passed with no output.
+
+```bash
+git diff --check
+```
+
+Result: passed with no output.
+
+```bash
+python3 -m pip install -e .
+```
+
+Result: editable install completed successfully for `posetag==0.1.0`.
+
+```bash
+$(python3 - <<'PY'
+import site
+from pathlib import Path
+print(Path(site.getuserbase()) / 'bin' / 'posetag-capture-face')
+PY
+) --help
+```
+
+Result: installed `posetag-capture-face --help` resolved successfully.
+
+## Outputs And Schema Verified
+
+Hardware-free tests verify the default path layout:
+
+```text
+<project_root>/shots/<object_base>/side<SideLetter>/
+  <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_raw.png
+  <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_ann.png
+  <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_meta.json
+```
+
+Metadata JSON tests verify:
+
+- `object_base`
+- `object_full`
+- `side`
+- `face_yaml`
+- `expected_tag_ids`
+- `detected_tag_ids`
+- `validation_ok`
+- `auto_face`
+- `image.path_raw`
+- `image.path_ann`
+- `image.path_meta`
+- `image.width`
+- `image.height`
+- `camera.fx`
+- `camera.fy`
+- `camera.cx`
+- `camera.cy`
+- `timestamp`
+
+Manifest tests verify one CSV row per saved shot with:
+
+- object/face identity
+- raw, annotated, and metadata paths
+- image size
+- camera intrinsics
+- detected and expected tag IDs
+- validation and auto-face flags
+
+The synthetic save test writes real small PNGs, metadata JSON, and
+`shots/manifest.csv` under a temporary project root.
+
+## Remaining Technical Debt
+
+- The interactive viewer still lives in `src/capture_face.py`. This is an
+  intentional compatibility choice for issue #37, not the final package-first
+  architecture.
+- A future architecture issue should move the full Step 3 viewer/runtime into
+  `src/posetag/pipelines/` after workflow boundaries through annotation are
+  better protected.
+- The command still uses OpenCV HighGUI for the preview and object picker.
+- Registry paths are still stored and emitted as string paths exactly as
+  produced by the current implementation. Portable path policy should be
+  handled in a later reproducibility/layout issue.
+
+## Manual Hardware-Dependent Checks Still Needed
+
+- Run `posetag-capture-face --source opencv --cam 0` with a real USB/laptop
+  camera.
+- Run `posetag-capture-face --source realsense` on a machine with
+  `pyrealsense2` and a connected RealSense camera.
+- Confirm live AprilTag overlays appear for the printed tag family.
+- Confirm auto-side selection chooses the intended face when multiple faces of
+  the same base object exist.
+- Confirm the double-press force-save behavior is acceptable when expected tags
+  are missing.
+- Confirm saved raw images contain enough visual context for the later
+  annotation step.

--- a/docs/workflows/step3_capture_face.md
+++ b/docs/workflows/step3_capture_face.md
@@ -1,0 +1,275 @@
+# Step 3: Capture Face Shots For Annotation
+
+This workflow validates the PoseTag Step 3 command:
+
+```bash
+posetag-capture-face --project_root <path> --source opencv --cam 0 --object_name <object_or_face>
+```
+
+Step 3 captures wide reference images of object faces after Step 2 has created
+board YAML files and `boards/tag_registry.yaml`. These images are used by the
+later annotation workflow to establish board-to-object transforms.
+
+Step 3 does not implement annotation, board-to-object transforms, dataset
+collection, or pose estimation. It records images, AprilTag detections, the
+registered face identity, camera intrinsics, and reproducible file paths.
+
+## Scientific Assumptions
+
+- Step 1 has produced a valid colour-camera calibration YAML.
+- Step 2 has produced one board YAML per physical face and a tag registry that
+  maps AprilTag IDs to those board YAML files.
+- The `--family` value matches the printed AprilTag family.
+- Face identity is resolved from expected tag IDs in `boards/tag_registry.yaml`
+  and the referenced board YAML files.
+- `expected_tag_ids` are the IDs registered for the selected face.
+- `detected_tag_ids` are the AprilTag IDs detected in the saved image.
+- The command does not compute `T_board_object`, `T_cam_board`, or
+  `T_cam_object`.
+- Camera intrinsics in metadata are copied from Step 1 calibration for
+  provenance; no calibration solve is performed in Step 3.
+
+## Required Inputs From Earlier Steps
+
+With:
+
+```bash
+--project_root my_project --calib calib_color.yaml
+```
+
+PoseTag first looks for:
+
+```text
+my_project/calib/calib_color.yaml
+```
+
+If a relative calibration path is supplied and that project path does not
+exist, PoseTag also checks the literal relative path and `<project_root>/<path>`
+for legacy compatibility. Absolute paths are used exactly as supplied.
+
+The default tag registry path is:
+
+```text
+my_project/boards/tag_registry.yaml
+```
+
+Every registry entry used by Step 3 must reference an existing board YAML, and
+the registry object/tag IDs must match the referenced board YAML.
+
+## Command Examples
+
+Generic OpenCV webcam:
+
+```bash
+posetag-capture-face --project_root my_project \
+  --source opencv --cam 0 \
+  --object_name connection_plate_white
+```
+
+Intel RealSense colour stream:
+
+```bash
+posetag-capture-face --project_root my_project \
+  --source realsense --width 640 --height 480 --fps 30 \
+  --object_name connection_plate_white
+```
+
+Video file:
+
+```bash
+posetag-capture-face --project_root my_project \
+  --source video --video sample.mp4 \
+  --object_name connection_plate_white
+```
+
+Specific face:
+
+```bash
+posetag-capture-face --project_root my_project \
+  --source opencv --cam 0 \
+  --object_name connection_plate_white_sideA
+```
+
+The default source remains `realsense` for compatibility with the legacy script.
+For a normal USB webcam, pass `--source opencv --cam 0` explicitly.
+
+## Object And Face Selection
+
+`--object_name` accepts either:
+
+- a base object name such as `connection_plate_white`
+- a full face name such as `connection_plate_white_sideA`
+
+When a base object is supplied, PoseTag keeps auto-side mode enabled and selects
+the best registered face by overlap between expected and detected tag IDs. When
+a full face is supplied, PoseTag uses that face directly.
+
+If `--object_name` is omitted, the OpenCV viewer starts in an object picker
+using the registered bases from `boards/tag_registry.yaml`.
+
+## Viewer Controls
+
+- `ENTER`: save the current frame.
+- `ENTER` twice within 3 seconds: force-save when expected tags are missing.
+- `o`: open the object picker.
+- Up/down or `W` / `S` / `K` / `J`: move in the picker.
+- `a`: toggle auto-side mode.
+- `f`: cycle faces when auto-side mode is off.
+- `g`: toggle gallery panels.
+- `h`: toggle help overlay.
+- `q` or `ESC`: quit cleanly without saving another shot.
+
+If a video reaches EOF before another save, the command exits cleanly.
+
+## Project Directory Side Effects
+
+Default outputs:
+
+```text
+my_project/
+  shots/
+    manifest.csv
+    <object_base>/
+      side<SideLetter>/
+        <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_raw.png
+        <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_ann.png
+        <object_base>_side<SideLetter>_<YYYYMMDD_HHMMSS>_meta.json
+  logs/
+    capture_face.log
+```
+
+The default layout is `by_object_side`. Alternative layouts:
+
+- `--layout flat` writes raw, annotated, and metadata files directly in
+  `shots/`.
+- `--layout by_object` writes files under `shots/<object_base>/`.
+- `--layout split_type` writes separate raw, annotated, and metadata folders.
+
+Example split layout:
+
+```bash
+posetag-capture-face --project_root my_project \
+  --source opencv --cam 0 \
+  --object_name connection_plate_white \
+  --layout split_type \
+  --raw_dir shots/images \
+  --ann_dir shots/ann \
+  --meta_dir shots/meta
+```
+
+Use `--out_dir`, `--manifest`, and `--log_file` to override default output
+locations. Relative output paths are resolved under the project root.
+
+Invalid source arguments, missing calibration, malformed calibration, missing
+registry files, malformed registries, missing board YAML references, and unknown
+object selections fail before camera/video preview and before Step 3 capture
+artifacts are written.
+
+## Metadata JSON Schema
+
+Each saved shot writes a `*_meta.json` file. The current schema is:
+
+```json
+{
+  "object_base": "connection_plate_white",
+  "object_full": "connection_plate_white_sideA",
+  "side": "A",
+  "face_yaml": "my_project/boards/connection_plate_white_sideA.yaml",
+  "expected_tag_ids": [52, 53],
+  "detected_tag_ids": [52],
+  "validation_ok": true,
+  "auto_face": true,
+  "image": {
+    "path_raw": "my_project/shots/connection_plate_white/sideA/..._raw.png",
+    "path_ann": "my_project/shots/connection_plate_white/sideA/..._ann.png",
+    "path_meta": "my_project/shots/connection_plate_white/sideA/..._meta.json",
+    "width": 640,
+    "height": 480
+  },
+  "camera": {
+    "fx": 600.0,
+    "fy": 610.0,
+    "cx": 320.0,
+    "cy": 240.0
+  },
+  "timestamp": "20260529_120000"
+}
+```
+
+The timestamp format is `YYYYMMDD_HHMMSS`. Paths are recorded exactly as written
+by the current command.
+
+## Manifest CSV Schema
+
+By default, Step 3 appends one row per saved shot to:
+
+```text
+my_project/shots/manifest.csv
+```
+
+Fields:
+
+- `timestamp`
+- `object_base`
+- `object_full`
+- `side`
+- `face_yaml`
+- `path_raw`
+- `path_ann`
+- `path_meta`
+- `width`
+- `height`
+- `fx`
+- `fy`
+- `cx`
+- `cy`
+- `detected_ids`
+- `expected_ids`
+- `validation_ok`
+- `auto_face`
+
+`detected_ids` and `expected_ids` are space-separated integer tag IDs in the
+CSV row.
+
+## Common Failure Modes
+
+- `--source video` without `--video` fails with a clear message.
+- Missing or unreadable video paths fail before Step 3 capture artifacts are
+  created.
+- `--source realsense` fails clearly when `pyrealsense2` is not installed.
+- Missing `calib/calib_color.yaml` fails before preview.
+- Malformed calibration YAML fails with a schema-oriented error.
+- Missing `boards/tag_registry.yaml` fails before preview.
+- Malformed or empty tag registries fail before preview.
+- Registry entries that reference missing board YAML files fail before preview.
+- Registry object/tag mismatches with referenced board YAML files fail before
+  preview.
+- Unknown `--object_name` selections fail before preview.
+- `ESC` / `q` exits cleanly without writing another shot.
+- Video EOF exits cleanly without hanging.
+
+## Verify Before Step 4
+
+Before moving to face annotation:
+
+1. Confirm `shots/manifest.csv` exists and has one row per saved reference
+   image.
+2. Confirm each row's raw, annotated, and metadata paths exist.
+3. Load each `*_meta.json` file and confirm `object_full`, `face_yaml`,
+   `expected_tag_ids`, `detected_tag_ids`, image size, and camera intrinsics are
+   plausible.
+4. Confirm the saved raw image shows the full physical face needed for later
+   annotation.
+5. Confirm the annotated image overlays the detected tag IDs expected for that
+   face.
+
+## Current Implementation Note
+
+The public `posetag-capture-face` entry point still delegates to the legacy
+top-level `src/capture_face.py` interactive OpenCV viewer. Pure validation,
+path, registered-face, metadata, and manifest helpers now live in
+`posetag.pipelines.capture_face` so the Step 3 contract can be tested without
+camera hardware.
+
+Migrating the full interactive viewer into a package-first module remains
+future technical debt and is intentionally outside issue #37.

--- a/docs/workflows/step3_capture_face.md
+++ b/docs/workflows/step3_capture_face.md
@@ -54,7 +54,9 @@ my_project/boards/tag_registry.yaml
 ```
 
 Every registry entry used by Step 3 must reference an existing board YAML, and
-the registry object/tag IDs must match the referenced board YAML.
+the registry object/tag IDs must match the referenced board YAML. The registry
+membership for a referenced board must cover all tag IDs listed in that board
+YAML, so Step 3 does not under-report expected tags for stale registries.
 
 ## Command Examples
 
@@ -244,6 +246,8 @@ CSV row.
 - Registry entries that reference missing board YAML files fail before preview.
 - Registry object/tag mismatches with referenced board YAML files fail before
   preview.
+- Registry membership that does not cover all tag IDs in the referenced board
+  YAML fails before preview.
 - Unknown `--object_name` selections fail before preview.
 - `ESC` / `q` exits cleanly without writing another shot.
 - Video EOF exits cleanly without hanging.

--- a/src/capture_face.py
+++ b/src/capture_face.py
@@ -31,29 +31,52 @@ g panels | h help | q / ESC quit
 """
 
 from __future__ import annotations
-import argparse, os, json, time
+import argparse, time
 from pathlib import Path
 from typing import List, Dict, Tuple, Optional, Set
 
 import numpy as np
 import cv2
 
-from utils.capture_source import open_source
-from utils.intel_realsense_utils import load_calib, _face_label
+from utils import capture_source
 from utils.capture_utils import (
     draw_detections, make_info_panel, make_recent_panel, text_lines,
-    load_registry, unique_bases, faces_for_base, faces_for_object,
-    parse_base_and_side, ensure_dir, timestamp, _append_manifest
 )
-from utils.project_config import resolve_project_root, ensure_project_dirs
 from utils.logger import init_project_logger
-
-try:
-    from pupil_apriltags import Detector
-except Exception as e:
-    raise SystemExit("Please install pupil-apriltags: pip install pupil-apriltags") from e
+from posetag.pipelines.capture_face import (
+    activate_capture_project_root,
+    CaptureFaceError,
+    build_capture_metadata,
+    build_shot_paths,
+    capture_timestamp,
+    create_apriltag_detector,
+    create_capture_output_dirs,
+    faces_for_base,
+    load_apriltag_detector_class,
+    load_capture_calibration,
+    load_capture_registry,
+    load_registered_faces,
+    prepare_capture_paths,
+    preview_capture_project_root,
+    resolve_capture_calibration_path,
+    select_initial_faces,
+    unique_bases,
+    validate_capture_source_args,
+    write_capture_outputs,
+)
 
 KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT = 2490368, 2621440, 2424832, 2555904
+
+
+def _face_label(face_entry, max_chars=28, default="unregistered"):
+    """Short label for overlay: YAML basename, truncated; safe if face_entry is None."""
+    if not face_entry:
+        return default
+    yml = face_entry.get("yaml", "")
+    base = Path(yml).stem if yml else default
+    if len(base) > max_chars:
+        base = base[:max_chars - 1] + "..."
+    return base
 
 
 def object_picker_panel(h: int, w: int, bases: List[str], sel: int,
@@ -94,9 +117,12 @@ def best_face_by_overlap(faces: List[Dict], det_ids: Set[int], prev_idx: int | N
     return best_i, best_k
 
 
-def main():
-  # Parse command-line arguments for capture settings
-    ap = argparse.ArgumentParser("Capture wide shots per face for later annotation")
+def main(argv=None):
+    # Parse command-line arguments for capture settings
+    ap = argparse.ArgumentParser(
+        prog="posetag-capture-face",
+        description="Capture wide shots per face for later annotation",
+    )
     ap.add_argument("--project_root", type=Path, default=None,
                     help="Root for boards/shots/objects/datasets (default: resolver/env/config).")
     ap.add_argument("--calib", default="calib_color.yaml",
@@ -132,66 +158,56 @@ def main():
                     help="Capture source: Intel RealSense (default), OpenCV webcam, or a video file")
     ap.add_argument("--cam", type=int, default=0, help="OpenCV camera index when --source=opencv")
     ap.add_argument("--video", type=str, default=None, help="Video path when --source=video")
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
 
-    # ---------- project root + path resolution ----------
-    pr = Path(resolve_project_root(args.project_root))
-    ensure_project_dirs(pr)
+    # ---------- validate project inputs before opening hardware or writing outputs ----------
+    try:
+        validate_capture_source_args(args.source, args.video, capture_source.rs)
+        pr = preview_capture_project_root(args.project_root)
+        calibration = load_capture_calibration(resolve_capture_calibration_path(pr, args.calib))
+        paths = prepare_capture_paths(
+            project_root=pr,
+            calib_path=calibration.path,
+            registry=args.registry,
+            out_dir=args.out_dir,
+            manifest=args.manifest,
+            log_file=args.log_file,
+            layout=args.layout,
+            raw_dir=args.raw_dir,
+            ann_dir=args.ann_dir,
+            meta_dir=args.meta_dir,
+        )
+        registry = load_capture_registry(paths.registry_path)
+        registered_faces = load_registered_faces(
+            registry,
+            project_root=paths.project_root,
+            registry_path=paths.registry_path,
+        )
+        initial_selection = select_initial_faces(args.object_name, registered_faces)
+        Detector = load_apriltag_detector_class()
+        det = create_apriltag_detector(args.family, detector_class=Detector)
+    except CaptureFaceError as exc:
+        raise SystemExit(str(exc)) from exc
 
-    def _under_pr(p: Optional[str | Path], default_rel: Optional[str]) -> Path:
-        if p is None:
-            return (pr / default_rel) if default_rel else pr
-        pth = Path(p)
-        return pth if pth.is_absolute() else (pr / pth)
-
-    # calib: prefer given path; else <pr>/calib/calib_color.yaml or <pr>/calib_color.yaml
-    calib_path = Path(args.calib)
-    if not calib_path.exists():
-        for cand in (pr / "calib" / "calib_color.yaml", pr / "calib_color.yaml"):
-            if cand.exists():
-                calib_path = cand
-                break
-
-    registry_path = _under_pr(args.registry, "boards/tag_registry.yaml")
-    out_dir = _under_pr(args.out_dir, "shots")
-
-    # logs
-    logs_dir = pr / "logs"; logs_dir.mkdir(parents=True, exist_ok=True)
-    log_path = (Path(args.log_file) if args.log_file and Path(args.log_file).is_absolute()
-                else logs_dir / (Path(args.log_file).name if args.log_file else "capture_face.log"))
-
-    # split-type dirs
-    if args.layout == "split_type":
-        raw_dir  = _under_pr(args.raw_dir,  str(out_dir / "images"))
-        ann_dir  = _under_pr(args.ann_dir,  str(out_dir / "ann"))
-        meta_dir = _under_pr(args.meta_dir, str(out_dir / "meta"))
-        for d in (raw_dir, ann_dir, meta_dir): d.mkdir(parents=True, exist_ok=True)
-    else:
-        raw_dir = ann_dir = meta_dir = None
-        out_dir.mkdir(parents=True, exist_ok=True)
-
-    # manifest
-    manifest_path = (pr / "shots" / "manifest.csv") if args.manifest is None else (
-        Path(args.manifest) if Path(args.manifest).is_absolute() else (pr / args.manifest)
-    )
-    manifest_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # ---------- logging & announce ----------
-    logger = init_project_logger(log_path, level=args.log_level, console=args.log_console)
-    logger.info("Using project root: %s", pr)
-    logger.info("Using calib: %s", str(calib_path))
-    logger.info("Using registry: %s", str(registry_path))
-    logger.info("Shots will be saved to: %s", str(out_dir))
-
-    # ---------- data & detector ----------
-    (fx, fy, cx, cy), K = load_calib(str(calib_path))
-    reg = load_registry(str(registry_path))
-    det = Detector(families=args.family, nthreads=4, quad_decimate=1.0, refine_edges=True)
-
-    # unified source
-    read_frame, stop, _ = open_source(
+    # unified source; keep this before output-directory creation so unreadable
+    # videos fail without leaving capture artifacts.
+    read_frame, stop, _ = capture_source.open_source(
         args.source, cam=args.cam, video=args.video, width=args.width, height=args.height, fps=args.fps, warmup=10
     )
+
+    try:
+        activate_capture_project_root(paths.project_root)
+        create_capture_output_dirs(paths, layout=args.layout)
+        logger = init_project_logger(paths.log_path, level=args.log_level, console=args.log_console)
+    except Exception:
+        stop()
+        raise
+
+    # ---------- logging & announce ----------
+    logger.info("Using project root: %s", paths.project_root)
+    logger.info("Using calib: %s", str(paths.calib_path))
+    logger.info("Using registry: %s", str(paths.registry_path))
+    logger.info("Shots will be saved to: %s", str(paths.out_dir))
 
     # ---------- UI state ----------
     state = {
@@ -200,15 +216,13 @@ def main():
         "save_warn": False, "save_warn_t0": 0.0,
     }
 
-    bases = unique_bases(reg)
+    bases = unique_bases(registered_faces)
 
     # Initial object from CLI
-    cli_obj = args.object_name.strip() if args.object_name else None
-    if cli_obj:
-        base, side = parse_base_and_side(cli_obj)
-        state["object_base"] = base
-        state["faces"] = faces_for_base(base, reg, pr) if side is None else faces_for_object(cli_obj, reg, pr)
-        state["auto_side"] = (side is None)
+    if initial_selection:
+        state["object_base"] = initial_selection.object_base
+        state["faces"] = list(initial_selection.faces)
+        state["auto_side"] = initial_selection.auto_side
         state["face_idx"] = 0
 
     mode, pick_sel, gallery_on, show_help = ('preview' if state["object_base"] else 'pick_object', 0, bool(args.gallery), False)
@@ -222,6 +236,9 @@ def main():
         while True:
             c = read_frame()
             if c is None:
+                if args.source == "video":
+                    logger.info("Video ended before another face shot was saved; exiting cleanly.")
+                    return 0
                 continue
 
             # Sync actual width/height for non-hardware-timestamped sources
@@ -305,11 +322,14 @@ def main():
                     base = bases[pick_sel] if bases else None
                     if base:
                         state["object_base"] = base
-                        state["faces"] = faces_for_base(base, reg, pr)
+                        state["faces"] = faces_for_base(base, registered_faces)
                         state["face_idx"] = 0
                         state["auto_side"] = True
                     mode = 'preview'
-                elif k in CANCEL_KEYS: mode = 'preview'
+                elif k in CANCEL_KEYS:
+                    if state["object_base"] is None:
+                        break
+                    mode = 'preview'
                 elif k == ord('q'):     break
                 continue
 
@@ -335,52 +355,44 @@ def main():
                         continue
                 state["save_warn"] = False
               
-                # Generate timestamp and determine save paths based on layout
-                ts = timestamp()
-                obj_full = face["object"] if face else (state["object_base"] or "unknown")
-                base_name, side = parse_base_and_side(obj_full)
-                side_code = (side or "unresolved").upper()
-
-                if args.layout == "flat":
-                    save_root, file_stub = out_dir, f"{obj_full}_{ts}"
-                elif args.layout == "by_object":
-                    save_root, file_stub = out_dir / base_name, f"{base_name}_side{side_code}_{ts}"
-                elif args.layout == "by_object_side":
-                    save_root, file_stub = out_dir / base_name / f"side{side_code}", f"{base_name}_side{side_code}_{ts}"
-                else:  # split_type
-                    save_root, file_stub = None, f"{base_name}_side{side_code}_{ts}"
-
-                raw_path = str((save_root / f"{file_stub}_raw.png") if save_root else (raw_dir / f"{file_stub}_raw.png"))
-                ann_path = str((save_root / f"{file_stub}_ann.png") if save_root else (ann_dir / f"{file_stub}_ann.png"))
-                meta_path = str((save_root / f"{file_stub}_meta.json") if save_root else (meta_dir / f"{file_stub}_meta.json"))
-                if save_root: ensure_dir(save_root)
-
-                cv2.imwrite(raw_path, c)
-                cv2.imwrite(ann_path, vis)
+                # Generate timestamp and determine save paths based on layout.
+                ts = capture_timestamp()
+                obj_full = face["object"]
+                shot_paths = build_shot_paths(
+                    layout=args.layout,
+                    out_dir=paths.out_dir,
+                    object_full=obj_full,
+                    timestamp=ts,
+                    raw_dir=paths.raw_dir,
+                    ann_dir=paths.ann_dir,
+                    meta_dir=paths.meta_dir,
+                )
+                meta = build_capture_metadata(
+                    face=face,
+                    shot_paths=shot_paths,
+                    detected_tag_ids=det_ids,
+                    validation_ok=ok,
+                    auto_face=state["auto_side"],
+                    frame_shape=c.shape,
+                    camera_params=calibration.camera_params,
+                    timestamp=ts,
+                )
+                try:
+                    write_capture_outputs(
+                        raw_frame=c,
+                        annotated_frame=vis,
+                        metadata=meta,
+                        shot_paths=shot_paths,
+                        manifest_path=paths.manifest_path,
+                        image_writer=cv2.imwrite,
+                    )
+                except CaptureFaceError as exc:
+                    raise SystemExit(str(exc)) from exc
                 state["last_saved_ann"] = vis.copy()
 
-                meta = {
-                    "object_base": base_name,
-                    "object_full": obj_full,
-                    "side": side_code,
-                    "face_yaml": face["yaml"] if face else None,
-                    "expected_tag_ids": sorted(list(set(face["tag_ids"]))) if face else [],
-                    "detected_tag_ids": sorted(list(det_ids)),
-                    "validation_ok": bool(ok),
-                    "auto_face": bool(state["auto_side"]),
-                    "image": {
-                        "path_raw": raw_path, "path_ann": ann_path, "path_meta": meta_path,
-                        "width": int(c.shape[1]), "height": int(c.shape[0]),
-                    },
-                    "camera": {"fx": float(fx), "fy": float(fy), "cx": float(cx), "cy": float(cy)},
-                    "timestamp": ts,
-                }
-                with open(meta_path, "w") as f:
-                    json.dump(meta, f, indent=2)
-                logger.info(f"[+] Saved {raw_path}")
-                logger.info(f"[+] Saved {ann_path}")
-                logger.info(f"[+] Saved {meta_path}")
-                _append_manifest(str(manifest_path), meta)
+                logger.info(f"[+] Saved {shot_paths.raw_path}")
+                logger.info(f"[+] Saved {shot_paths.ann_path}")
+                logger.info(f"[+] Saved {shot_paths.meta_path}")
 
                 # Update thumbnails for gallery panel
                 try:
@@ -393,7 +405,8 @@ def main():
     finally:
         stop()
         cv2.destroyAllWindows()
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/posetag/cli/capture_face.py
+++ b/src/posetag/cli/capture_face.py
@@ -1,7 +1,11 @@
 """PoseTag CLI wrapper for face-shot capture."""
 
 
-def main():
+def main(argv=None):
     from capture_face import main as _main
 
-    return _main()
+    return _main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/posetag/pipelines/capture_face.py
+++ b/src/posetag/pipelines/capture_face.py
@@ -1,0 +1,756 @@
+"""Reusable helpers for PoseTag Step 3 face-shot capture.
+
+The interactive OpenCV viewer remains in the legacy top-level
+``capture_face`` module for now.  The helpers here cover validation, path
+resolution, registered-face loading, metadata construction, and manifest
+writing so Step 3 can be tested without camera hardware.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+import math
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Optional, Sequence, Union
+
+import yaml
+
+from posetag.pipelines.make_board import (
+    MakeBoardError,
+    load_calibration_yaml,
+    preview_project_root,
+)
+
+try:
+    from posetag.utils.project_config import ensure_project_dirs, resolve_project_root
+except ModuleNotFoundError:
+    repo_root = Path(__file__).resolve().parents[3]
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from posetag.utils.project_config import ensure_project_dirs, resolve_project_root
+
+
+SIDE_RE = re.compile(r"^(?P<base>.+?)_side(?P<side>[A-Za-z]+)$")
+
+CAPTURE_MANIFEST_FIELDS = (
+    "timestamp",
+    "object_base",
+    "object_full",
+    "side",
+    "face_yaml",
+    "path_raw",
+    "path_ann",
+    "path_meta",
+    "width",
+    "height",
+    "fx",
+    "fy",
+    "cx",
+    "cy",
+    "detected_ids",
+    "expected_ids",
+    "validation_ok",
+    "auto_face",
+)
+
+
+class CaptureFaceError(ValueError):
+    """User-facing validation error for Step 3 face-shot capture."""
+
+
+@dataclass(frozen=True)
+class CaptureCalibration:
+    """Loaded colour-camera intrinsics used for capture metadata."""
+
+    path: Path
+    camera_params: tuple[float, float, float, float]
+
+
+@dataclass(frozen=True)
+class CaptureFacePaths:
+    """Resolved Step 3 project and output paths."""
+
+    project_root: Path
+    calib_path: Path
+    registry_path: Path
+    out_dir: Path
+    manifest_path: Path
+    log_path: Path
+    raw_dir: Optional[Path] = None
+    ann_dir: Optional[Path] = None
+    meta_dir: Optional[Path] = None
+
+
+@dataclass(frozen=True)
+class CaptureSelection:
+    """Registered faces selected from an optional CLI object name."""
+
+    object_base: str
+    faces: tuple[dict[str, Any], ...]
+    auto_side: bool
+
+
+@dataclass(frozen=True)
+class ShotPaths:
+    """Output paths for one saved face-shot capture."""
+
+    raw_path: Path
+    ann_path: Path
+    meta_path: Path
+    object_base: str
+    side_code: str
+    file_stub: str
+
+
+def preview_capture_project_root(project_root: Optional[Union[Path, str]]) -> Path:
+    """Resolve the project root for validation without creating explicit roots."""
+
+    return preview_project_root(project_root)
+
+
+def activate_capture_project_root(project_root: Union[Path, str]) -> Path:
+    """Register and create the project layout once validation has passed."""
+
+    root = Path(resolve_project_root(project_root))
+    ensure_project_dirs(root)
+    return root
+
+
+def resolve_under_project(
+    project_root: Union[Path, str],
+    value: Optional[Union[Path, str]],
+    default: Union[Path, str],
+) -> Path:
+    """Resolve a path under the project root unless it is already absolute."""
+
+    root = Path(project_root).expanduser().resolve()
+    raw = Path(default if value is None else value).expanduser()
+    return raw if raw.is_absolute() else root / raw
+
+
+def resolve_capture_calibration_path(
+    project_root: Union[Path, str],
+    calib: Optional[Union[Path, str]] = "calib_color.yaml",
+) -> Path:
+    """Resolve Step 3 calibration input using the legacy project-aware order."""
+
+    root = Path(project_root).expanduser().resolve()
+    raw = Path(calib or "calib_color.yaml").expanduser()
+    if raw.is_absolute():
+        return raw
+    if raw.exists():
+        return raw
+
+    candidates = (root / "calib" / raw, root / raw)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def prepare_capture_paths(
+    *,
+    project_root: Union[Path, str],
+    calib_path: Union[Path, str],
+    registry: Optional[Union[Path, str]] = None,
+    out_dir: Optional[Union[Path, str]] = None,
+    manifest: Optional[Union[Path, str]] = None,
+    log_file: Optional[Union[Path, str]] = None,
+    layout: str = "by_object_side",
+    raw_dir: Optional[Union[Path, str]] = None,
+    ann_dir: Optional[Union[Path, str]] = None,
+    meta_dir: Optional[Union[Path, str]] = None,
+) -> CaptureFacePaths:
+    """Resolve Step 3 input/output paths without creating directories."""
+
+    root = Path(project_root).expanduser().resolve()
+    resolved_out_dir = resolve_under_project(root, out_dir, "shots")
+    registry_path = resolve_under_project(root, registry, "boards/tag_registry.yaml")
+    manifest_path = resolve_under_project(root, manifest, "shots/manifest.csv")
+
+    logs_dir = root / "logs"
+    if log_file is None:
+        log_path = logs_dir / "capture_face.log"
+    else:
+        raw_log = Path(log_file).expanduser()
+        log_path = raw_log if raw_log.is_absolute() else logs_dir / raw_log.name
+
+    if layout == "split_type":
+        resolved_raw_dir = resolve_under_project(root, raw_dir, resolved_out_dir / "images")
+        resolved_ann_dir = resolve_under_project(root, ann_dir, resolved_out_dir / "ann")
+        resolved_meta_dir = resolve_under_project(root, meta_dir, resolved_out_dir / "meta")
+    else:
+        resolved_raw_dir = resolved_ann_dir = resolved_meta_dir = None
+
+    return CaptureFacePaths(
+        project_root=root,
+        calib_path=Path(calib_path).expanduser(),
+        registry_path=registry_path,
+        out_dir=resolved_out_dir,
+        manifest_path=manifest_path,
+        log_path=log_path,
+        raw_dir=resolved_raw_dir,
+        ann_dir=resolved_ann_dir,
+        meta_dir=resolved_meta_dir,
+    )
+
+
+def create_capture_output_dirs(paths: CaptureFacePaths, *, layout: str) -> None:
+    """Create the standard project and Step 3 output directories."""
+
+    ensure_project_dirs(paths.project_root)
+    paths.log_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    if layout == "split_type":
+        for directory in (paths.raw_dir, paths.ann_dir, paths.meta_dir):
+            if directory is None:
+                raise CaptureFaceError("split_type layout requires raw, annotated, and metadata directories.")
+            directory.mkdir(parents=True, exist_ok=True)
+    else:
+        paths.out_dir.mkdir(parents=True, exist_ok=True)
+
+
+def load_capture_calibration(path: Union[Path, str]) -> CaptureCalibration:
+    """Load and validate the Step 1 colour-camera calibration YAML."""
+
+    try:
+        calibration = load_calibration_yaml(path)
+    except MakeBoardError as exc:
+        raise CaptureFaceError(str(exc)) from exc
+    return CaptureCalibration(
+        path=Path(path).expanduser(),
+        camera_params=calibration.camera_params,
+    )
+
+
+def validate_capture_source_args(
+    source: str,
+    video: Optional[Union[Path, str]],
+    realsense_module: Any,
+) -> None:
+    """Validate source-specific arguments before opening hardware."""
+
+    if source == "video":
+        if not video:
+            raise CaptureFaceError("--video path is required when --source=video")
+        if not Path(video).expanduser().exists():
+            raise CaptureFaceError(f"Could not open video: {video}")
+    if source == "realsense" and realsense_module is None:
+        raise CaptureFaceError(
+            "pyrealsense2 is not available; install PoseTag with the 'realsense' "
+            "extra or use --source opencv|video"
+        )
+
+
+def load_apriltag_detector_class() -> Any:
+    """Load the optional pupil-apriltags detector class."""
+
+    try:
+        from pupil_apriltags import Detector
+    except Exception as exc:
+        raise CaptureFaceError(
+            "pupil-apriltags is not available; install PoseTag with the "
+            "'apriltags' extra or run `python -m pip install pupil-apriltags`."
+        ) from exc
+    return Detector
+
+
+def create_apriltag_detector(family: str, detector_class: Optional[Any] = None) -> Any:
+    """Create the AprilTag detector used by face-shot capture."""
+
+    Detector = detector_class or load_apriltag_detector_class()
+    try:
+        return Detector(
+            families=family,
+            nthreads=4,
+            quad_decimate=1.0,
+            refine_edges=True,
+        )
+    except Exception as exc:
+        raise CaptureFaceError(
+            f"Could not initialize AprilTag detector for family '{family}': {exc}"
+        ) from exc
+
+
+def load_capture_registry(path: Union[Path, str]) -> dict[str, Any]:
+    """Load and validate the Step 2 tag registry YAML."""
+
+    target = Path(path).expanduser()
+    if not target.exists():
+        raise CaptureFaceError(
+            f"Tag registry YAML not found: {target}. Run Step 2 with posetag-make-board first."
+        )
+    try:
+        with target.open("r", encoding="utf-8") as handle:
+            registry = yaml.safe_load(handle) or {}
+    except yaml.YAMLError as exc:
+        raise CaptureFaceError(f"Malformed tag registry YAML: {target}: {exc}") from exc
+    except OSError as exc:
+        raise CaptureFaceError(f"Could not read tag registry YAML: {target}: {exc}") from exc
+
+    if not isinstance(registry, Mapping):
+        raise CaptureFaceError(f"Malformed tag registry YAML: {target} must contain a mapping.")
+    tags = registry.get("tags")
+    if not isinstance(tags, Mapping):
+        raise CaptureFaceError(f"Malformed tag registry YAML: {target} tags must be a mapping.")
+    if not tags:
+        raise CaptureFaceError(
+            f"Tag registry YAML has no tag mappings: {target}. Run Step 2 with posetag-make-board first."
+        )
+    return dict(registry)
+
+
+def load_registered_faces(
+    registry: Mapping[str, Any],
+    *,
+    project_root: Union[Path, str],
+    registry_path: Union[Path, str],
+) -> tuple[dict[str, Any], ...]:
+    """Resolve registry entries into readable registered face records."""
+
+    root = Path(project_root).expanduser().resolve()
+    reg_path = Path(registry_path).expanduser()
+    tags = registry.get("tags")
+    if not isinstance(tags, Mapping) or not tags:
+        raise CaptureFaceError("Tag registry YAML must contain at least one tag mapping.")
+
+    board_cache: dict[Path, tuple[str, frozenset[int]]] = {}
+    grouped: dict[tuple[Path, str], set[int]] = {}
+
+    for raw_tag_id, raw_entry in sorted(tags.items(), key=lambda item: str(item[0])):
+        tag_id = _parse_int(raw_tag_id)
+        if tag_id is None:
+            raise CaptureFaceError(f"Registry tag key {raw_tag_id!r} must be an integer tag ID.")
+        if not isinstance(raw_entry, Mapping):
+            raise CaptureFaceError(f"Registry entry {raw_tag_id!r} must be a mapping.")
+
+        object_name = raw_entry.get("object")
+        if not isinstance(object_name, str) or not object_name.strip():
+            raise CaptureFaceError(f"Registry entry {raw_tag_id!r} is missing an object name.")
+
+        yaml_value = raw_entry.get("yaml")
+        if not isinstance(yaml_value, str) or not yaml_value.strip():
+            raise CaptureFaceError(f"Registry entry {raw_tag_id!r} is missing a board YAML path.")
+
+        board_path = resolve_registry_board_path(root, reg_path, yaml_value)
+        if not board_path.exists():
+            raise CaptureFaceError(
+                f"Referenced board YAML for tag {raw_tag_id!r} was not found: {board_path}"
+            )
+
+        cached = board_cache.get(board_path)
+        if cached is None:
+            board_object, board_tag_ids = load_board_face_schema(board_path)
+            board_cache[board_path] = (board_object, board_tag_ids)
+        else:
+            board_object, board_tag_ids = cached
+
+        if object_name != board_object:
+            raise CaptureFaceError(
+                f"Registry entry {raw_tag_id!r} maps object {object_name!r}, "
+                f"but {board_path} declares object {board_object!r}."
+            )
+        if tag_id not in board_tag_ids:
+            raise CaptureFaceError(
+                f"Registry tag {raw_tag_id!r} is not present in referenced board YAML: {board_path}"
+            )
+
+        grouped.setdefault((board_path, object_name), set()).add(tag_id)
+
+    faces = [
+        {
+            "yaml": str(board_path),
+            "object": object_name,
+            "tag_ids": tuple(sorted(tag_ids)),
+        }
+        for (board_path, object_name), tag_ids in grouped.items()
+    ]
+    faces.sort(key=lambda face: (str(face["object"]), Path(str(face["yaml"])).name))
+    if not faces:
+        raise CaptureFaceError("Tag registry YAML did not resolve to any readable board faces.")
+    return tuple(faces)
+
+
+def resolve_registry_board_path(
+    project_root: Union[Path, str],
+    registry_path: Union[Path, str],
+    yaml_value: str,
+) -> Path:
+    """Resolve a board YAML reference stored in the tag registry."""
+
+    root = Path(project_root).expanduser().resolve()
+    registry_parent = Path(registry_path).expanduser().parent
+    raw = Path(yaml_value).expanduser()
+    if raw.is_absolute():
+        return raw
+
+    candidates = [
+        root / raw,
+        registry_parent / raw,
+    ]
+    if raw.parts and raw.parts[0] == root.name:
+        candidates.append(root.parent / raw)
+    candidates.append(raw)
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def load_board_face_schema(path: Union[Path, str]) -> tuple[str, frozenset[int]]:
+    """Load the object name and tag IDs from a Step 2 board YAML."""
+
+    target = Path(path).expanduser()
+    try:
+        with target.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise CaptureFaceError(f"Malformed board YAML: {target}: {exc}") from exc
+    except OSError as exc:
+        raise CaptureFaceError(f"Could not read board YAML: {target}: {exc}") from exc
+
+    if not isinstance(data, Mapping):
+        raise CaptureFaceError(f"Malformed board YAML: {target} must contain a mapping.")
+    object_name = data.get("object")
+    if not isinstance(object_name, str) or not object_name.strip():
+        raise CaptureFaceError(f"Malformed board YAML: {target} is missing object.")
+    tags = data.get("tags")
+    if not isinstance(tags, Sequence) or isinstance(tags, (str, bytes)) or not tags:
+        raise CaptureFaceError(f"Malformed board YAML: {target} tags must be a non-empty list.")
+
+    tag_ids: set[int] = set()
+    for index, tag in enumerate(tags):
+        if not isinstance(tag, Mapping):
+            raise CaptureFaceError(f"Malformed board YAML: {target} tag entry {index} must be a mapping.")
+        tag_id = _parse_int(tag.get("id"))
+        if tag_id is None:
+            raise CaptureFaceError(
+                f"Malformed board YAML: {target} tag entry {index} id must be an integer."
+            )
+        tag_ids.add(tag_id)
+    return object_name, frozenset(tag_ids)
+
+
+def parse_base_and_side(name: str) -> tuple[str, Optional[str]]:
+    """Split ``object_sideA`` style names into base object and side label."""
+
+    match = SIDE_RE.match(name)
+    if match:
+        return match.group("base"), match.group("side")
+    return name, None
+
+
+def unique_bases(faces: Iterable[Mapping[str, Any]]) -> list[str]:
+    """Return stable base object names from registered face records."""
+
+    bases = {
+        parse_base_and_side(str(face.get("object", "")))[0]
+        for face in faces
+        if str(face.get("object", "")).strip()
+    }
+    return sorted(bases)
+
+
+def faces_for_base(base: str, faces: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Return registered faces for one base object."""
+
+    selected = [
+        dict(face)
+        for face in faces
+        if parse_base_and_side(str(face.get("object", "")))[0] == base
+    ]
+    selected.sort(key=lambda face: (str(face["object"]), Path(str(face["yaml"])).name))
+    return selected
+
+
+def faces_for_object(object_name: str, faces: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    """Return registered faces for one full object/face name."""
+
+    selected = [dict(face) for face in faces if str(face.get("object")) == object_name]
+    selected.sort(key=lambda face: (str(face["object"]), Path(str(face["yaml"])).name))
+    return selected
+
+
+def select_initial_faces(
+    object_name: Optional[str],
+    faces: Sequence[Mapping[str, Any]],
+) -> Optional[CaptureSelection]:
+    """Resolve an optional CLI object selection against registered faces."""
+
+    if object_name is None:
+        if not faces:
+            raise CaptureFaceError("No registered object faces were found in the tag registry.")
+        return None
+
+    requested = object_name.strip()
+    if not requested:
+        raise CaptureFaceError("--object_name must not be empty when supplied.")
+
+    base, side = parse_base_and_side(requested)
+    if side is None:
+        selected = faces_for_base(base, faces)
+        auto_side = True
+    else:
+        selected = faces_for_object(requested, faces)
+        auto_side = False
+
+    if not selected:
+        raise CaptureFaceError(
+            f"No registered face found for --object_name {requested!r}. "
+            "Run Step 2 with posetag-make-board and confirm boards/tag_registry.yaml."
+        )
+    return CaptureSelection(
+        object_base=base,
+        faces=tuple(selected),
+        auto_side=auto_side,
+    )
+
+
+def capture_timestamp() -> str:
+    """Return the timestamp format used in Step 3 output filenames."""
+
+    return datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+
+def build_shot_paths(
+    *,
+    layout: str,
+    out_dir: Union[Path, str],
+    object_full: str,
+    timestamp: str,
+    raw_dir: Optional[Union[Path, str]] = None,
+    ann_dir: Optional[Union[Path, str]] = None,
+    meta_dir: Optional[Union[Path, str]] = None,
+) -> ShotPaths:
+    """Build deterministic raw/annotated/meta paths for one saved shot."""
+
+    base_name, side = parse_base_and_side(object_full)
+    side_code = (side or "unresolved").upper()
+
+    if layout == "flat":
+        save_root = Path(out_dir)
+        file_stub = f"{object_full}_{timestamp}"
+        raw_path = save_root / f"{file_stub}_raw.png"
+        ann_path = save_root / f"{file_stub}_ann.png"
+        meta_path = save_root / f"{file_stub}_meta.json"
+    elif layout == "by_object":
+        save_root = Path(out_dir) / base_name
+        file_stub = f"{base_name}_side{side_code}_{timestamp}"
+        raw_path = save_root / f"{file_stub}_raw.png"
+        ann_path = save_root / f"{file_stub}_ann.png"
+        meta_path = save_root / f"{file_stub}_meta.json"
+    elif layout == "by_object_side":
+        save_root = Path(out_dir) / base_name / f"side{side_code}"
+        file_stub = f"{base_name}_side{side_code}_{timestamp}"
+        raw_path = save_root / f"{file_stub}_raw.png"
+        ann_path = save_root / f"{file_stub}_ann.png"
+        meta_path = save_root / f"{file_stub}_meta.json"
+    elif layout == "split_type":
+        if raw_dir is None or ann_dir is None or meta_dir is None:
+            raise CaptureFaceError("split_type layout requires raw_dir, ann_dir, and meta_dir.")
+        file_stub = f"{base_name}_side{side_code}_{timestamp}"
+        raw_path = Path(raw_dir) / f"{file_stub}_raw.png"
+        ann_path = Path(ann_dir) / f"{file_stub}_ann.png"
+        meta_path = Path(meta_dir) / f"{file_stub}_meta.json"
+    else:
+        raise CaptureFaceError("Capture layout must be flat, by_object, by_object_side, or split_type.")
+
+    return ShotPaths(
+        raw_path=raw_path,
+        ann_path=ann_path,
+        meta_path=meta_path,
+        object_base=base_name,
+        side_code=side_code,
+        file_stub=file_stub,
+    )
+
+
+def build_capture_metadata(
+    *,
+    face: Mapping[str, Any],
+    shot_paths: ShotPaths,
+    detected_tag_ids: Iterable[int],
+    validation_ok: bool,
+    auto_face: bool,
+    frame_shape: Sequence[int],
+    camera_params: Sequence[float],
+    timestamp: str,
+) -> dict[str, Any]:
+    """Build the public per-shot metadata JSON schema."""
+
+    fx, fy, cx, cy = [float(value) for value in camera_params]
+    height = int(frame_shape[0])
+    width = int(frame_shape[1])
+    expected_ids = sorted({int(tag_id) for tag_id in face.get("tag_ids", [])})
+    detected_ids = sorted({int(tag_id) for tag_id in detected_tag_ids})
+
+    return {
+        "object_base": shot_paths.object_base,
+        "object_full": str(face.get("object")),
+        "side": shot_paths.side_code,
+        "face_yaml": str(face.get("yaml")) if face.get("yaml") else None,
+        "expected_tag_ids": expected_ids,
+        "detected_tag_ids": detected_ids,
+        "validation_ok": bool(validation_ok),
+        "auto_face": bool(auto_face),
+        "image": {
+            "path_raw": str(shot_paths.raw_path),
+            "path_ann": str(shot_paths.ann_path),
+            "path_meta": str(shot_paths.meta_path),
+            "width": width,
+            "height": height,
+        },
+        "camera": {"fx": fx, "fy": fy, "cx": cx, "cy": cy},
+        "timestamp": timestamp,
+    }
+
+
+def write_capture_outputs(
+    *,
+    raw_frame: Any,
+    annotated_frame: Any,
+    metadata: Mapping[str, Any],
+    shot_paths: ShotPaths,
+    manifest_path: Union[Path, str],
+    image_writer: Callable[[str, Any], bool],
+) -> None:
+    """Write raw/annotated images, metadata JSON, and one manifest row."""
+
+    for path, image in (
+        (shot_paths.raw_path, raw_frame),
+        (shot_paths.ann_path, annotated_frame),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not image_writer(str(path), image):
+            raise CaptureFaceError(f"Could not write capture image: {path}")
+
+    shot_paths.meta_path.parent.mkdir(parents=True, exist_ok=True)
+    with shot_paths.meta_path.open("w", encoding="utf-8") as handle:
+        json.dump(dict(metadata), handle, indent=2)
+        handle.write("\n")
+
+    append_capture_manifest(manifest_path, metadata)
+
+
+def append_capture_manifest(
+    manifest_path: Union[Path, str],
+    metadata: Mapping[str, Any],
+) -> None:
+    """Append one face-shot metadata row to the Step 3 CSV manifest."""
+
+    target = Path(manifest_path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    image = metadata.get("image", {})
+    camera = metadata.get("camera", {})
+    row = {
+        "timestamp": metadata.get("timestamp", ""),
+        "object_base": metadata.get("object_base", ""),
+        "object_full": metadata.get("object_full", ""),
+        "side": metadata.get("side", ""),
+        "face_yaml": metadata.get("face_yaml", "") or "",
+        "path_raw": image.get("path_raw", ""),
+        "path_ann": image.get("path_ann", ""),
+        "path_meta": image.get("path_meta", ""),
+        "width": image.get("width", 0),
+        "height": image.get("height", 0),
+        "fx": camera.get("fx", 0.0),
+        "fy": camera.get("fy", 0.0),
+        "cx": camera.get("cx", 0.0),
+        "cy": camera.get("cy", 0.0),
+        "detected_ids": " ".join(map(str, metadata.get("detected_tag_ids", []))),
+        "expected_ids": " ".join(map(str, metadata.get("expected_tag_ids", []))),
+        "validation_ok": int(bool(metadata.get("validation_ok", False))),
+        "auto_face": int(bool(metadata.get("auto_face", False))),
+    }
+
+    write_header = not target.exists()
+    with target.open("a", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(CAPTURE_MANIFEST_FIELDS))
+        if write_header:
+            writer.writeheader()
+        writer.writerow(row)
+
+
+def validate_capture_metadata_schema(metadata: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return schema errors for one Step 3 metadata JSON mapping."""
+
+    errors: list[str] = []
+    for field in (
+        "object_base",
+        "object_full",
+        "side",
+        "face_yaml",
+        "expected_tag_ids",
+        "detected_tag_ids",
+        "validation_ok",
+        "auto_face",
+        "image",
+        "camera",
+        "timestamp",
+    ):
+        if field not in metadata:
+            errors.append(f"Capture metadata is missing field {field!r}.")
+
+    for field in ("object_base", "object_full", "side", "timestamp"):
+        if field in metadata and (
+            not isinstance(metadata.get(field), str) or not str(metadata[field]).strip()
+        ):
+            errors.append(f"Capture metadata field {field!r} must be a non-empty string.")
+
+    for field in ("expected_tag_ids", "detected_tag_ids"):
+        value = metadata.get(field)
+        if not isinstance(value, list) or any(_parse_int(item) is None for item in value):
+            errors.append(f"Capture metadata field {field!r} must be a list of integer tag IDs.")
+
+    for field in ("validation_ok", "auto_face"):
+        if field in metadata and not isinstance(metadata.get(field), bool):
+            errors.append(f"Capture metadata field {field!r} must be boolean.")
+
+    image = metadata.get("image")
+    if not isinstance(image, Mapping):
+        errors.append("Capture metadata field 'image' must be a mapping.")
+    else:
+        for field in ("path_raw", "path_ann", "path_meta"):
+            if not isinstance(image.get(field), str) or not image[field].strip():
+                errors.append(f"Capture metadata image field {field!r} must be a non-empty string.")
+        for field in ("width", "height"):
+            parsed = _parse_int(image.get(field))
+            if parsed is None or parsed <= 0:
+                errors.append(f"Capture metadata image field {field!r} must be a positive integer.")
+
+    camera = metadata.get("camera")
+    if not isinstance(camera, Mapping):
+        errors.append("Capture metadata field 'camera' must be a mapping.")
+    else:
+        for field in ("fx", "fy", "cx", "cy"):
+            value = camera.get(field)
+            if isinstance(value, bool):
+                errors.append(f"Capture metadata camera field {field!r} must be numeric.")
+                continue
+            try:
+                numeric = float(value)
+            except (TypeError, ValueError):
+                errors.append(f"Capture metadata camera field {field!r} must be numeric.")
+                continue
+            if not math.isfinite(numeric):
+                errors.append(f"Capture metadata camera field {field!r} must be finite.")
+
+    return tuple(errors)
+
+
+def _parse_int(value: Any) -> Optional[int]:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    if isinstance(value, float) and not value.is_integer():
+        return None
+    return parsed

--- a/src/posetag/pipelines/capture_face.py
+++ b/src/posetag/pipelines/capture_face.py
@@ -143,13 +143,13 @@ def resolve_capture_calibration_path(
     raw = Path(calib or "calib_color.yaml").expanduser()
     if raw.is_absolute():
         return raw
-    if raw.exists():
-        return raw
 
     candidates = (root / "calib" / raw, root / raw)
     for candidate in candidates:
         if candidate.exists():
             return candidate
+    if raw.exists():
+        return raw
     return candidates[0]
 
 
@@ -362,14 +362,23 @@ def load_registered_faces(
 
         grouped.setdefault((board_path, object_name), set()).add(tag_id)
 
-    faces = [
-        {
-            "yaml": str(board_path),
-            "object": object_name,
-            "tag_ids": tuple(sorted(tag_ids)),
-        }
-        for (board_path, object_name), tag_ids in grouped.items()
-    ]
+    faces = []
+    for (board_path, object_name), registry_tag_ids in grouped.items():
+        board_object, board_tag_ids = board_cache[board_path]
+        missing_tag_ids = sorted(board_tag_ids.difference(registry_tag_ids))
+        if missing_tag_ids:
+            joined = ", ".join(str(tag_id) for tag_id in missing_tag_ids)
+            raise CaptureFaceError(
+                f"Tag registry entries for {board_path} do not cover all board "
+                f"YAML tag IDs; missing {joined}."
+            )
+        faces.append(
+            {
+                "yaml": str(board_path),
+                "object": board_object,
+                "tag_ids": tuple(sorted(board_tag_ids)),
+            }
+        )
     faces.sort(key=lambda face: (str(face["object"]), Path(str(face["yaml"])).name))
     if not faces:
         raise CaptureFaceError("Tag registry YAML did not resolve to any readable board faces.")

--- a/tests/test_step3_capture_face.py
+++ b/tests/test_step3_capture_face.py
@@ -1,0 +1,577 @@
+from __future__ import annotations
+
+import csv
+import json
+import os
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import numpy as np
+import yaml
+
+import capture_face as legacy_capture_face
+from posetag.cli import capture_face as capture_face_cli
+from posetag.pipelines.capture_face import (
+    append_capture_manifest,
+    build_capture_metadata,
+    build_shot_paths,
+    load_capture_registry,
+    load_registered_faces,
+    prepare_capture_paths,
+    resolve_capture_calibration_path,
+    select_initial_faces,
+    validate_capture_metadata_schema,
+)
+from posetag.pipelines.make_board import build_board_yaml, write_board_yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _isolated_env(base: Path) -> dict[str, str]:
+    return {
+        "HOME": str(base / "home"),
+        "XDG_CONFIG_HOME": str(base / ".config"),
+    }
+
+
+def _write_calibration(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "image_width": 640,
+                "image_height": 480,
+                "camera_matrix": {
+                    "fx": 600.0,
+                    "fy": 610.0,
+                    "cx": 320.0,
+                    "cy": 240.0,
+                },
+                "distortion_coefficients": {
+                    "k1": 0.0,
+                    "k2": 0.0,
+                    "p1": 0.0,
+                    "p2": 0.0,
+                    "k3": 0.0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_board_and_registry(project_root: Path) -> tuple[Path, Path]:
+    board_path = project_root / "boards" / "connection_plate_white_sideA.yaml"
+    registry_path = project_root / "boards" / "tag_registry.yaml"
+    board = build_board_yaml(
+        object_name="connection_plate_white_sideA",
+        family="tag36h11",
+        tag_size_mm=80.0,
+        origin_id=52,
+        entries=[
+            {"id": 52, "cx": 0.0, "cy": 0.0, "yaw_deg": 0.0},
+            {"id": 53, "cx": 0.1, "cy": -0.2, "yaw_deg": 180.0},
+        ],
+    )
+    write_board_yaml(board_path, board)
+    registry = {
+        "version": 1,
+        "updated": "2026-05-29T12:00:00Z",
+        "tags": {
+            "52": {"object": "connection_plate_white_sideA", "yaml": str(board_path)},
+            "53": {"object": "connection_plate_white_sideA", "yaml": str(board_path)},
+        },
+    }
+    registry_path.write_text(yaml.safe_dump(registry), encoding="utf-8")
+    return board_path, registry_path
+
+
+class FakeDetector:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def detect(self, *args, **kwargs):
+        return []
+
+
+class OneTagDetector:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def detect(self, *args, **kwargs):
+        return [FakeDetection(52)]
+
+
+class FakeDetection:
+    def __init__(self, tag_id: int) -> None:
+        self.tag_id = tag_id
+        self.corners = np.array(
+            [[2.0, 2.0], [18.0, 2.0], [18.0, 18.0], [2.0, 18.0]],
+            dtype=float,
+        )
+
+
+class CaptureFaceStep3Tests(unittest.TestCase):
+    def test_cli_help_resolves(self) -> None:
+        stdout = StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            with redirect_stdout(stdout):
+                capture_face_cli.main(["--help"])
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("Capture wide shots per face", stdout.getvalue())
+        self.assertIn("--source", stdout.getvalue())
+
+    def test_console_script_target_help_resolves_after_install(self) -> None:
+        code = (
+            "from posetag.cli.capture_face import main\n"
+            "try:\n"
+            "    main(['--help'])\n"
+            "except SystemExit as exc:\n"
+            "    raise SystemExit(exc.code)\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("Capture wide shots per face", result.stdout)
+
+    def test_missing_video_for_video_source_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            with self.assertRaises(SystemExit) as ctx:
+                capture_face_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--source",
+                        "video",
+                        "--object_name",
+                        "connection_plate_white",
+                    ]
+                )
+
+            self.assertIn("--video path is required", str(ctx.exception))
+            self.assertFalse((project_root / "shots").exists())
+
+    def test_unreadable_video_path_fails_before_capture_artifacts(self) -> None:
+        class FakeClosedVideoCapture:
+            def __init__(self, _path: str) -> None:
+                pass
+
+            def isOpened(self) -> bool:
+                return False
+
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            video = base / "empty.mp4"
+            video.touch()
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+            _write_board_and_registry(project_root)
+
+            with patch.dict(os.environ, _isolated_env(base), clear=False):
+                with patch("capture_face.load_apriltag_detector_class", return_value=FakeDetector):
+                    with patch.object(
+                        legacy_capture_face.capture_source.cv2,
+                        "VideoCapture",
+                        FakeClosedVideoCapture,
+                    ):
+                        with self.assertRaises(SystemExit) as ctx:
+                            capture_face_cli.main(
+                                [
+                                    "--project_root",
+                                    str(project_root),
+                                    "--source",
+                                    "video",
+                                    "--video",
+                                    str(video),
+                                    "--object_name",
+                                    "connection_plate_white",
+                                ]
+                            )
+
+            self.assertIn("Could not open video", str(ctx.exception))
+            self.assertFalse((project_root / "shots").exists())
+            self.assertFalse((project_root / "logs").exists())
+
+    def test_realsense_source_without_dependency_fails_clearly(self) -> None:
+        with patch.object(legacy_capture_face.capture_source, "rs", None):
+            with self.assertRaises(SystemExit) as ctx:
+                capture_face_cli.main(["--source", "realsense"])
+
+        self.assertIn("pyrealsense2 is not available", str(ctx.exception))
+
+    def test_missing_calibration_yaml_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            with self.assertRaises(SystemExit) as ctx:
+                capture_face_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--source",
+                        "opencv",
+                        "--object_name",
+                        "connection_plate_white",
+                    ]
+                )
+
+            self.assertIn("Calibration YAML not found", str(ctx.exception))
+            self.assertFalse((project_root / "shots").exists())
+
+    def test_malformed_calibration_yaml_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib = project_root / "calib" / "calib_color.yaml"
+            calib.parent.mkdir(parents=True)
+            calib.write_text("not_camera_matrix: true\n", encoding="utf-8")
+
+            with self.assertRaises(SystemExit) as ctx:
+                capture_face_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--source",
+                        "opencv",
+                        "--object_name",
+                        "connection_plate_white",
+                    ]
+                )
+
+            self.assertIn("Malformed calibration YAML", str(ctx.exception))
+            self.assertFalse((project_root / "shots").exists())
+
+    def test_missing_registry_yaml_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+
+            with self.assertRaises(SystemExit) as ctx:
+                capture_face_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--source",
+                        "opencv",
+                        "--object_name",
+                        "connection_plate_white",
+                    ]
+                )
+
+            self.assertIn("Tag registry YAML not found", str(ctx.exception))
+            self.assertFalse((project_root / "shots").exists())
+
+    def test_malformed_registry_yaml_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+            registry = project_root / "boards" / "tag_registry.yaml"
+            registry.parent.mkdir(parents=True)
+            registry.write_text("tags: []\n", encoding="utf-8")
+
+            with self.assertRaises(SystemExit) as ctx:
+                capture_face_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--source",
+                        "opencv",
+                        "--object_name",
+                        "connection_plate_white",
+                    ]
+                )
+
+            self.assertIn("Malformed tag registry YAML", str(ctx.exception))
+            self.assertFalse((project_root / "shots").exists())
+
+    def test_missing_board_yaml_reference_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+            registry = project_root / "boards" / "tag_registry.yaml"
+            registry.parent.mkdir(parents=True)
+            registry.write_text(
+                yaml.safe_dump(
+                    {
+                        "version": 1,
+                        "tags": {
+                            "52": {
+                                "object": "connection_plate_white_sideA",
+                                "yaml": str(project_root / "boards" / "missing.yaml"),
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(SystemExit) as ctx:
+                capture_face_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--source",
+                        "opencv",
+                        "--object_name",
+                        "connection_plate_white",
+                    ]
+                )
+
+            self.assertIn("Referenced board YAML", str(ctx.exception))
+            self.assertIn("was not found", str(ctx.exception))
+            self.assertFalse((project_root / "shots").exists())
+
+    def test_unknown_object_selection_fails_before_opening_source(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+            _write_board_and_registry(project_root)
+
+            with self.assertRaises(SystemExit) as ctx:
+                capture_face_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--source",
+                        "opencv",
+                        "--object_name",
+                        "unknown_object",
+                    ]
+                )
+
+            self.assertIn("No registered face found", str(ctx.exception))
+            self.assertFalse((project_root / "shots").exists())
+
+    def test_registry_and_selection_helpers_resolve_faces(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            board_path, registry_path = _write_board_and_registry(project_root)
+
+            registry = load_capture_registry(registry_path)
+            faces = load_registered_faces(
+                registry,
+                project_root=project_root,
+                registry_path=registry_path,
+            )
+            selection = select_initial_faces("connection_plate_white", faces)
+
+            self.assertIsNotNone(selection)
+            self.assertEqual(selection.object_base, "connection_plate_white")
+            self.assertTrue(selection.auto_side)
+            self.assertEqual(selection.faces[0]["yaml"], str(board_path))
+            self.assertEqual(selection.faces[0]["tag_ids"], (52, 53))
+
+    def test_path_metadata_and_manifest_helpers(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib = project_root / "calib" / "calib_color.yaml"
+            _write_calibration(calib)
+            resolved_calib = resolve_capture_calibration_path(project_root, "calib_color.yaml")
+            self.assertEqual(resolved_calib.resolve(), calib.resolve())
+
+            paths = prepare_capture_paths(
+                project_root=project_root,
+                calib_path=calib,
+                layout="by_object_side",
+            )
+            shot_paths = build_shot_paths(
+                layout="by_object_side",
+                out_dir=paths.out_dir,
+                object_full="connection_plate_white_sideA",
+                timestamp="20260529_120000",
+            )
+            resolved_project = project_root.resolve()
+            self.assertEqual(
+                shot_paths.raw_path,
+                resolved_project
+                / "shots"
+                / "connection_plate_white"
+                / "sideA"
+                / "connection_plate_white_sideA_20260529_120000_raw.png",
+            )
+
+            metadata = build_capture_metadata(
+                face={
+                    "yaml": str(project_root / "boards" / "connection_plate_white_sideA.yaml"),
+                    "object": "connection_plate_white_sideA",
+                    "tag_ids": (52, 53),
+                },
+                shot_paths=shot_paths,
+                detected_tag_ids={52},
+                validation_ok=True,
+                auto_face=True,
+                frame_shape=(480, 640, 3),
+                camera_params=(600.0, 610.0, 320.0, 240.0),
+                timestamp="20260529_120000",
+            )
+
+            self.assertEqual(validate_capture_metadata_schema(metadata), ())
+            append_capture_manifest(paths.manifest_path, metadata)
+
+            with paths.manifest_path.open("r", newline="", encoding="utf-8") as handle:
+                rows = list(csv.DictReader(handle))
+
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["object_full"], "connection_plate_white_sideA")
+            self.assertEqual(rows[0]["detected_ids"], "52")
+            self.assertEqual(rows[0]["expected_ids"], "52 53")
+
+    def test_video_eof_exits_cleanly_without_capture(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            video = base / "input.mp4"
+            video.touch()
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+            _write_board_and_registry(project_root)
+
+            stopped = {"called": False}
+
+            def fake_open_source(*args, **kwargs):
+                def read_frame():
+                    return None
+
+                def stop():
+                    stopped["called"] = True
+
+                return read_frame, stop, {"kind": "video"}
+
+            with patch.dict(os.environ, _isolated_env(base), clear=False):
+                with patch("capture_face.load_apriltag_detector_class", return_value=FakeDetector):
+                    with patch.object(legacy_capture_face.capture_source, "open_source", fake_open_source):
+                        with patch("capture_face.cv2.namedWindow"):
+                            with patch("capture_face.cv2.resizeWindow"):
+                                with patch("capture_face.cv2.destroyAllWindows"):
+                                    result = capture_face_cli.main(
+                                        [
+                                            "--project_root",
+                                            str(project_root),
+                                            "--source",
+                                            "video",
+                                            "--video",
+                                            str(video),
+                                            "--object_name",
+                                            "connection_plate_white",
+                                        ]
+                                    )
+
+            self.assertEqual(result, 0)
+            self.assertTrue(stopped["called"])
+            self.assertFalse((project_root / "shots" / "manifest.csv").exists())
+
+    def test_escape_exits_cleanly_without_capture(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            video = base / "input.mp4"
+            video.touch()
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+            _write_board_and_registry(project_root)
+            frame = np.zeros((40, 60, 3), dtype=np.uint8)
+
+            def fake_open_source(*args, **kwargs):
+                return lambda: frame.copy(), lambda: None, {"kind": "video"}
+
+            with patch.dict(os.environ, _isolated_env(base), clear=False):
+                with patch("capture_face.load_apriltag_detector_class", return_value=FakeDetector):
+                    with patch.object(legacy_capture_face.capture_source, "open_source", fake_open_source):
+                        with patch("capture_face.cv2.namedWindow"):
+                            with patch("capture_face.cv2.resizeWindow"):
+                                with patch("capture_face.cv2.imshow"):
+                                    with patch("capture_face.cv2.waitKeyEx", return_value=27):
+                                        with patch("capture_face.cv2.destroyAllWindows"):
+                                            result = capture_face_cli.main(
+                                                [
+                                                    "--project_root",
+                                                    str(project_root),
+                                                    "--source",
+                                                    "video",
+                                                    "--video",
+                                                    str(video),
+                                                    "--object_name",
+                                                    "connection_plate_white",
+                                                ]
+                                            )
+
+            self.assertEqual(result, 0)
+            self.assertFalse((project_root / "shots" / "manifest.csv").exists())
+
+    def test_synthetic_enter_save_writes_images_metadata_and_manifest(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            video = base / "input.mp4"
+            video.touch()
+            _write_calibration(project_root / "calib" / "calib_color.yaml")
+            _write_board_and_registry(project_root)
+            frame = np.full((40, 60, 3), 80, dtype=np.uint8)
+            frames = [frame.copy(), None]
+
+            def fake_open_source(*args, **kwargs):
+                def read_frame():
+                    return frames.pop(0)
+
+                return read_frame, lambda: None, {"kind": "video"}
+
+            with patch.dict(os.environ, _isolated_env(base), clear=False):
+                with patch("capture_face.load_apriltag_detector_class", return_value=OneTagDetector):
+                    with patch.object(legacy_capture_face.capture_source, "open_source", fake_open_source):
+                        with patch("capture_face.capture_timestamp", return_value="20260529_120000"):
+                            with patch("capture_face.cv2.namedWindow"):
+                                with patch("capture_face.cv2.resizeWindow"):
+                                    with patch("capture_face.cv2.imshow"):
+                                        with patch("capture_face.cv2.waitKeyEx", return_value=13):
+                                            with patch("capture_face.cv2.destroyAllWindows"):
+                                                result = capture_face_cli.main(
+                                                    [
+                                                        "--project_root",
+                                                        str(project_root),
+                                                        "--source",
+                                                        "video",
+                                                        "--video",
+                                                        str(video),
+                                                        "--object_name",
+                                                        "connection_plate_white",
+                                                    ]
+                                                )
+
+            self.assertEqual(result, 0)
+            resolved_project = project_root.resolve()
+            shot_dir = resolved_project / "shots" / "connection_plate_white" / "sideA"
+            raw_path = shot_dir / "connection_plate_white_sideA_20260529_120000_raw.png"
+            ann_path = shot_dir / "connection_plate_white_sideA_20260529_120000_ann.png"
+            meta_path = shot_dir / "connection_plate_white_sideA_20260529_120000_meta.json"
+            manifest_path = resolved_project / "shots" / "manifest.csv"
+
+            self.assertTrue(raw_path.is_file())
+            self.assertTrue(ann_path.is_file())
+            self.assertTrue(meta_path.is_file())
+            self.assertTrue(manifest_path.is_file())
+
+            metadata = json.loads(meta_path.read_text(encoding="utf-8"))
+            self.assertEqual(validate_capture_metadata_schema(metadata), ())
+            self.assertEqual(metadata["object_full"], "connection_plate_white_sideA")
+            self.assertEqual(metadata["expected_tag_ids"], [52, 53])
+            self.assertEqual(metadata["detected_tag_ids"], [52])
+            self.assertTrue(metadata["validation_ok"])
+
+            with manifest_path.open("r", newline="", encoding="utf-8") as handle:
+                rows = list(csv.DictReader(handle))
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["path_meta"], str(meta_path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_step3_capture_face.py
+++ b/tests/test_step3_capture_face.py
@@ -21,6 +21,7 @@ from posetag.pipelines.capture_face import (
     append_capture_manifest,
     build_capture_metadata,
     build_shot_paths,
+    CaptureFaceError,
     load_capture_registry,
     load_registered_faces,
     prepare_capture_paths,
@@ -372,6 +373,42 @@ class CaptureFaceStep3Tests(unittest.TestCase):
             self.assertTrue(selection.auto_side)
             self.assertEqual(selection.faces[0]["yaml"], str(board_path))
             self.assertEqual(selection.faces[0]["tag_ids"], (52, 53))
+
+    def test_stale_registry_missing_board_tag_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _board_path, registry_path = _write_board_and_registry(project_root)
+            registry = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+            del registry["tags"]["53"]
+            registry_path.write_text(yaml.safe_dump(registry), encoding="utf-8")
+
+            with self.assertRaises(CaptureFaceError) as ctx:
+                load_registered_faces(
+                    load_capture_registry(registry_path),
+                    project_root=project_root,
+                    registry_path=registry_path,
+                )
+
+            self.assertIn("do not cover all board YAML tag IDs", str(ctx.exception))
+            self.assertIn("53", str(ctx.exception))
+
+    def test_project_calibration_takes_precedence_over_cwd_file(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            base = Path(tmpdir)
+            project_root = base / "project"
+            project_calib = project_root / "calib" / "calib_color.yaml"
+            cwd_calib = base / "cwd" / "calib_color.yaml"
+            _write_calibration(project_calib)
+            _write_calibration(cwd_calib)
+
+            previous_cwd = Path.cwd()
+            os.chdir(cwd_calib.parent)
+            try:
+                resolved = resolve_capture_calibration_path(project_root, "calib_color.yaml")
+            finally:
+                os.chdir(previous_cwd)
+
+            self.assertEqual(resolved.resolve(), project_calib.resolve())
 
     def test_path_metadata_and_manifest_helpers(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/utils/capture_utils.py
+++ b/utils/capture_utils.py
@@ -2,7 +2,10 @@ import argparse, os, sys, json, time, datetime, re
 import yaml
 import numpy as np
 import cv2
-import pyrealsense2 as rs
+try:
+    import pyrealsense2 as rs
+except Exception:
+    rs = None
 from pathlib import Path
 from typing import List, Dict, Tuple, Optional, Set
 import csv

--- a/utils/intel_realsense_utils.py
+++ b/utils/intel_realsense_utils.py
@@ -1,5 +1,8 @@
 import time, os
-import pyrealsense2 as rs
+try:
+    import pyrealsense2 as rs
+except Exception:
+    rs = None
 import yaml
 import numpy as np
 


### PR DESCRIPTION
Closes #37.

Summary:
- Adds package-level Step 3 helpers for validation, path resolution, registered-face loading, metadata JSON, and manifest CSV writing.
- Keeps the existing OpenCV face-shot viewer behavior while making `posetag-capture-face --help` work from an editable install.
- Hardens missing calibration, malformed calibration, missing or malformed registry, missing board YAML, unknown object selection, video-source, RealSense dependency, video EOF, and clean quit paths.
- Adds the Step 3 workflow doc, README Step 3 updates, and the validation report.

Validation:
- `python3 -m unittest tests.test_step3_capture_face -v` -> 16 tests passed.
- `python3 -m unittest discover -s tests -v` -> 218 tests passed.
- `python3 -m compileall -q src utils tests` -> passed.
- `git diff --check` -> passed.
- `python3 -m pip install -e .` -> editable install succeeded.
- Installed `posetag-capture-face --help` -> resolved successfully.

Outputs and schema verified:
- Default raw/annotated/meta output layout under `shots/<object_base>/side<Side>/`.
- Per-shot metadata fields for object identity, face YAML, expected/detected IDs, validation flags, image paths/size, camera intrinsics, and timestamp.
- `shots/manifest.csv` rows for saved captures.
- Synthetic hardware-free save writes small PNGs, metadata JSON, and manifest CSV in a temporary project.

Residual risks and technical debt:
- The interactive viewer still lives in `src/capture_face.py`; a later architecture pass should move the runtime after workflow boundaries through annotation are better protected.
- Manual webcam, RealSense, live overlay, auto-side, and double-press force-save checks are still needed on real hardware.
- This PR intentionally does not implement face annotation, board-to-object transforms, dataset collection, or pose estimation.
