### PR TITLE
Validate dataset collection workflow and pose outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,11 @@ coverage, such as moving the board toward missing frame edges/corners or
 changing distance. Guided auto-capture saves good frames as the board covers
 the grid, while `SPACE` remains available as a manual override. The GUI does
 not reimplement AprilTag rendering, calibration solving, board-frame math,
-board YAML schemas, registry writing, annotation, or dataset workflows.
+board YAML schemas, registry writing, annotation, or dataset writing. In Stage
+8 it can dry-run and launch the existing `posetag-collect` workflow with a
+session name and OpenCV/RealSense/video/bag source settings; the separate
+capture/review window still owns frame acceptance and pose-labelled output
+writing.
 
 ## Scientific Contract
 
@@ -855,40 +859,72 @@ Detailed Step 5 notes: `docs/workflows/step5_annotate_faces.md`.
 
 ### 6) Collect a ground-truth dataset (multi-object / multi-face)
 
-Live RealSense, RealSense `.bag`, or any OpenCV-readable video. For each frame:
+OpenCV webcam, live RealSense, RealSense `.bag`, or any OpenCV-readable video.
+For each frame:
 
 - detect tags once, even when faces use mixed tag sizes
 - choose the best visible face per object
 - compose `T_cam_object = T_cam_board @ T_board_object`
-- review annotated, reprojection, and status panels before saving
+- save either by manual review, quality-gated smart auto-capture, or the crude
+  legacy continuous mode
 
-**Live (RGB, optional aligned depth)**
+Preflight without opening a camera or writing dataset outputs:
 
 ```bash
-posetag-collect --mode live --session run01 --calib calib_color.yaml --rs_w 640 --rs_h 480 --rs_fps 30
+posetag-collect --project_root my_project --mode opencv --session run01 --dry-run
+```
+
+In the GUI, open Stage 8 and use **Dry Run** for the same input/schema
+preflight, then **Start Collection** to launch the existing `posetag-collect`
+workflow. The dashboard defaults to smart auto-capture, streams process output,
+and refreshes project status after the process exits; it does not reimplement
+pose estimation or dataset writing.
+
+Required inputs are `calib/calib_color.yaml`, `boards/tag_registry.yaml`, board
+YAMLs referenced by the registry, `faces/face_manifest.csv`, and annotation
+YAMLs containing `T_board_object`. `objects/<object>/keypoints.json` is
+optional; when present it improves bounding boxes and review metadata.
+
+**OpenCV webcam**
+
+```bash
+posetag-collect --mode opencv --cam 0 --session run01 --calib calib_color.yaml --auto-capture
+```
+
+Smart auto-capture waits for stable object pose, minimum detection quality,
+cooldown, and a useful new view before saving. It considers visible tag count,
+bbox area, optional tag-scale diagnostics, image coverage grid cells, distance
+bins, and pose deltas. `ENTER` / `y` / `s` still force-save the current frame.
+Use `--continuous` only when you explicitly want the old save-every-frame
+behavior.
+
+**Live RealSense (RGB, optional aligned depth)**
+
+```bash
+posetag-collect --mode live --session run02 --calib calib_color.yaml --rs_w 640 --rs_h 480 --rs_fps 30
 # add --save_depth to save aligned depth .npy per accepted frame
 ```
 
 **Playback from `.bag`**
 
 ```bash
-posetag-collect --mode bag --bag path/to/rec.bag --session run02 --calib calib_color.yaml
+posetag-collect --mode bag --bag path/to/rec.bag --session run03 --calib calib_color.yaml
 ```
 
 **Any video**
 
 ```bash
-posetag-collect --mode video --video sample.mp4 --session run03 --calib calib_color.yaml
+posetag-collect --mode video --video sample.mp4 --session run04 --calib calib_color.yaml
 ```
 
 **Keys**
 
-- `ENTER` / `y` / `s`: accept and save current view
+- `ENTER` / `y` / `s`: accept and save current view, or force-save in smart mode
 - `SPACE` / `p`: pause or resume
 - `r` / `n` / `BACKSPACE`: reject or skip frame
 - `h`: toggle help
-- `ESC` / `q`: abort current frame
-- `Q` / `X`: quit all
+- `ESC` / `q` / `Q`: close capture cleanly
+- `x` / `X`: close capture cleanly
 
 Important: the stream resolution must match `calib_color.yaml`
 (`image_width` / `image_height`). Use `--rs_w` / `--rs_h` or recalibrate.
@@ -930,6 +966,11 @@ saved objects.
   "annotated_image": "Run_<tag>_annotated_frame_<idx>.png",
   "reproj_image": "Run_<tag>_reproj_frame_<idx>.png",
   "depth": "Run_<tag>_depth_frame_<idx>.npy",
+  "capture": {
+    "mode": "smart_auto",
+    "reason": "coverage_cell",
+    "trigger_object": "connection_plate_white"
+  },
   "camera_intrinsics": {
     "fx": 594.97,
     "fy": 601.72,
@@ -943,13 +984,34 @@ saved objects.
     "orientation": [x, y, z, w],
     "rpy_deg": [roll, pitch, yaw]
   },
+  "pose_convention": {
+    "composition": "T_cam_object = T_cam_board @ T_board_object",
+    "translation_units": "meters",
+    "quaternion_order": "x, y, z, w",
+    "rpy_order": "roll, pitch, yaw",
+    "angle_units": "degrees"
+  },
   "objects": [
     {
+      "object_name": "connection_plate_white",
+      "selected_face": "connection_plate_white_sideA",
+      "selected_board": "boards/connection_plate_white_sideA.yaml",
       "class_id": 2,
       "class_name": "connection_plate",
       "2D_center": [cx, cy],
       "width": 0.25,
       "height": 0.18,
+      "transforms": {
+        "T_cam_board": {"matrix": [[...]]},
+        "T_board_object": {"matrix": [[...]]},
+        "T_cam_object": {"matrix": [[...]]}
+      },
+      "quality": {
+        "tag_used": 52,
+        "num_tags_visible": 2,
+        "score": 2500.0,
+        "bbox_source": "face_kps"
+      },
       "6DOF_pose": {
         "position": [tx, ty, tz],
         "orientation": [roll, pitch, yaw],
@@ -967,12 +1029,23 @@ Notes on interpretation:
 - `camera_extrinsics.orientation` is a quaternion in `[x, y, z, w]` order
 - `objects[].6DOF_pose.orientation` is roll, pitch, yaw in degrees
 - `objects[].6DOF_pose.rotation` is a quaternion in `[x, y, z, w]` order
+- `objects[].transforms.T_cam_object` must equal
+  `T_cam_board @ T_board_object`
 - 2D centers and box sizes are normalized by image width and height
 - the raw image saved in `images/` is tag-covered to suppress AprilTags visually
+- if present, `capture` records acceptance provenance such as `manual_review`,
+  `smart_auto`, or `continuous`; it does not change pose semantics
+
+Detailed Step 6 notes: `docs/workflows/step6_collect_dataset.md`.
 
 Common options include:
 
 - `--continuous`
+- `--auto-capture`
+- `--auto-stable-frames N`
+- `--auto-cooldown-sec SEC`
+- `--auto-grid ROWSxCOLS`
+- `--auto-distance-bin-m M`
 - `--max_frames N`
 - `--save_depth`
 - `--axes {both,board,object,none}`
@@ -1085,7 +1158,7 @@ are:
 - `posetag-collect` -> dataset capture
 - `posetag-gui` -> optional workflow dashboard for status, ChArUco board
   setup, guided calibration launch, object AprilTag generation, and
-  board-building guidance
+  board-building, face-shot, annotation, and dataset-collection guidance
 - `python3 -m gen_keypoints` -> legacy mesh-keypoint browser
 - `python3 -m generate_canonical_keypoints` -> experimental sampled keypoint
   files under `canonical_keypoints/` (not annotation-ready)

--- a/README.md
+++ b/README.md
@@ -865,8 +865,8 @@ For each frame:
 - detect tags once, even when faces use mixed tag sizes
 - choose the best visible face per object
 - compose `T_cam_object = T_cam_board @ T_board_object`
-- save either by manual review, quality-gated smart auto-capture, or the crude
-  legacy continuous mode
+- save pose-labelled frames by manual review, quality-gated smart auto-capture,
+  or the crude legacy continuous mode
 
 Preflight without opening a camera or writing dataset outputs:
 
@@ -895,8 +895,8 @@ Smart auto-capture waits for stable object pose, minimum detection quality,
 cooldown, and a useful new view before saving. It considers visible tag count,
 bbox area, optional tag-scale diagnostics, image coverage grid cells, distance
 bins, and pose deltas. `ENTER` / `y` / `s` still force-save the current frame.
-Use `--continuous` only when you explicitly want the old save-every-frame
-behavior.
+Use `--continuous` only when you explicitly want the old crude behavior of
+saving every frame that has at least one pose-labelled object.
 
 **Live RealSense (RGB, optional aligned depth)**
 

--- a/STEP6_COLLECT_DATASET_REPORT.md
+++ b/STEP6_COLLECT_DATASET_REPORT.md
@@ -42,7 +42,9 @@ T_cam_object = T_cam_board @ T_board_object
   - add `--auto-capture` as a quality-gated smart collection policy over the
     existing pose results
   - keep manual review as a force-save path and keep `--continuous` as the
-    legacy save-every-frame mode
+    legacy save-every-pose-labelled-frame mode
+  - reject accepted saves when no object pose was estimated, so frame-only
+    captures do not masquerade as pose-labelled dataset annotations
   - keep the existing interactive capture loop and best-face selection logic
 - Added smart auto-capture helpers and tests for stability gates, cooldown,
   image-grid coverage, distance/pose diversity, candidate quality rejection,
@@ -159,21 +161,21 @@ python3 -m posetag.cli.collect --project_root my_project --mode opencv --session
 Focused collection tests:
 
 ```text
-Ran 16 tests in 0.170s
+Ran 17 tests in 0.138s
 OK
 ```
 
 Focused Stage 8 / GUI / status tests:
 
 ```text
-Ran 90 tests in 0.750s
+Ran 91 tests in 0.736s
 OK
 ```
 
 Full test suite:
 
 ```text
-Ran 307 tests in 3.523s
+Ran 308 tests in 3.219s
 OK
 ```
 

--- a/STEP6_COLLECT_DATASET_REPORT.md
+++ b/STEP6_COLLECT_DATASET_REPORT.md
@@ -1,0 +1,224 @@
+# Step 6 Dataset Collection Validation Report
+
+Issue: #39 `[workflow] Validate Step 5: dataset collection and pose outputs`
+
+Branch: `feature/39-dataset-collection-validation`
+
+## Purpose
+
+This validation pass hardens `posetag-collect`, the workflow that records
+ground-truth pose-labelled dataset frames after calibration, board building,
+face-shot capture, mesh keypoint generation, and face annotation are complete.
+
+The scientific pose invariant is preserved:
+
+```text
+T_cam_object = T_cam_board @ T_board_object
+```
+
+## What Changed
+
+- Added `posetag.pipelines.collect_dataset` with hardware-free helpers for:
+  - source argument validation
+  - calibration, registry, face manifest, board YAML, and annotation preflight
+  - dataset path resolution
+  - session metadata construction
+  - frame pose-record serialization
+  - transform composition checks
+  - quaternion `[x, y, z, w]` serialization
+- Updated `posetag-collect` / `src/collect_gt_dataset.py` to:
+  - support `main(argv)` through the canonical CLI wrapper
+  - add `--project_root`, `--registry`, `--face_manifest`, and `--dry-run`
+  - add `--mode opencv` for generic OpenCV webcam capture
+  - keep `--mode live` as RealSense live, `--mode bag` as RealSense playback,
+    and `--mode video` as OpenCV-readable video playback
+  - validate required project inputs before opening capture sources
+  - require calibration `image_width` and `image_height` for collection
+  - reject missing video/bag arguments, unreadable videos, missing RealSense
+    support, missing registries, missing manifests, missing board YAMLs, and
+    annotation YAMLs missing `T_board_object.matrix`
+  - include explicit object name, selected face, selected board, transforms,
+    quality fields, units, and rotation ordering in per-frame JSON labels
+  - add `--auto-capture` as a quality-gated smart collection policy over the
+    existing pose results
+  - keep manual review as a force-save path and keep `--continuous` as the
+    legacy save-every-frame mode
+  - keep the existing interactive capture loop and best-face selection logic
+- Added smart auto-capture helpers and tests for stability gates, cooldown,
+  image-grid coverage, distance/pose diversity, candidate quality rejection,
+  and pose-delta calculations.
+- Updated README collection notes and added
+  `docs/workflows/step6_collect_dataset.md`.
+- Added hardware-free tests in `tests/test_step6_collect_dataset.py`.
+- Wired Stage 8 project-status inspection so `posetag-gui` no longer reports
+  collection as `not_applicable` after annotation is complete. A collection-
+  ready project with no dataset sessions now reports Stage 8 as missing/ready
+  to run, and malformed dataset pose records surface as needs-attention.
+- Added `posetag.workflows.collect_dataset` with GUI-independent launch helpers
+  for Stage 8 command construction, source/session validation, dry-run launch,
+  collection launch, and process-state summaries.
+- Added a Stage 8 dashboard action panel with session/source controls,
+  smart auto-capture controls, **Dry Run**, **Start Collection**, process state,
+  and stdout/stderr logging. The GUI launches the existing `posetag-collect`
+  process and does not duplicate detection, pose estimation, transform
+  composition, or dataset writing.
+- Refined the runtime GT Capture review window while preserving capture and
+  pose logic: annotation and reprojection panes now use clearer labels, and the
+  right panel shows structured session metrics, selected object pose summaries,
+  capture feedback, and keyboard controls instead of the older yellow text
+  dump.
+- Simplified GT Capture quit behavior: `ESC`, `q`, `Q`, `x`, and `X` now close
+  the capture loop through normal cleanup, and the window close button is
+  detected when OpenCV reports it.
+- Updated the GUI command preview for collection to start with
+  `posetag-collect --mode opencv --session SESSION --calib calib_color.yaml
+  --auto-capture --dry-run`.
+
+## Required Inputs
+
+`posetag-collect --dry-run` now validates:
+
+- `calib/calib_color.yaml`
+- `boards/tag_registry.yaml`
+- board YAMLs referenced by the face annotations and registry
+- `faces/face_manifest.csv`
+- annotation YAMLs listed by the face manifest
+- `T_board_object.matrix` inside each annotation YAML
+
+`objects/<object>/keypoints.json` remains optional for collection. Missing
+keypoints are reported in dry-run/session metadata and trigger tag-derived
+bounding-box fallback.
+
+## Source Behavior
+
+- `--mode opencv`: generic OpenCV webcam via `--cam`, `--width`, `--height`,
+  and `--fps`.
+- `--mode live`: Intel RealSense live colour stream, optional depth output
+  with `--save_depth`.
+- `--mode bag`: Intel RealSense `.bag` playback.
+- `--mode video`: OpenCV-readable video file via `--video`.
+
+`--mode live` and `--mode bag` fail clearly when `pyrealsense2` is unavailable.
+
+## Output Schema
+
+Each accepted frame writes:
+
+- `datasets/<session>/images/*.png`
+- `datasets/<session>/annotated/*.png`
+- `datasets/<session>/reproj/*.png`
+- optional `datasets/<session>/depth/*.npy`
+- `datasets/<session>/annotations/*.json`
+- `datasets/<session>/session.yaml`
+- `datasets/<session>/<session>.jsonl`
+
+Per-object annotation records now include:
+
+- `object_name`
+- `selected_face`
+- `selected_board`
+- normalized and pixel bounding boxes
+- `transforms.T_cam_board`
+- `transforms.T_board_object`
+- `transforms.T_cam_object`
+- `quality` fields such as tag count, selected tag, score, bbox source, and
+  tag-scale diagnostics
+- `6DOF_pose.position` in meters
+- `6DOF_pose.orientation` as roll, pitch, yaw in degrees
+- `6DOF_pose.rotation` as quaternion `[x, y, z, w]`
+
+Per-frame records may include top-level `capture` provenance for the acceptance
+policy (`manual_review`, `smart_auto`, or `continuous`). This is additive
+metadata and does not change object pose semantics.
+
+The serializer verifies that:
+
+```text
+T_cam_object == T_cam_board @ T_board_object
+```
+
+within numeric tolerance before writing an object pose record.
+
+## Validation Run
+
+Commands run:
+
+```bash
+python3 -m unittest tests.test_step6_collect_dataset -v
+python3 -m unittest tests.test_step6_collect_dataset tests.test_workflow_status tests.test_workflow_gui -v
+python3 -m unittest tests.test_workflow_gui tests.test_workflow_status tests.test_step6_collect_dataset -v
+python3 -m unittest discover -s tests -v
+python3 -m compileall -q src utils tests
+git diff --check
+python3 -m posetag.cli.collect --help
+/Users/samueladebayo/Library/Python/3.11/bin/posetag-collect --help
+python3 -m posetag.cli.collect --project_root my_project --mode opencv --session run01 --dry-run --auto-capture
+python3 -m posetag.cli.collect --project_root my_project --mode opencv --session run01 --dry-run --auto-capture --continuous
+```
+
+Focused collection tests:
+
+```text
+Ran 16 tests in 0.170s
+OK
+```
+
+Focused Stage 8 / GUI / status tests:
+
+```text
+Ran 90 tests in 0.750s
+OK
+```
+
+Full test suite:
+
+```text
+Ran 307 tests in 3.523s
+OK
+```
+
+`compileall`, `git diff --check`, and both help smoke checks completed
+successfully. The user-local `posetag-collect` script exists and resolves by
+absolute path, but that script directory
+(`/Users/samueladebayo/Library/Python/3.11/bin`) is not on this shell's `PATH`;
+`python3 -m posetag.cli.collect --help` is the PATH-independent smoke check.
+
+Local project dry-run smoke:
+
+```text
+Dataset collection dry run OK
+annotations : 6
+source mode : opencv
+```
+
+The intentionally invalid `--continuous --auto-capture` smoke exited with:
+
+```text
+--continuous and --auto-capture are mutually exclusive.
+```
+
+## Remaining Technical Debt
+
+- The collector still lives mainly in `src/collect_gt_dataset.py`; the
+  validation helpers are package-first, but the interactive capture loop was
+  intentionally not migrated in this issue.
+- `--allow-face-scan` preserves the legacy fallback that scans face YAMLs when
+  `faces/face_manifest.csv` is absent. New reproducible projects should use
+  the manifest.
+- Bounding-box quality still depends on optional keypoint coverage when
+  keypoints exist; missing keypoints fall back to tag-derived boxes.
+- Smart auto-capture thresholds are conservative defaults validated with
+  hardware-free policy tests; real-camera sessions should tune stability,
+  cooldown, coverage, and pose-diversity thresholds.
+
+## Manual Hardware Checks Still Needed
+
+- Run `--mode opencv` with a real webcam at the calibration resolution.
+- Run `--mode live` with an Intel RealSense device.
+- Run `--mode bag` with a representative `.bag` recording.
+- Run `--mode video` against a real experiment video with visible registered
+  faces.
+- Run `--auto-capture` on real OpenCV/RealSense/video sources and confirm it
+  saves stable, diverse views without flooding near-duplicates.
+- Confirm saved annotated/reprojection panels show plausible selected faces,
+  axes, and bounding boxes for real hardware captures.

--- a/docs/workflows/step6_collect_dataset.md
+++ b/docs/workflows/step6_collect_dataset.md
@@ -1,0 +1,334 @@
+# Step 6: Collect Dataset / Pose Outputs
+
+Step 6 is the runtime pose-labelling workflow. At this point PoseTag should
+already know the camera calibration, AprilTag board layouts, face-shot
+provenance, object keypoints where available, and the annotated
+`T_board_object` transform for each object face.
+
+The runtime pose composition is:
+
+```text
+T_cam_object = T_cam_board @ T_board_object
+```
+
+Do not invert or reorder this composition. `T_cam_board` maps board-frame
+points into the camera frame, `T_board_object` maps object-frame points into the
+board frame, and `T_cam_object` maps object-frame points into the camera frame.
+Matrices are 4x4 homogeneous transforms stored as row-major nested lists and
+are intended for column-vector multiplication.
+
+## Command
+
+```bash
+posetag-collect --project_root my_project --mode opencv --session run01 --dry-run
+```
+
+`--dry-run` validates required inputs and source arguments without opening a
+camera, creating a dataset session, or writing frame outputs. Run this first on
+a prepared project.
+
+## Optional GUI Launch
+
+The optional `posetag-gui` dashboard exposes dataset collection as Stage 8.
+When calibration, board definitions, face shots, mesh keypoints, and
+annotations are complete, Stage 8 shows readiness, expected outputs, and two
+actions:
+
+- **Dry Run** launches `posetag-collect --dry-run` with `POSETAG_PROJECT` set
+  for the selected project. It validates inputs and exits without opening a
+  camera or writing dataset outputs.
+- **Start Collection** launches the existing `posetag-collect` workflow with
+  the selected session/source values. The dashboard defaults to smart
+  auto-capture; the OpenCV/RealSense capture window still owns frame review
+  and saving.
+
+The GUI is process orchestration only. It does not reimplement AprilTag
+detection, pose estimation, best-face selection, transform composition, or
+dataset writing.
+
+## Required Inputs
+
+PoseTag validates these before opening the capture source:
+
+- `calib/calib_color.yaml`
+- `boards/tag_registry.yaml`
+- board YAMLs referenced by the face annotations and registry
+- `faces/face_manifest.csv`
+- annotation YAMLs listed by the face manifest
+- each annotation YAML must contain `T_board_object.matrix`
+
+`objects/<object>/keypoints.json` is optional for collection. When it exists,
+PoseTag uses object or face keypoints for bounding boxes and review metadata.
+When it is missing, collection can still run and falls back to tag-derived
+boxes.
+
+Relative calibration names such as `--calib calib_color.yaml` resolve first to
+`<project_root>/calib/calib_color.yaml`.
+
+## Source Modes
+
+OpenCV webcam:
+
+```bash
+posetag-collect --project_root my_project --mode opencv --cam 0 --session run01 \
+  --auto-capture
+```
+
+Live Intel RealSense:
+
+```bash
+posetag-collect --project_root my_project --mode live --session run02 \
+  --rs_w 640 --rs_h 480 --rs_fps 30
+```
+
+Add `--save_depth` to save aligned depth arrays when depth is available.
+
+RealSense `.bag` playback:
+
+```bash
+posetag-collect --project_root my_project --mode bag --bag path/to/rec.bag \
+  --session run03
+```
+
+OpenCV-readable video:
+
+```bash
+posetag-collect --project_root my_project --mode video --video sample.mp4 \
+  --session run04
+```
+
+`--mode live` and `--mode bag` require `pyrealsense2`. Install the RealSense
+extra or use `--mode opencv` / `--mode video` when RealSense support is not
+available.
+
+## Runtime Behavior
+
+For each frame, PoseTag:
+
+1. Checks the stream resolution against `calib/calib_color.yaml`
+   `image_width` / `image_height`.
+2. Detects AprilTags once per tag size.
+3. Estimates `T_cam_board` for visible faces.
+4. Composes `T_cam_object = T_cam_board @ T_board_object`.
+5. Scores visible faces and keeps the best face per object.
+6. Shows annotation review, reprojection/debug, and structured status panels.
+7. Saves the accepted frame and pose label when the user accepts it, when
+   smart auto-capture accepts it, or every frame when `--continuous` is
+   enabled.
+
+The best-face score prioritizes visible tag count, then image-space area.
+When the origin tag is visible, it is used for `T_cam_board`; otherwise PoseTag
+uses the visible board tag with the highest AprilTag decision margin and the
+stored `T_board_tag` transform from the board YAML.
+
+The status panel reports visible faces, saved frames, capture mode, selected
+object pose summaries, tag-scale diagnostics, and keyboard controls. This panel
+is display-only; it does not change pose estimation, frame acceptance, or output
+schemas.
+
+## Smart Auto-Capture
+
+`--auto-capture` is the preferred low-effort collection mode. It waits for:
+
+- detection quality: minimum visible tags and bbox area
+- optional tag-scale quality: reject candidates whose measured tag spacing is
+  too far from the board definition when scale diagnostics are available
+- pose stability: consecutive frames within translation and rotation deltas
+- cooldown: minimum time between saved frames
+- usefulness: first sample, a new image coverage grid cell, a new distance bin,
+  or a sufficiently different pose
+
+Common tuning flags:
+
+```bash
+posetag-collect --mode opencv --session run01 --auto-capture \
+  --auto-stable-frames 5 \
+  --auto-cooldown-sec 1.0 \
+  --auto-grid 3x3 \
+  --auto-min-translation-delta-m 0.04 \
+  --auto-min-rotation-delta-deg 8.0
+```
+
+`--continuous` remains available as the old crude save-every-frame mode, but it
+is mutually exclusive with `--auto-capture`.
+
+## Controls
+
+- `ENTER` / `y` / `s`: accept and save current view; force-save in smart mode
+- `SPACE` / `p`: pause or resume
+- `r` / `n` / `BACKSPACE`: reject or skip frame
+- `h`: toggle help
+- `ESC` / `q` / `Q`: close capture cleanly
+- `x` / `X`: close capture cleanly
+
+## Outputs
+
+Accepted frames are written under:
+
+```text
+datasets/<session>/
+  images/
+    Run_<YYYYMMDD-HHMMSS>_rgb_frame_<000000>.png
+  annotated/
+    Run_<YYYYMMDD-HHMMSS>_annotated_frame_<000000>.png
+  reproj/
+    Run_<YYYYMMDD-HHMMSS>_reproj_frame_<000000>.png
+  depth/
+    Run_<YYYYMMDD-HHMMSS>_depth_frame_<000000>.npy
+  annotations/
+    Run_<YYYYMMDD-HHMMSS>_frame_<000000>.json
+  session.yaml
+  <session>.jsonl
+```
+
+`images/` contains the saved RGB/BGR frame with detected tags covered to reduce
+visual tag leakage. `annotated/` contains overlays, bounding boxes, labels, and
+axes. `reproj/` contains the reprojection/debug view. `depth/` is written only
+when `--save_depth` is set and the source supplies aligned depth.
+
+`session.yaml` stores session-level provenance: source mode, camera kind,
+calibration path, intrinsics, tag family, pose convention, face index, optional
+missing keypoints, object counts, and frame count. `<session>.jsonl` is an
+append-only rolling capture log with frame filenames, timestamps, tag family,
+and saved object names.
+
+## Per-Frame Pose Schema
+
+Each `annotations/*.json` file includes:
+
+```json
+{
+  "version": "1.0",
+  "metadata": {
+    "dataset_name": "run01",
+    "frame_index": 0,
+    "timestamp": 1724631234.123,
+    "tag_family": "tag36h11"
+  },
+  "pose_convention": {
+    "composition": "T_cam_object = T_cam_board @ T_board_object",
+    "translation_units": "meters",
+    "quaternion_order": "x, y, z, w",
+    "rpy_order": "roll, pitch, yaw",
+    "angle_units": "degrees"
+  },
+  "image_filename": "Run_<tag>_rgb_frame_<idx>.png",
+  "annotated_image": "Run_<tag>_annotated_frame_<idx>.png",
+  "reproj_image": "Run_<tag>_reproj_frame_<idx>.png",
+  "depth": null,
+  "capture": {
+    "mode": "smart_auto",
+    "status": "ready",
+    "reason": "coverage_cell",
+    "trigger_object": "connection_plate_white",
+    "trigger_face": "connection_plate_white_sideA",
+    "stable_count": 5
+  },
+  "camera_intrinsics": {
+    "fx": 600.0,
+    "fy": 610.0,
+    "cx": 320.0,
+    "cy": 240.0,
+    "width": 640,
+    "height": 480
+  },
+  "camera_extrinsics": {
+    "position": [0.0, 0.0, 0.0],
+    "orientation": [0.0, 0.0, 0.0, 1.0],
+    "rotation": [0.0, 0.0, 0.0, 1.0],
+    "rpy_deg": [0.0, 0.0, 0.0],
+    "reference_face": "connection_plate_white_sideA",
+    "reference_board": "boards/connection_plate_white_sideA.yaml"
+  },
+  "objects": [
+    {
+      "object_name": "connection_plate_white",
+      "selected_face": "connection_plate_white_sideA",
+      "selected_board": "boards/connection_plate_white_sideA.yaml",
+      "class_id": 2,
+      "class_name": "connection_plate",
+      "2D_center": [0.5, 0.5],
+      "width": 0.25,
+      "height": 0.18,
+      "bbox_xywh_px": [160.0, 120.0, 160.0, 86.0],
+      "bbox_source": "face_kps",
+      "transforms": {
+        "T_cam_board": {"matrix": [[...]]},
+        "T_board_object": {"matrix": [[...]]},
+        "T_cam_object": {"matrix": [[...]]}
+      },
+      "quality": {
+        "tag_used": 52,
+        "num_tags_visible": 2,
+        "score": 2500.0,
+        "score_tags": 2,
+        "score_area_px": 500,
+        "bbox_source": "face_kps",
+        "tag_scale_ratio": 1.0,
+        "tag_scale_pairs": 1,
+        "tag_scale_mad": 0.0,
+        "tag_scale_auto_corrected": false
+      },
+      "6DOF_pose": {
+        "position": [0.27, -0.07, 1.54],
+        "orientation": [0.0, 0.0, 0.0],
+        "rotation": [0.0, 0.0, 0.0, 1.0],
+        "translation_units": "meters",
+        "orientation_order": "roll, pitch, yaw",
+        "orientation_units": "degrees",
+        "rotation_quaternion_order": "x, y, z, w",
+        "dimensions": [0.1, 0.1, 0.0]
+      }
+    }
+  ]
+}
+```
+
+Compatibility notes:
+
+- `camera_extrinsics.orientation` is retained as the quaternion field used by
+  earlier docs; `camera_extrinsics.rotation` is an explicit alias in the same
+  `[x, y, z, w]` order.
+- `objects[].6DOF_pose.orientation` is roll, pitch, yaw in degrees.
+- `objects[].6DOF_pose.rotation` is the object quaternion in `[x, y, z, w]`
+  order.
+- `objects[].transforms.T_cam_object` is checked in tests against
+  `T_cam_board @ T_board_object`.
+- `capture` is optional provenance for frame acceptance. It records whether
+  the frame was saved by manual review, smart auto-capture, or continuous mode;
+  it does not change pose semantics.
+
+## Common Failure Modes
+
+- `--mode video` without `--video` fails before capture.
+- An unreadable `--video` path fails before capture.
+- `--mode bag` without `--bag` fails before capture.
+- `--mode live` or `--mode bag` fails clearly when `pyrealsense2` is missing.
+- `--continuous` together with `--auto-capture` fails before capture because
+  those policies conflict.
+- Missing or malformed `calib/calib_color.yaml` fails before capture.
+- Calibration YAML must include positive `image_width` and `image_height`.
+- Missing or malformed `boards/tag_registry.yaml` fails before capture.
+- Board YAMLs missing from the registry or annotation records fail before
+  capture.
+- Missing `faces/face_manifest.csv` fails before capture unless
+  `--allow-face-scan` is supplied for legacy projects.
+- Missing or malformed annotation YAMLs fail before capture.
+- Annotation YAMLs missing `T_board_object.matrix` fail before capture.
+- Runtime stream resolution mismatch with calibration exits with a clear
+  message. Use matching `--width` / `--height` or `--rs_w` / `--rs_h`, or
+  recalibrate at the capture resolution.
+
+## Verify Before Review / Export
+
+After collection:
+
+1. Confirm `datasets/<session>/session.yaml` records the expected calibration,
+   source mode, and pose convention.
+2. Inspect a few `annotations/*.json` records and verify every object includes
+   `selected_face`, `selected_board`, `transforms`, `quality`, and `6DOF_pose`.
+3. Confirm `T_cam_object = T_cam_board @ T_board_object` for representative
+   saved objects.
+4. Review `annotated/` and `reproj/` images for plausible selected faces,
+   bounding boxes, and axes.
+5. Confirm `<session>.jsonl` has one row per accepted frame.

--- a/docs/workflows/step6_collect_dataset.md
+++ b/docs/workflows/step6_collect_dataset.md
@@ -113,8 +113,8 @@ For each frame, PoseTag:
 5. Scores visible faces and keeps the best face per object.
 6. Shows annotation review, reprojection/debug, and structured status panels.
 7. Saves the accepted frame and pose label when the user accepts it, when
-   smart auto-capture accepts it, or every frame when `--continuous` is
-   enabled.
+   smart auto-capture accepts it, or each pose-labelled frame when
+   `--continuous` is enabled.
 
 The best-face score prioritizes visible tag count, then image-space area.
 When the origin tag is visible, it is used for `T_cam_board`; otherwise PoseTag
@@ -149,8 +149,9 @@ posetag-collect --mode opencv --session run01 --auto-capture \
   --auto-min-rotation-delta-deg 8.0
 ```
 
-`--continuous` remains available as the old crude save-every-frame mode, but it
-is mutually exclusive with `--auto-capture`.
+`--continuous` remains available as the old crude mode that saves every frame
+with at least one pose-labelled object, but it is mutually exclusive with
+`--auto-capture`.
 
 ## Controls
 

--- a/src/collect_gt_dataset.py
+++ b/src/collect_gt_dataset.py
@@ -133,7 +133,7 @@ Common options
   --registry PATH                Tag registry (default boards/tag_registry.yaml)
   --face_manifest PATH           Face manifest (default faces/face_manifest.csv)
   --dry-run                      Validate inputs without capture/output writes
-  --continuous                   Save every frame automatically (crude legacy mode)
+  --continuous                   Save every pose-labelled frame automatically
   --auto-capture                 Quality-gated smart auto-capture
   --auto-stable-frames N         Stable frames before smart save (default 5)
   --auto-cooldown-sec FLOAT      Delay between smart saves (default 1.0)
@@ -162,7 +162,7 @@ Keys
   r / n / BACKSPACE reject / skip frame
   ESC / q / Q       close capture window cleanly
   x / X             close capture window cleanly
-  SPACE or p        pause/resume stream (continuous keeps saving)
+  SPACE or p        pause/resume stream
   h                 toggle help panel
 """
 
@@ -840,6 +840,11 @@ def save_frame(
         anno_img: Optional[np.ndarray] = None,  # <- NEW: annotated image
         capture_metadata: Optional[dict] = None,
 ):
+    if not results:
+        raise CollectDatasetError(
+            "Cannot save a dataset frame without at least one pose-labelled object."
+        )
+
     # --- folder layout ---
     images_dir = out_dir / "images"  # raw rgb only
     reproj_dir = out_dir / "reproj"  # reprojection / tag debug
@@ -939,7 +944,7 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Validate inputs and print a summary without opening a camera or writing outputs.")
     parser.add_argument("--family", default="tag36h11")
     parser.add_argument("--continuous", action="store_true",
-                        help="Do not prompt per frame; save all automatically")
+                        help="Do not prompt per frame; save each frame that has at least one pose-labelled object.")
     parser.add_argument("--auto-capture", action="store_true",
                         help="Quality-gated smart auto-capture; saves stable, useful views automatically.")
     parser.add_argument("--auto-stable-frames", type=int, default=5,
@@ -1312,6 +1317,10 @@ def main(argv=None):
             def _capture_now(capture_metadata: Optional[dict] = None) -> bool:
                 nonlocal idx, capture_msg, capture_msg_until, objects_seen_counts
                 if last_bgr is None or last_ts is None or last_cov is None:
+                    return False
+                if not best_by_object:
+                    capture_msg = "No pose-labelled object visible; frame not saved"
+                    capture_msg_until = time.time() + 2.0
                     return False
                 save_frame(
                     out_dir, idx, last_ts,

--- a/src/collect_gt_dataset.py
+++ b/src/collect_gt_dataset.py
@@ -2,16 +2,17 @@
 """
 collect_gt_dataset.py
 =====================
-Collect a ground-truth dataset (multi-object, multi-face) from Intel RealSense
-(live or .bag) or any OpenCV-readable video. For each frame, estimate a pose
-for every face whose board has at least one visible AprilTag. A review UI is
-provided, with optional continuous capture.
+Collect a ground-truth dataset (multi-object, multi-face) from an OpenCV
+webcam, Intel RealSense (live or .bag), or any OpenCV-readable video. For each
+frame, estimate a pose for every face whose board has at least one visible
+AprilTag. A review UI is provided, with optional continuous capture.
 
 What's new vs. previous script
 ------------------------------
 - Project layout via `resolve_project_root(...)`.
-- Scans faces from <project_root>/faces/**/<face_key>_T_board_object.yaml
-  (or faces/face_manifest.csv if present).
+- Validates required inputs before capture: calib/calib_color.yaml,
+  boards/tag_registry.yaml, faces/face_manifest.csv, board YAMLs, and
+  annotation YAMLs containing T_board_object.
 - Writes session metadata and per-frame annotations in a **blueprint-style schema**.
 - Camera extrinsics now use `rotation` (quaternion [x,y,z,w]); optional `rpy_deg`
   is added for readability.
@@ -74,10 +75,19 @@ Per-frame JSON schema (blueprint-style)
 
   "objects": [
     {
+      "object_name": "<str>",
+      "selected_face": "<face_key>",
+      "selected_board": "<board_yaml>",
       "class_id": <int>,
       "class_name": "<str>",
       "2D_center": [cx, cy],            # normalized [0..1]
       "width": <float>, "height": <float>,  # normalized box size
+      "transforms": {
+        "T_cam_board": {"matrix": [[...]]},
+        "T_board_object": {"matrix": [[...]]},
+        "T_cam_object": {"matrix": [[...]]}
+      },
+      "quality": {...},
       "6DOF_pose": {
         "position":   [tx, ty, tz],     # camera->object translation (meters)
         "orientation":[roll, pitch, yaw],# degrees, for readability
@@ -102,18 +112,36 @@ Notes on interpretation
 
 Usage examples
 --------------
+  # Preflight without opening a camera or writing dataset outputs
+  python -m src.collect_gt_dataset --mode opencv --session run01 --dry-run
+
+  # OpenCV webcam
+  python -m src.collect_gt_dataset --mode opencv --cam 0 --session run01 --calib calib_color.yaml
+
   # RealSense live (RGB + depth if available)
-  python -m src.collect_gt_dataset --mode live --session run01 --calib calib_color.yaml
+  python -m src.collect_gt_dataset --mode live --session run02 --calib calib_color.yaml
 
   # RealSense playback from a .bag
-  python -m src.collect_gt_dataset --mode bag --bag path/to/recording.bag --session run02 --calib calib_color.yaml
+  python -m src.collect_gt_dataset --mode bag --bag path/to/recording.bag --session run03 --calib calib_color.yaml
 
   # Any video readable by OpenCV
-  python -m src.collect_gt_dataset --mode video --video sample.mp4 --session run03 --calib calib_color.yaml
+  python -m src.collect_gt_dataset --mode video --video sample.mp4 --session run04 --calib calib_color.yaml
 
 Common options
 --------------
-  --continuous                   Save every frame automatically
+  --project_root PATH            Project root (default resolver/env/config)
+  --registry PATH                Tag registry (default boards/tag_registry.yaml)
+  --face_manifest PATH           Face manifest (default faces/face_manifest.csv)
+  --dry-run                      Validate inputs without capture/output writes
+  --continuous                   Save every frame automatically (crude legacy mode)
+  --auto-capture                 Quality-gated smart auto-capture
+  --auto-stable-frames N         Stable frames before smart save (default 5)
+  --auto-cooldown-sec FLOAT      Delay between smart saves (default 1.0)
+  --auto-min-tags N              Minimum visible tags for smart save (default 1)
+  --auto-min-bbox-area FLOAT     Minimum smart-save bbox area in pixels
+  --auto-max-tag-scale-error F   Max relative tag-scale error when available
+  --auto-grid ROWSxCOLS          Image coverage grid for smart diversity
+  --auto-distance-bin-m FLOAT    Distance-bin size for smart diversity
   --max_frames N                 Stop after N frames
   --rs_w/--rs_h/--rs_fps         Live RealSense stream parameters
   --save_depth                   Save aligned depth as .npy
@@ -125,29 +153,26 @@ Common options
   --check-tag-scale              Report tag scale ratio s
   --auto-correct-scale           Apply 1/s to T_cam_board translation if |s-1|>tol
   --scale-tol FLOAT              Relative tolerance (default 0.02)
-  --tag-cover-margin-m FLOAT     Extra paper allowance around tag (default 0.015 m)
-  --tag-sample-extra-m FLOAT     Ring thickness for background color sample (default 0.015 m)
+  --tag-cover-margin-m FLOAT     Extra paper allowance around tag (default 0.010 m)
+  --tag-sample-extra-m FLOAT     Ring thickness for background color sample (default 0.008 m)
 
 Keys
 ----
-  ENTER / y / s     accept & save frame
+  ENTER / y / s     accept / force-save frame
   r / n / BACKSPACE reject / skip frame
-  ESC / q           abort current frame (continue stream)
-  Q / X             quit all immediately
+  ESC / q / Q       close capture window cleanly
+  x / X             close capture window cleanly
   SPACE or p        pause/resume stream (continuous keeps saving)
   h                 toggle help panel
 """
 
 from __future__ import annotations
-import argparse, json, os, sys, time, math, logging
+import argparse, csv, json, os, sys, time, logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Tuple, Optional
 import numpy as np
 import cv2, yaml
-
-import csv
-import logging
 
 log: logging.Logger
 
@@ -161,24 +186,34 @@ except Exception:
     rs = None  # optional
 
 # --- repo utils ---
-from utils.project_config import resolve_project_root, ensure_project_dirs
+from utils.project_config import ensure_project_dirs
 from utils.logger import init_project_logger
 from utils.annotation_utils import (
     detect_tags, load_board, se3, inv_se3, load_keypoints_fuzzy
 )
-from utils.gt_pose_utils import rotation_to_quat
-from utils.collect_gt_utils import rpy_from_R, _estimate_tag_scale, _text_panel, _show_dash, _ts_tag_from_epoch, \
-    _map_class_id_and_name, _dominant_color_near_polygon
-
-try:
-    from scipy.spatial.transform import Rotation as Rot
-
-
-    def to_quat(R):
-        return Rot.from_matrix(R).as_quat()  # [x,y,z,w]
-except Exception:
-    def to_quat(R):
-        return rotation_to_quat(R)
+from utils.collect_gt_utils import rpy_from_R, _estimate_tag_scale, _show_dash, _ts_tag_from_epoch, \
+    _capture_key_requests_quit, _capture_status_panel, _dominant_color_near_polygon, \
+    _normalize_capture_key
+from posetag.pipelines.collect_dataset import (
+    AutoCaptureConfig,
+    AutoCaptureState,
+    CollectDatasetError,
+    Intrinsics,
+    auto_capture_candidates_from_results,
+    build_frame_annotation_record,
+    build_session_metadata,
+    evaluate_auto_capture,
+    load_intrinsics_from_calibration,
+    parse_auto_capture_grid,
+    preview_project_root,
+    record_auto_capture_save,
+    resolve_calibration_path,
+    resolve_dataset_root,
+    resolve_face_manifest_path,
+    resolve_registry_path,
+    validate_collection_inputs,
+    validate_source_args,
+)
 
 try:
     cv2.ocl.setUseOpenCL(False)
@@ -186,56 +221,15 @@ try:
 except Exception:
     pass
 
-EXIT_QUIT_ALL = 99
-DATASET_VERSION = "1.0"
-
-log: logging.Logger  # set in main()
-
-
-def _quit_all():
-    try:
-        cv2.destroyAllWindows()
-        try:
-            sys.stdout.flush()
-        except:
-            pass
-        try:
-            sys.stderr.flush()
-        except:
-            pass
-    finally:
-        os._exit(EXIT_QUIT_ALL)
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 
 # --------------------------- Camera / Sources --------------------------------
-@dataclass
-class Intrinsics:
-    fx: float;
-    fy: float;
-    cx: float;
-    cy: float
-    width: int;
-    height: int
-    dist: Optional[np.ndarray] = None  # (1,5) if available
-
-
-def _load_dist_from_calib(calib_path: Path) -> np.ndarray:
-    try:
-        y = yaml.safe_load(open(calib_path, "r"))
-        dc = y.get("distortion_coefficients", {})
-        return np.array([[dc.get("k1", 0), dc.get("k2", 0), dc.get("p1", 0), dc.get("p2", 0), dc.get("k3", 0)]], float)
-    except Exception:
-        return np.zeros((1, 5), float)
-
-
 def load_intrinsics_from_calib(calib_path: Path) -> Intrinsics:
-    y = yaml.safe_load(open(calib_path, "r"))
-    cam = y["camera_matrix"]
-    fx, fy, cx, cy = cam["fx"], cam["fy"], cam["cx"], cam["cy"]
-    w = int(y.get("image_width", 640))
-    h = int(y.get("image_height", 480))
-    dist = _load_dist_from_calib(calib_path)
-    return Intrinsics(fx, fy, cx, cy, w, h, dist)
+    """Compatibility wrapper for the validated collection calibration loader."""
+
+    return load_intrinsics_from_calibration(calib_path)
 
 
 class FrameSource:
@@ -251,7 +245,11 @@ class FrameSource:
 
 class VideoSource(FrameSource):
     def __init__(self, path: Path, fps_hint: float = 30.0):
+        if not Path(path).expanduser().exists():
+            raise RuntimeError(f"Could not open video: {path}")
         self.cap = cv2.VideoCapture(str(path))
+        if not self.cap.isOpened():
+            raise RuntimeError(f"Could not open video: {path}")
         fps = float(self.cap.get(cv2.CAP_PROP_FPS)) or fps_hint
         self.fps_delay = 1.0 / max(1e-6, fps)
 
@@ -262,6 +260,39 @@ class VideoSource(FrameSource):
         return bgr, None, time.time()
 
     def stop(self): self.cap.release()
+
+
+class OpenCVWebcamSource(FrameSource):
+    def __init__(self, cam: int = 0, width: int = 0, height: int = 0, fps: int = 30):
+        self.cam = int(cam)
+        self.width = int(width)
+        self.height = int(height)
+        self.fps = int(fps)
+        self.cap = None
+
+    def start(self):
+        self.cap = cv2.VideoCapture(self.cam)
+        if not self.cap.isOpened():
+            raise RuntimeError(f"Could not open OpenCV camera index {self.cam}")
+        if self.width > 0:
+            self.cap.set(cv2.CAP_PROP_FRAME_WIDTH, self.width)
+        if self.height > 0:
+            self.cap.set(cv2.CAP_PROP_FRAME_HEIGHT, self.height)
+        if self.fps > 0:
+            self.cap.set(cv2.CAP_PROP_FPS, self.fps)
+
+    def read(self):
+        ok, bgr = self.cap.read()
+        if not ok:
+            return None, None, time.time()
+        return bgr, None, time.time()
+
+    def stop(self):
+        if self.cap is not None:
+            self.cap.release()
+
+    def camera_kind(self) -> str:
+        return "opencv_webcam"
 
 
 class RealSenseLive(FrameSource):
@@ -397,12 +428,17 @@ def _scan_faces_yaml(project_root: Path) -> List[Path]:
     return list((project_root / "faces").glob("*/*/*_T_board_object.yaml"))
 
 
-def load_face_registry(project_root: Path) -> Dict[str, FaceEntry]:
+def load_face_registry(
+        project_root: Path,
+        *,
+        face_manifest_path: Optional[Path] = None,
+        allow_face_scan: bool = False,
+) -> Dict[str, FaceEntry]:
     """
     Build registry from faces/face_manifest.csv when present; otherwise scan faces/*.
     """
     reg: Dict[str, FaceEntry] = {}
-    manifest_rows = _read_faces_manifest(project_root)
+    manifest_rows = _read_faces_manifest(project_root, face_manifest_path)
 
     yaml_paths: List[Tuple[str, Optional[float], Path, Optional[
         Path]]] = []  # (face_key, tag_size_m_hint, yaml_path, board_yaml_from_manifest)
@@ -414,6 +450,12 @@ def load_face_registry(project_root: Path) -> Dict[str, FaceEntry]:
                 continue
             yaml_paths.append((r.face_key, r.tag_size_m, r.yaml_path, r.board_yaml))
     else:
+        if not allow_face_scan:
+            manifest_path = face_manifest_path or _faces_manifest_path(project_root)
+            raise SystemExit(
+                f"[!] Face manifest not found: {manifest_path}. Run posetag-annotate "
+                "so faces/face_manifest.csv lists T_board_object YAMLs."
+            )
         # Fallback scan
         for y in _scan_faces_yaml(project_root):
             face_key = y.stem.replace("_T_board_object", "")
@@ -480,12 +522,14 @@ class FaceManifestRow:
     tag_size_m: Optional[float]
 
 
-def _faces_manifest_path(project_root: Path) -> Path:
+def _faces_manifest_path(project_root: Path, face_manifest_path: Optional[Path] = None) -> Path:
+    if face_manifest_path is not None:
+        return Path(face_manifest_path).expanduser()
     return project_root / "faces" / "face_manifest.csv"
 
 
-def _read_faces_manifest(project_root: Path) -> List[FaceManifestRow]:
-    p = _faces_manifest_path(project_root)
+def _read_faces_manifest(project_root: Path, face_manifest_path: Optional[Path] = None) -> List[FaceManifestRow]:
+    p = _faces_manifest_path(project_root, face_manifest_path)
     rows: List[FaceManifestRow] = []
     if not p.exists():
         log.warning("[faces-manifest] Not found: %s (will fall back to scanning faces/*)", p)
@@ -760,6 +804,7 @@ def estimate_poses_multi(
             "bbox_xywh": bbox_xywh,
             "bbox_source": bbox_source,
             "T_cam_board": {"matrix": T_cam_board.tolist()},
+            "T_board_object": {"matrix": fe.T_board_object.tolist()},
             "T_cam_object": {"matrix": T_cam_obj.tolist()},
             "overlay_bgr": [int(overlay_bgr[0]), int(overlay_bgr[1]), int(overlay_bgr[2])],
             "diagnostics": {
@@ -793,6 +838,7 @@ def save_frame(
         dataset_name: str,
         pts3d_by_object: Optional[Dict[str, np.ndarray]] = None,
         anno_img: Optional[np.ndarray] = None,  # <- NEW: annotated image
+        capture_metadata: Optional[dict] = None,
 ):
     # --- folder layout ---
     images_dir = out_dir / "images"  # raw rgb only
@@ -828,121 +874,20 @@ def save_frame(
     if save_depth and depth is not None:
         np.save(str(depth_path), depth)
 
-    W = float(intr.width)
-    H = float(intr.height)
-
-    K = np.array([[intr.fx, 0, intr.cx], [0, intr.fy, intr.cy], [0, 0, 1]], float)
-
-    # ---- camera extrinsics (camera pose in the frame of the most reliable board) ----
-    camera_pos = [0.0, 0.0, 0.0]
-    cam_quat = [0.0, 0.0, 0.0, 1.0]
-
-    # pick the entry with the most tags, then score
-    if results:
-        ref = max(results.values(), key=lambda r: (r.get("num_tags_visible", 0), r.get("score", 0.0)))
-        T_cam_board = np.array(ref["T_cam_board"]["matrix"], float)
-        try:
-            T_board_cam = np.linalg.inv(T_cam_board)
-            Rbc, tbc = T_board_cam[:3, :3], T_board_cam[:3, 3]
-            camera_pos = [float(tbc[0]), float(tbc[1]), float(tbc[2])]
-            cam_quat = [float(q) for q in to_quat(Rbc)]
-            try:
-                roll, pitch, yaw = rpy_from_R(Rbc)
-                cam_rpy = [float(roll), float(pitch), float(yaw)]
-            except Exception:
-                cam_rpy = None
-        except Exception:
-            pass
-
-    # ----- build objects list (best per object already computed upstream) -----
-    objects_out = []
-    for r in results.values():
-        obj_name = r["object"]
-        cls_id, cls_name = _map_class_id_and_name(obj_name)
-        x0, y0, w_px, h_px = r["bbox_xywh"]
-        cx = (x0 + 0.5 * w_px) / float(W)
-        cy = (y0 + 0.5 * h_px) / float(H)
-        ww = w_px / float(W)
-        hh = h_px / float(H)
-
-        # pose (camera -> object)
-        M = np.array(r["T_cam_object"]["matrix"], float)
-        R, t = M[:3, :3], M[:3, 3]
-        roll, pitch, yaw = rpy_from_R(R)
-        q_xyzw = to_quat(R)
-
-        # dimensions (from keypoints)
-        dimensions = None
-        mins, maxs = None, None
-        if pts3d_by_object and obj_name in pts3d_by_object:
-            P = pts3d_by_object[obj_name].astype(float)
-            if P.size > 0:
-                mins = P.min(axis=0)
-                maxs = P.max(axis=0)
-                d = (maxs - mins)
-                dimensions = [float(d[0]), float(d[1]), float(d[2])]
-
-        obb_corners_cam = None
-        obb_corners_img = None
-        if mins is not None:
-            # 8 corners in the object frame
-            xs = [mins[0], maxs[0]]
-            ys = [mins[1], maxs[1]]
-            zs = [mins[2], maxs[2]]
-            C_obj = np.array([[x, y, z] for x in xs for y in ys for z in zs], float)  # (8,3)
-            # transform to camera frame
-            C_cam = (R @ C_obj.T + t.reshape(3, 1)).T  # (8,3)
-            obb_corners_cam = C_cam.tolist()
-            # project to image (for visual losses or debugging)
-            uv = project_points(C_obj.astype(np.float32), M, K, intr.dist)
-            obb_corners_img = uv.tolist()
-
-        entry = {
-            "class_id": int(cls_id),
-            "class_name": cls_name,
-            "2D_center": [float(cx), float(cy)],
-            "width": float(ww),
-            "height": float(hh),
-            "6DOF_pose": {
-                "position": [float(t[0]), float(t[1]), float(t[2])],
-                "orientation": [float(roll), float(pitch), float(yaw)],
-                "rotation": [float(q_xyzw[0]), float(q_xyzw[1]), float(q_xyzw[2]), float(q_xyzw[3])],
-                **({"dimensions": dimensions} if dimensions is not None else {}),
-                **({"obb_corners_cam": obb_corners_cam, "obb_corners_img": obb_corners_img}
-                   if obb_corners_cam is not None else {}),
-            },
-        }
-        objects_out.append(entry)
-
-    # ---- final annotation record ----
-    record = {
-        "version": DATASET_VERSION,
-        "metadata": {
-            "dataset_name": dataset_name,
-            "frame_index": int(idx),
-            "timestamp": float(ts),
-            "tag_family": family,
-        },
-        "image_filename": rgb_name,
-        "objects": objects_out,
-        "annotated_image": (annoimg_path.name if anno_img is not None else None),
-        "reproj_image": (reproj_path.name if reproj_img is not None else None),
-        "depth": (depth_path.name if (save_depth and depth is not None) else None),
-        "camera_intrinsics": {
-            "fx": float(intr.fx),
-            "fy": float(intr.fy),
-            "cx": float(intr.cx),
-            "cy": float(intr.cy),
-            "width": int(intr.width),
-            "height": int(intr.height),
-        },
-        "camera_extrinsics": {
-            "position": camera_pos,
-            "orientation": cam_quat,  # xyzw
-            **({"rpy_deg": cam_rpy} if cam_rpy is not None else {}),
-        },
-
-    }
+    record = build_frame_annotation_record(
+        dataset_name=dataset_name,
+        frame_index=idx,
+        timestamp=ts,
+        tag_family=family,
+        image_filename=rgb_name,
+        annotated_image=(annoimg_path.name if anno_img is not None else None),
+        reproj_image=(reproj_path.name if reproj_img is not None else None),
+        depth=(depth_path.name if (save_depth and depth is not None) else None),
+        intrinsics=intr,
+        results=results,
+        pts3d_by_object=pts3d_by_object,
+        capture_metadata=capture_metadata,
+    )
     ann_path.write_text(json.dumps(record, indent=5))
 
     log_entry = {
@@ -955,31 +900,73 @@ def save_frame(
         "tag_family": family,
         "objects": sorted({r["object"] for r in results.values()}),
     }
+    if capture_metadata:
+        log_entry["capture"] = capture_metadata
     with open(log_path, "a", encoding="utf-8") as f:
         f.write(json.dumps(log_entry) + "\n")
 
 
 # ------------------------------- Main loop -----------------------------------
 
-def main():
-    project_root = resolve_project_root(None)
-    ensure_project_dirs(project_root)
-    # Logger
-    global log
-    log = init_project_logger(project_root / "logs" / "collect_gt_dataset.log",
-                              level="INFO", console=True)
+class _HelpFmt(argparse.ArgumentDefaultsHelpFormatter, argparse.RawTextHelpFormatter):
+    """Show defaults while preserving multiline help."""
 
-    parser = argparse.ArgumentParser("Collect multi-object/multi-face GT dataset with review UI")
-    parser.add_argument("--mode", choices=["live", "bag", "video"], required=True)
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="posetag-collect",
+        description="Collect multi-object/multi-face GT dataset with review UI",
+        formatter_class=_HelpFmt,
+    )
+    parser.add_argument("--project_root", type=Path, default=None,
+                        help="Root for boards/faces/objects/datasets (default: resolver/env/config).")
+    parser.add_argument("--mode", choices=["live", "opencv", "bag", "video"], required=True,
+                        help="Frame source: RealSense live, OpenCV webcam, RealSense bag, or video file.")
     parser.add_argument("--bag", type=str, help="Path to RealSense .bag (for mode=bag)")
     parser.add_argument("--video", type=str, help="Path to a video file (for mode=video)")
     parser.add_argument("--session", required=True, help="Dataset session name (folder under datasets/)")
-    parser.add_argument("--dataset_root", type=str, default=str(project_root / "datasets"))
-    parser.add_argument("--calib", default="calib_color.yaml", help="Calibration YAML (fx,fy,cx,cy,dist)")
+    parser.add_argument("--dataset_root", type=str, default=None,
+                        help="Dataset root directory (default: <project_root>/datasets)")
+    parser.add_argument("--calib", default="calib_color.yaml",
+                        help="Calibration YAML (default resolves to calib/calib_color.yaml)")
+    parser.add_argument("--registry", default=None,
+                        help="Tag registry YAML (default: <project_root>/boards/tag_registry.yaml)")
+    parser.add_argument("--face_manifest", default=None,
+                        help="Face manifest CSV (default: <project_root>/faces/face_manifest.csv)")
+    parser.add_argument("--allow-face-scan", action="store_true",
+                        help="Legacy fallback: scan faces/**/*_T_board_object.yaml if face_manifest is missing.")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="Validate inputs and print a summary without opening a camera or writing outputs.")
     parser.add_argument("--family", default="tag36h11")
     parser.add_argument("--continuous", action="store_true",
                         help="Do not prompt per frame; save all automatically")
+    parser.add_argument("--auto-capture", action="store_true",
+                        help="Quality-gated smart auto-capture; saves stable, useful views automatically.")
+    parser.add_argument("--auto-stable-frames", type=int, default=5,
+                        help="Consecutive stable frames required before smart auto-capture can save.")
+    parser.add_argument("--auto-cooldown-sec", type=float, default=1.0,
+                        help="Minimum time between smart auto-capture saves.")
+    parser.add_argument("--auto-min-tags", type=int, default=1,
+                        help="Minimum visible tags for a smart auto-capture candidate.")
+    parser.add_argument("--auto-min-bbox-area", type=float, default=12000.0,
+                        help="Minimum candidate bbox area in pixels for smart auto-capture.")
+    parser.add_argument("--auto-max-tag-scale-error", type=float, default=0.08,
+                        help="Maximum allowed relative tag-scale error when scale diagnostics are available.")
+    parser.add_argument("--auto-min-translation-delta-m", type=float, default=0.04,
+                        help="Translation threshold used for stability and pose-diversity gating.")
+    parser.add_argument("--auto-min-rotation-delta-deg", type=float, default=8.0,
+                        help="Rotation threshold used for stability and pose-diversity gating.")
+    parser.add_argument("--auto-grid", default="3x3",
+                        help="Image coverage grid for smart auto-capture, formatted ROWSxCOLS.")
+    parser.add_argument("--auto-distance-bin-m", type=float, default=0.25,
+                        help="Distance-bin size used for smart auto-capture diversity.")
+    parser.add_argument("--auto-max-frames-per-object", type=int, default=0,
+                        help="Maximum smart auto-captured frames per object (0=unlimited).")
     parser.add_argument("--max_frames", type=int, default=0, help="Stop after N frames (0=unlimited)")
+    parser.add_argument("--cam", type=int, default=0, help="OpenCV camera index when --mode=opencv")
+    parser.add_argument("--width", type=int, default=0, help="OpenCV webcam width; 0=calibration width")
+    parser.add_argument("--height", type=int, default=0, help="OpenCV webcam height; 0=calibration height")
+    parser.add_argument("--fps", type=int, default=30, help="OpenCV webcam FPS request")
     parser.add_argument("--rs_w", type=int, default=0, help="Color width; 0=auto")
     parser.add_argument("--rs_h", type=int, default=0, help="Color height; 0=auto")
     parser.add_argument("--rs_fps", type=int, default=30, help="FPS for live mode")
@@ -993,7 +980,7 @@ def main():
     parser.add_argument("--auto-correct-scale", action="store_true",
                         help="If |s-1|>tol, divide T_cam_board translation by s")
     parser.add_argument("--scale-tol", type=float, default=0.02,
-                        help="Relative tolerance (default 0.02 = 2%)")
+                        help="Relative tolerance (default 0.02 = 2%%)")
     parser.add_argument("--bbox-mode", choices=["auto", "face", "object"], default="auto",
                         help="Which 3D points drive the bbox: 'face' (4 corners), 'object' (all kps), or 'auto' (larger).")
     parser.add_argument("--bbox-tag-mult", type=float, default=5.0,
@@ -1001,45 +988,115 @@ def main():
     parser.add_argument("--bbox-min-area", type=int, default=12000,
                         help="If bbox area < this, use tag fallback (default 12000 px^2).")
     parser.add_argument("--bbox-pad-frac", type=float, default=0.06,
-                        help="Pad final bbox by this fraction of its size (default 6%).")
+                        help="Pad final bbox by this fraction of its size (default 6%%).")
     parser.add_argument("--tag-cover-margin-m", type=float, default=0.010)
     parser.add_argument("--tag-sample-extra-m", type=float, default=0.008)
+    return parser
 
-    args = parser.parse_args()
 
-    # Intrinsics calibration data
-    calib_path = project_root / args.calib
-    intr = load_intrinsics_from_calib(calib_path)
-    K = np.array([[intr.fx, 0, intr.cx], [0, intr.fy, intr.cy], [0, 0, 1]], float)
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+
+    try:
+        if args.continuous and args.auto_capture:
+            raise CollectDatasetError("--continuous and --auto-capture are mutually exclusive.")
+        auto_grid_rows, auto_grid_cols = parse_auto_capture_grid(args.auto_grid)
+        if args.auto_stable_frames <= 0:
+            raise CollectDatasetError("--auto-stable-frames must be positive.")
+        if args.auto_cooldown_sec < 0.0:
+            raise CollectDatasetError("--auto-cooldown-sec must be non-negative.")
+        if args.auto_min_tags <= 0:
+            raise CollectDatasetError("--auto-min-tags must be positive.")
+        if args.auto_min_bbox_area < 0.0:
+            raise CollectDatasetError("--auto-min-bbox-area must be non-negative.")
+        if args.auto_max_tag_scale_error < 0.0:
+            raise CollectDatasetError("--auto-max-tag-scale-error must be non-negative.")
+        if args.auto_min_translation_delta_m < 0.0:
+            raise CollectDatasetError("--auto-min-translation-delta-m must be non-negative.")
+        if args.auto_min_rotation_delta_deg < 0.0:
+            raise CollectDatasetError("--auto-min-rotation-delta-deg must be non-negative.")
+        if args.auto_distance_bin_m <= 0.0:
+            raise CollectDatasetError("--auto-distance-bin-m must be positive.")
+        if args.auto_max_frames_per_object < 0:
+            raise CollectDatasetError("--auto-max-frames-per-object must be non-negative.")
+        project_root = preview_project_root(args.project_root)
+        calib_path = resolve_calibration_path(project_root, args.calib)
+        intr = load_intrinsics_from_calib(calib_path)
+        registry_path = resolve_registry_path(project_root, args.registry)
+        face_manifest_path = resolve_face_manifest_path(project_root, args.face_manifest)
+        datasets_root = resolve_dataset_root(project_root, args.dataset_root)
+
+        validate_source_args(
+            mode=args.mode,
+            video=args.video,
+            bag=args.bag,
+            realsense_module=rs,
+            video_capture_factory=cv2.VideoCapture if args.mode == "video" else None,
+        )
+        input_summary = validate_collection_inputs(
+            project_root=project_root,
+            calib_path=calib_path,
+            registry_path=registry_path,
+            face_manifest_path=face_manifest_path,
+            allow_face_scan=args.allow_face_scan,
+        )
+    except CollectDatasetError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    if args.dry_run:
+        print("Dataset collection dry run OK")
+        print(f"  project_root: {project_root}")
+        print(f"  calibration : {input_summary.calibration_path}")
+        print(f"  registry    : {input_summary.registry_path}")
+        print(f"  manifest    : {input_summary.face_manifest_path}")
+        print(f"  annotations : {len(input_summary.annotations)}")
+        print(f"  source mode : {args.mode}")
+        if input_summary.missing_keypoints:
+            print("  optional keypoints missing:")
+            for path in input_summary.missing_keypoints:
+                print(f"    - {path}")
+        return 0
+
+    ensure_project_dirs(project_root)
+
+    # Logger
+    global log
+    log = init_project_logger(project_root / "logs" / "collect_gt_dataset.log",
+                              level="INFO", console=True)
 
     # Face registry (from <project_root>/faces)
-    faces = load_face_registry(project_root)
+    faces = load_face_registry(
+        project_root,
+        face_manifest_path=face_manifest_path,
+        allow_face_scan=args.allow_face_scan,
+    )
     log.info("[i] Faces loaded: %d", len(faces))
-
-    # Output layout
-    datasets_root = Path(args.dataset_root) if args.dataset_root else (project_root / "datasets")
-    out_dir = datasets_root / args.session
-    ensure_dir(datasets_root)
-    ensure_dir(out_dir)
 
     # Choose frame source
     if args.mode == "live":
         w = args.rs_w or intr.width
         h = args.rs_h or intr.height
         src = RealSenseLive(width=w, height=h, fps=args.rs_fps)
+    elif args.mode == "opencv":
+        w = args.width or intr.width
+        h = args.height or intr.height
+        src = OpenCVWebcamSource(cam=args.cam, width=w, height=h, fps=args.fps)
     elif args.mode == "bag":
-        if not args.bag: sys.exit("--bag is required for mode=bag")
-        src = RealSenseBag(Path(args.bag))
+        src = RealSenseBag(Path(args.bag).expanduser())
     else:
-        if not args.video: sys.exit("--video is required for mode=video")
-        src = VideoSource(Path(args.video))
+        src = VideoSource(Path(args.video).expanduser())
 
     # Start source
     src.start()
     cam_kind = src.camera_kind()
 
+    # Output layout
+    out_dir = datasets_root / args.session
+    ensure_dir(datasets_root)
+    ensure_dir(out_dir)
+
     cv2.namedWindow("GT Capture", cv2.WINDOW_NORMAL | cv2.WINDOW_KEEPRATIO)
-    cv2.resizeWindow("GT Capture", 1920, 480)
+    cv2.resizeWindow("GT Capture", 1640, 520)
 
     # Preload face keypoints for bbox projection
     pts3d_by_face: Dict[str, np.ndarray] = {}
@@ -1058,29 +1115,58 @@ def main():
         except Exception as e:
             log.warning("[warn] keypoints for %s not fully available: %s", fk, e)
 
+    auto_capture_config = AutoCaptureConfig(
+        enabled=bool(args.auto_capture),
+        stable_frames=int(args.auto_stable_frames),
+        cooldown_sec=float(args.auto_cooldown_sec),
+        min_tags_visible=int(args.auto_min_tags),
+        min_bbox_area_px=float(args.auto_min_bbox_area),
+        max_tag_scale_error=float(args.auto_max_tag_scale_error),
+        min_translation_delta_m=float(args.auto_min_translation_delta_m),
+        min_rotation_delta_deg=float(args.auto_min_rotation_delta_deg),
+        grid_rows=int(auto_grid_rows),
+        grid_cols=int(auto_grid_cols),
+        distance_bin_m=float(args.auto_distance_bin_m),
+        max_frames_per_object=int(args.auto_max_frames_per_object),
+    )
+    auto_capture_state = AutoCaptureState()
+
     # Session metadata scaffold
-    session_meta = {
-        "version": DATASET_VERSION,
-        "name": args.session,
-        "created": time.strftime("%Y-%m-%d %H:%M:%S"),
-        "project_root": str(project_root),
-        "paths": {"root": str(datasets_root), "session_dir": str(out_dir)},
-        "camera": {
-            "kind": cam_kind,  # "intel_realsense" or "generic"
-            "fx": intr.fx, "fy": intr.fy, "cx": intr.cx, "cy": intr.cy,
-            "width": intr.width, "height": intr.height,
-            "distortion_coefficients": None if intr.dist is None else intr.dist.reshape(-1).tolist(),
-        },
-        "tag_family": args.family,
-        "tag_scale_controls": {
+    faces_index = {fk: {"object": fe.object_name, "board_yaml": str(fe.board_yaml)} for fk, fe in faces.items()}
+    session_meta = build_session_metadata(
+        session_name=args.session,
+        project_root=project_root,
+        dataset_root=datasets_root,
+        session_dir=out_dir,
+        intrinsics=intr,
+        tag_family=args.family,
+        camera_kind=cam_kind,
+        mode=args.mode,
+        tag_scale_controls={
             "check_tag_scale": bool(args.check_tag_scale),
             "auto_correct_scale": bool(args.auto_correct_scale),
             "scale_tol": float(args.scale_tol),
         },
-        "faces_index": {fk: {"object": fe.object_name, "board_yaml": str(fe.board_yaml)} for fk, fe in faces.items()},
-        "objects_available": sorted({fe.object_name for fe in faces.values()}),
-        "objects_seen_counts": {},  # filled as we save frames
-        "frames_captured": 0,
+        faces_index=faces_index,
+        missing_keypoints=input_summary.missing_keypoints,
+    )
+    session_meta["created"] = time.strftime("%Y-%m-%d %H:%M:%S")
+    session_meta["capture_policy"] = {
+        "mode": "smart_auto" if args.auto_capture else ("continuous" if args.continuous else "review"),
+        "continuous": bool(args.continuous),
+        "auto_capture": {
+            "enabled": bool(auto_capture_config.enabled),
+            "stable_frames": int(auto_capture_config.stable_frames),
+            "cooldown_sec": float(auto_capture_config.cooldown_sec),
+            "min_tags_visible": int(auto_capture_config.min_tags_visible),
+            "min_bbox_area_px": float(auto_capture_config.min_bbox_area_px),
+            "max_tag_scale_error": float(auto_capture_config.max_tag_scale_error),
+            "min_translation_delta_m": float(auto_capture_config.min_translation_delta_m),
+            "min_rotation_delta_deg": float(auto_capture_config.min_rotation_delta_deg),
+            "grid": f"{int(auto_capture_config.grid_rows)}x{int(auto_capture_config.grid_cols)}",
+            "distance_bin_m": float(auto_capture_config.distance_bin_m),
+            "max_frames_per_object": int(auto_capture_config.max_frames_per_object),
+        },
     }
     (out_dir / "session.yaml").write_text(yaml.safe_dump(session_meta, sort_keys=False))
 
@@ -1152,55 +1238,81 @@ def main():
                 if (obj not in best_by_object) or (r["score"] > best_by_object[obj]["score"]):
                     best_by_object[obj] = r
 
-            # right panel text
-            lines = [
-                "GT Capture",
-                f"session: {args.session}",
-                f"faces visible: {len(results)}   (saved: {idx})",
-                "",
-                "Panels:",
-                "  Left  = Annotation (axes, bbox, labels)",
-                "  Middle= Reprojection / tag debug",
-                "  Right = Status, legend, capture feedback",
-                "",
-                "Keys: ENTER/y/s=accept, r/n/BACK=reject",
-                "      ESC/q=abort  Q/X=quit-all",
-                "      SPACE/p=cont/pause  h=help",
-                "",
-            ]
-            if show_help:
-                for obj, r in best_by_object.items():
-                    M = np.array(r["T_cam_object"]["matrix"], float)
-                    R, t = M[:3, :3], M[:3, 3]
-                    roll, pitch, yaw = rpy_from_R(R)
-                    lines.append(f"- {obj} [{r['face_key']}]")
-                    lines.append(f"   t (m): [{t[0]:.3f}, {t[1]:.3f}, {t[2]:.3f}]  | dist={np.linalg.norm(t):.3f} m")
-                    lines.append(f"   rpy deg : [{roll:.1f}, {pitch:.1f}, {yaw:.1f}]")
-                    lines.append(f"   tag_used: {r['tag_used']}  bbox: {r['bbox_source']}")
-                    diag = r.get("diagnostics", {})
-                    lines.append(f"   tag_scale s={diag.get('tag_scale_ratio', 1.0):.3f} "
-                                 f"pairs={diag.get('tag_scale_pairs', 0)} "
-                                 f"{'AUTO' if diag.get('tag_scale_auto_corrected', False) else ''}")
-                    lines.append("")
-
             now = time.time()
-            if capture_msg and now < capture_msg_until:
-                lines.append(f"*** {capture_msg} ***")
+            auto_candidates = auto_capture_candidates_from_results(best_by_object)
+            auto_capture_decision = None
+            auto_capture_message = ""
+            if args.auto_capture and not paused:
+                auto_capture_decision = evaluate_auto_capture(
+                    auto_candidates,
+                    auto_capture_state,
+                    auto_capture_config,
+                    frame_width=intr.width,
+                    frame_height=intr.height,
+                    timestamp=now,
+                )
+                auto_capture_message = auto_capture_decision.message
+            elif args.auto_capture:
+                auto_capture_message = "Auto: paused"
 
-            right = _text_panel(lines, width=640, height=480)
+            object_summaries = []
+            for obj, r in best_by_object.items():
+                M = np.array(r["T_cam_object"]["matrix"], float)
+                R, t = M[:3, :3], M[:3, 3]
+                roll, pitch, yaw = rpy_from_R(R)
+                diag = r.get("diagnostics", {})
+                object_summaries.append(
+                    {
+                        "object": obj,
+                        "face_key": r["face_key"],
+                        "translation_m": tuple(float(v) for v in t),
+                        "distance_m": float(np.linalg.norm(t)),
+                        "rpy_deg": (float(roll), float(pitch), float(yaw)),
+                        "tag_used": r.get("tag_used", "?"),
+                        "bbox_source": r.get("bbox_source", "?"),
+                        "tag_scale_ratio": diag.get("tag_scale_ratio", 1.0),
+                        "tag_scale_pairs": diag.get("tag_scale_pairs", 0),
+                        "tag_scale_auto_corrected": diag.get(
+                            "tag_scale_auto_corrected",
+                            False,
+                        ),
+                    }
+                )
+
+            right = _capture_status_panel(
+                session=args.session,
+                faces_visible=len(results),
+                saved_count=idx,
+                object_summaries=object_summaries,
+                paused=paused,
+                continuous=args.continuous,
+                auto_capture_enabled=args.auto_capture,
+                auto_capture_status=auto_capture_message,
+                show_help=show_help,
+                capture_message=capture_msg if capture_msg and now < capture_msg_until else "",
+            )
             _show_dash(last_anno, last_reproj, right)
 
             # decide
-            k = cv2.waitKey(1) & 0xFF
-            if k in (ord('Q'), ord('X'), ord('x')): _quit_all()
+            raw_key = cv2.waitKeyEx(1) if hasattr(cv2, "waitKeyEx") else cv2.waitKey(1)
+            k = _normalize_capture_key(raw_key)
+            try:
+                if cv2.getWindowProperty("GT Capture", cv2.WND_PROP_VISIBLE) < 1:
+                    log.info("[i] GT Capture window closed.")
+                    break
+            except cv2.error:
+                log.info("[i] GT Capture window closed.")
+                break
+            if _capture_key_requests_quit(raw_key):
+                log.info("[i] Quit requested from GT Capture window.")
+                break
             if k == ord('h'): show_help = not show_help
             if k in (ord('p'), 32): paused = not paused  # pause/resume
-            if k in (27, ord('q')):  # abort current frame (skip)
-                continue
 
-            def _capture_now():
+            def _capture_now(capture_metadata: Optional[dict] = None) -> bool:
                 nonlocal idx, capture_msg, capture_msg_until, objects_seen_counts
-                if last_bgr is None: return
+                if last_bgr is None or last_ts is None or last_cov is None:
+                    return False
                 save_frame(
                     out_dir, idx, last_ts,
                     bgr_raw=last_cov,  # <- was last_anno; now the pure frame
@@ -1213,29 +1325,68 @@ def main():
                     dataset_name=args.session,
                     pts3d_by_object=pts3d_by_object,
                     anno_img=last_anno,  # <- annotated goes to its own folder
+                    capture_metadata=capture_metadata,
                 )
 
                 # update counters
                 for r in best_by_object.values():
                     objects_seen_counts[r["object"]] = objects_seen_counts.get(r["object"], 0) + 1
-                capture_msg = f"Frame #{idx:03d} captured [OK]"
+                mode = (capture_metadata or {}).get("mode", "manual")
+                reason = (capture_metadata or {}).get("reason")
+                suffix = f" {reason}" if reason else ""
+                capture_msg = f"Frame #{idx:03d} captured [{mode}]{suffix}"
                 capture_msg_until = time.time() + 2.0
                 idx += 1
+                return True
 
             if k in (13, ord('y'), ord('s')):  # accept
-                _capture_now()
+                if _capture_now({"mode": "manual_review", "trigger": "key"}):
+                    if args.auto_capture and auto_candidates:
+                        try:
+                            record_auto_capture_save(
+                                auto_capture_state,
+                                auto_candidates[0],
+                                auto_capture_config,
+                                frame_width=intr.width,
+                                frame_height=intr.height,
+                                timestamp=now,
+                            )
+                        except CollectDatasetError as exc:
+                            log.warning("[auto-capture] manual save bookkeeping skipped: %s", exc)
+            elif (
+                args.auto_capture
+                and not paused
+                and auto_capture_decision is not None
+                and auto_capture_decision.should_save
+            ):
+                if _capture_now(auto_capture_decision.metadata()):
+                    for candidate in auto_candidates:
+                        if (
+                            candidate.object_name == auto_capture_decision.trigger_object
+                            and candidate.face_key == auto_capture_decision.trigger_face
+                        ):
+                            record_auto_capture_save(
+                                auto_capture_state,
+                                candidate,
+                                auto_capture_config,
+                                frame_width=intr.width,
+                                frame_height=intr.height,
+                                timestamp=now,
+                            )
+                            break
             if args.continuous and not paused:
-                _capture_now()
+                _capture_now({"mode": "continuous"})
 
             if args.max_frames and idx >= args.max_frames:
                 log.info("[i] Reached max_frames=%d.", args.max_frames)
                 break
 
     except SystemExit as e:
-        if e.code != EXIT_QUIT_ALL:
-            log.error("Exited: %s", e)
+        log.error("Exited: %s", e)
+        raise
     except BaseException as e:
         log.error("[!] Error: %s", e, exc_info=True)
+        raise
     finally:
         # finalize session metadata
         session_meta["frames_captured"] = int(idx)
@@ -1247,7 +1398,8 @@ def main():
         except:
             pass
         cv2.destroyAllWindows()
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/src/posetag/cli/collect.py
+++ b/src/posetag/cli/collect.py
@@ -1,7 +1,11 @@
 """PoseTag CLI wrapper for dataset collection."""
 
 
-def main():
+def main(argv=None):
     from collect_gt_dataset import main as _main
 
-    return _main()
+    return _main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/posetag/gui/main_window.py
+++ b/src/posetag/gui/main_window.py
@@ -196,6 +196,29 @@ from posetag.workflows.annotation import (
     remove_annotation_output,
     summarize_annotation_process_result,
 )
+from posetag.workflows.collect_dataset import (
+    COLLECT_PROCESS_NOT_STARTED,
+    COLLECT_SOURCE_CHOICES,
+    COLLECT_SOURCE_LABELS,
+    DEFAULT_CAMERA_INDEX as DEFAULT_DATASET_CAMERA_INDEX,
+    DEFAULT_FAMILY as DEFAULT_DATASET_FAMILY,
+    DEFAULT_FPS as DEFAULT_DATASET_FPS,
+    DEFAULT_SESSION_NAME as DEFAULT_DATASET_SESSION,
+    SOURCE_BAG as DATASET_SOURCE_BAG,
+    SOURCE_LIVE as DATASET_SOURCE_LIVE,
+    SOURCE_OPENCV as DATASET_SOURCE_OPENCV,
+    SOURCE_VIDEO as DATASET_SOURCE_VIDEO,
+    DatasetCollectionConfig,
+    DatasetCollectionProcessState,
+    DatasetCollectionReadiness,
+    build_dataset_collection_launch,
+    collect_dataset_process_failed,
+    collect_dataset_process_not_started,
+    collect_dataset_process_running,
+    inspect_dataset_collection_readiness,
+    normalize_source as normalize_dataset_source,
+    summarize_dataset_collection_process_result,
+)
 
 CAPTURE_FACE_QUEUE_LABEL = "All missing registered faces"
 MESH_PREVIEW_TOOLTIP = (
@@ -2109,6 +2132,11 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._annotation_process_state = annotation_process_not_started()
             self._annotation_running_expected_face_manifest: Optional[Path] = None
             self._annotation_running_mode = ANNOTATION_MODE_BROWSE
+            self._dataset_process: Any = None
+            self._dataset_process_state = collect_dataset_process_not_started()
+            self._dataset_running_expected_session_dir: Optional[Path] = None
+            self._dataset_running_previous_session_yaml_mtime_ns: Optional[int] = None
+            self._dataset_running_dry_run = False
             self._mesh_keypoint_viewer_windows: list[Any] = []
 
             self._calibration_output_timer = QtCore.QTimer(self)
@@ -4612,6 +4640,291 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             annotation_layout.addLayout(annotation_options)
             annotation_layout.addLayout(annotation_body)
 
+            self._dataset_card = QtWidgets.QFrame()
+            self._dataset_card.setObjectName("ActionCard")
+            dataset_layout = QtWidgets.QVBoxLayout(self._dataset_card)
+            dataset_layout.setContentsMargins(14, 12, 14, 12)
+            dataset_layout.setSpacing(9)
+
+            self._dataset_session = QtWidgets.QLineEdit(DEFAULT_DATASET_SESSION)
+            self._dataset_session.setPlaceholderText("run01")
+            self._dataset_session.textChanged.connect(
+                self._update_dataset_collection_flow
+            )
+
+            self._dataset_source = QtWidgets.QComboBox()
+            for source in COLLECT_SOURCE_CHOICES:
+                self._dataset_source.addItem(COLLECT_SOURCE_LABELS[source], source)
+            self._dataset_source.setCurrentText(COLLECT_SOURCE_LABELS[DATASET_SOURCE_OPENCV])
+            self._dataset_source.currentIndexChanged.connect(
+                lambda _index: self._update_dataset_collection_flow()
+            )
+
+            self._dataset_camera_index = _make_int_spin(
+                0,
+                99,
+                DEFAULT_DATASET_CAMERA_INDEX,
+            )
+            self._dataset_camera_index.valueChanged.connect(
+                self._update_dataset_collection_flow
+            )
+
+            self._dataset_video_path = QtWidgets.QLineEdit()
+            self._dataset_video_path.setPlaceholderText("Video path for source=video")
+            dataset_video_browse_button = QtWidgets.QPushButton("Browse")
+            dataset_video_browse_button.clicked.connect(self._browse_dataset_video)
+            self._dataset_video_browse_button = dataset_video_browse_button
+            dataset_video_row = QtWidgets.QHBoxLayout()
+            dataset_video_row.setContentsMargins(0, 0, 0, 0)
+            dataset_video_row.addWidget(self._dataset_video_path, 1)
+            dataset_video_row.addWidget(dataset_video_browse_button)
+            dataset_video_widget = QtWidgets.QWidget()
+            dataset_video_widget.setLayout(dataset_video_row)
+
+            self._dataset_bag_path = QtWidgets.QLineEdit()
+            self._dataset_bag_path.setPlaceholderText("RealSense .bag path")
+            dataset_bag_browse_button = QtWidgets.QPushButton("Browse")
+            dataset_bag_browse_button.clicked.connect(self._browse_dataset_bag)
+            self._dataset_bag_browse_button = dataset_bag_browse_button
+            dataset_bag_row = QtWidgets.QHBoxLayout()
+            dataset_bag_row.setContentsMargins(0, 0, 0, 0)
+            dataset_bag_row.addWidget(self._dataset_bag_path, 1)
+            dataset_bag_row.addWidget(dataset_bag_browse_button)
+            dataset_bag_widget = QtWidgets.QWidget()
+            dataset_bag_widget.setLayout(dataset_bag_row)
+
+            self._dataset_calibration_path = QtWidgets.QLineEdit()
+            self._dataset_calibration_path.setPlaceholderText(
+                "Default: <project_root>/calib/calib_color.yaml"
+            )
+            dataset_calib_browse_button = QtWidgets.QPushButton("Browse")
+            dataset_calib_browse_button.clicked.connect(
+                self._browse_dataset_calibration
+            )
+            dataset_calib_row = QtWidgets.QHBoxLayout()
+            dataset_calib_row.setContentsMargins(0, 0, 0, 0)
+            dataset_calib_row.addWidget(self._dataset_calibration_path, 1)
+            dataset_calib_row.addWidget(dataset_calib_browse_button)
+            dataset_calib_widget = QtWidgets.QWidget()
+            dataset_calib_widget.setLayout(dataset_calib_row)
+
+            self._dataset_registry_path = QtWidgets.QLineEdit()
+            self._dataset_registry_path.setPlaceholderText(
+                "Default: <project_root>/boards/tag_registry.yaml"
+            )
+            self._dataset_face_manifest_path = QtWidgets.QLineEdit()
+            self._dataset_face_manifest_path.setPlaceholderText(
+                "Default: <project_root>/faces/face_manifest.csv"
+            )
+            self._dataset_family = QtWidgets.QLineEdit(DEFAULT_DATASET_FAMILY)
+            self._dataset_family.setPlaceholderText(DEFAULT_DATASET_FAMILY)
+            self._dataset_smart_auto = QtWidgets.QCheckBox("Smart auto-capture")
+            self._dataset_smart_auto.setChecked(True)
+            self._dataset_continuous = QtWidgets.QCheckBox("Continuous capture")
+            self._dataset_save_depth = QtWidgets.QCheckBox("Save depth")
+            self._dataset_max_frames = _make_int_spin(0, 1000000, 0)
+            self._dataset_max_frames.setSpecialValueText("unlimited")
+            self._dataset_auto_stable_frames = _make_int_spin(1, 120, 5)
+            self._dataset_auto_cooldown = _make_float_spin(0.0, 60.0, 1.0, " s")
+            self._dataset_auto_cooldown.setSingleStep(0.25)
+            for field in (
+                self._dataset_video_path,
+                self._dataset_bag_path,
+                self._dataset_calibration_path,
+                self._dataset_registry_path,
+                self._dataset_face_manifest_path,
+                self._dataset_family,
+            ):
+                field.textChanged.connect(self._update_dataset_collection_flow)
+            for checkbox in (
+                self._dataset_smart_auto,
+                self._dataset_continuous,
+                self._dataset_save_depth,
+            ):
+                checkbox.toggled.connect(
+                    lambda _checked: self._update_dataset_collection_flow()
+                )
+            self._dataset_max_frames.valueChanged.connect(
+                self._update_dataset_collection_flow
+            )
+            self._dataset_auto_stable_frames.valueChanged.connect(
+                self._update_dataset_collection_flow
+            )
+            self._dataset_auto_cooldown.valueChanged.connect(
+                self._update_dataset_collection_flow
+            )
+
+            dataset_title = QtWidgets.QLabel("Dataset collection")
+            dataset_title.setObjectName("CardTitle")
+            self._dataset_dry_run_button = QtWidgets.QPushButton("Dry Run")
+            self._dataset_dry_run_button.setObjectName("SecondaryActionButton")
+            self._dataset_dry_run_button.clicked.connect(
+                lambda: self._run_dataset_collection(dry_run=True)
+            )
+            self._dataset_run_button = QtWidgets.QPushButton("Start Collection")
+            self._dataset_run_button.setObjectName("PrimaryActionButton")
+            self._dataset_run_button.clicked.connect(
+                lambda: self._run_dataset_collection(dry_run=False)
+            )
+            dataset_refresh_button = QtWidgets.QPushButton("Refresh Status")
+            dataset_refresh_button.setObjectName("SecondaryActionButton")
+            dataset_refresh_button.clicked.connect(self._refresh)
+            dataset_title_row = QtWidgets.QHBoxLayout()
+            dataset_title_row.setContentsMargins(0, 0, 0, 0)
+            dataset_title_row.setSpacing(8)
+            dataset_title_row.addWidget(dataset_title)
+            dataset_title_row.addStretch(1)
+            dataset_title_row.addWidget(self._dataset_dry_run_button)
+            dataset_title_row.addWidget(self._dataset_run_button)
+            dataset_title_row.addWidget(dataset_refresh_button)
+
+            dataset_note = QtWidgets.QLabel(
+                "Run the existing posetag-collect workflow to detect visible "
+                "boards, select object faces, compose T_cam_object, and save "
+                "pose-labelled dataset frames."
+            )
+            dataset_note.setObjectName("MutedText")
+            dataset_note.setWordWrap(True)
+
+            dataset_grid = QtWidgets.QGridLayout()
+            dataset_grid.setContentsMargins(0, 0, 0, 0)
+            dataset_grid.setHorizontalSpacing(10)
+            dataset_grid.setVerticalSpacing(8)
+            dataset_grid.addWidget(_make_field("Session", self._dataset_session), 0, 0)
+            dataset_grid.addWidget(_make_field("Source", self._dataset_source), 0, 1)
+            self._dataset_camera_field = _make_field(
+                "Camera index",
+                self._dataset_camera_index,
+            )
+            self._dataset_video_field = _make_field("Video path", dataset_video_widget)
+            self._dataset_bag_field = _make_field("Bag path", dataset_bag_widget)
+            dataset_grid.addWidget(self._dataset_camera_field, 1, 0)
+            dataset_grid.addWidget(self._dataset_video_field, 1, 0, 1, 2)
+            dataset_grid.addWidget(self._dataset_bag_field, 1, 0, 1, 2)
+            dataset_grid.addWidget(
+                _make_field("Calibration YAML", dataset_calib_widget),
+                2,
+                0,
+                1,
+                2,
+            )
+            dataset_grid.setColumnStretch(0, 1)
+            dataset_grid.setColumnStretch(1, 1)
+
+            dataset_advanced_widget = QtWidgets.QWidget()
+            dataset_advanced_grid = QtWidgets.QGridLayout(dataset_advanced_widget)
+            dataset_advanced_grid.setContentsMargins(0, 0, 0, 0)
+            dataset_advanced_grid.setHorizontalSpacing(10)
+            dataset_advanced_grid.setVerticalSpacing(8)
+            dataset_advanced_grid.addWidget(
+                _make_field("Tag registry", self._dataset_registry_path),
+                0,
+                0,
+                1,
+                2,
+            )
+            dataset_advanced_grid.addWidget(
+                _make_field("Face manifest", self._dataset_face_manifest_path),
+                1,
+                0,
+                1,
+                2,
+            )
+            dataset_advanced_grid.addWidget(
+                _make_field("AprilTag family", self._dataset_family),
+                2,
+                0,
+            )
+            dataset_advanced_grid.addWidget(
+                _make_field("Max frames", self._dataset_max_frames),
+                2,
+                1,
+            )
+            dataset_advanced_grid.addWidget(self._dataset_smart_auto, 3, 0)
+            dataset_advanced_grid.addWidget(self._dataset_continuous, 3, 1)
+            dataset_advanced_grid.addWidget(
+                _make_field("Auto stable frames", self._dataset_auto_stable_frames),
+                4,
+                0,
+            )
+            dataset_advanced_grid.addWidget(
+                _make_field("Auto cooldown", self._dataset_auto_cooldown),
+                4,
+                1,
+            )
+            dataset_advanced_grid.addWidget(self._dataset_save_depth, 5, 0)
+            dataset_advanced_grid.setColumnStretch(0, 1)
+            dataset_advanced_grid.setColumnStretch(1, 1)
+            dataset_advanced_group = _make_collapsible_group(
+                "Advanced Inputs And Capture",
+                dataset_advanced_widget,
+                checked=False,
+            )
+
+            self._dataset_readiness = QtWidgets.QLabel()
+            self._dataset_readiness.setObjectName("OutputText")
+            self._dataset_readiness.setWordWrap(True)
+            self._dataset_readiness.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            self._dataset_outputs = QtWidgets.QLabel()
+            self._dataset_outputs.setObjectName("OutputText")
+            self._dataset_outputs.setWordWrap(True)
+            self._dataset_outputs.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            self._dataset_process_state_label = QtWidgets.QLabel()
+            self._dataset_process_state_label.setObjectName("OutputText")
+            self._dataset_process_state_label.setWordWrap(True)
+            self._dataset_process_state_label.setTextInteractionFlags(
+                QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+            )
+            self._dataset_log = QtWidgets.QPlainTextEdit()
+            self._dataset_log.setObjectName("CalibrationLog")
+            self._dataset_log.setReadOnly(True)
+            self._dataset_log.setMaximumHeight(92)
+            self._dataset_log.setPlaceholderText(
+                "Dataset collection stdout/stderr will appear here after launch."
+            )
+            self._dataset_log.document().setMaximumBlockCount(250)
+
+            dataset_summary_grid = QtWidgets.QGridLayout()
+            dataset_summary_grid.setContentsMargins(0, 0, 0, 0)
+            dataset_summary_grid.setHorizontalSpacing(10)
+            dataset_summary_grid.setVerticalSpacing(8)
+            dataset_summary_grid.addWidget(
+                _make_field("Readiness", self._dataset_readiness),
+                0,
+                0,
+            )
+            dataset_summary_grid.addWidget(
+                _make_field("Expected outputs", self._dataset_outputs),
+                0,
+                1,
+            )
+            dataset_summary_grid.addWidget(
+                _make_field("Process state", self._dataset_process_state_label),
+                1,
+                0,
+                1,
+                2,
+            )
+            dataset_summary_grid.addWidget(
+                _make_field("Process log", self._dataset_log),
+                2,
+                0,
+                1,
+                2,
+            )
+            dataset_summary_grid.setColumnStretch(0, 1)
+            dataset_summary_grid.setColumnStretch(1, 1)
+
+            dataset_layout.addLayout(dataset_title_row)
+            dataset_layout.addWidget(dataset_note)
+            dataset_layout.addLayout(dataset_grid)
+            dataset_layout.addWidget(dataset_advanced_group)
+            dataset_layout.addLayout(dataset_summary_grid)
+
             detail_content = QtWidgets.QWidget()
             detail_content_layout = QtWidgets.QVBoxLayout(detail_content)
             detail_content_layout.setContentsMargins(0, 0, 0, 0)
@@ -4619,6 +4932,7 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             detail_content_layout.addLayout(title_row)
             detail_content_layout.addWidget(self._message_label)
             detail_content_layout.addWidget(self._annotation_card)
+            detail_content_layout.addWidget(self._dataset_card)
             detail_content_layout.addLayout(cards_grid)
             detail_content_layout.addWidget(self._charuco_card)
             detail_content_layout.addWidget(self._calibration_card)
@@ -4945,6 +5259,44 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             )
             if selected:
                 self._capture_face_video_path.setText(selected)
+
+        def _browse_dataset_calibration(self) -> None:
+            current = self._dataset_calibration_path.text().strip()
+            start_path = current or str(
+                self._current_project_root() / "calib" / "calib_color.yaml"
+            )
+            selected, _ = QtWidgets.QFileDialog.getOpenFileName(
+                self,
+                "Select dataset calibration YAML",
+                start_path,
+                "YAML files (*.yaml *.yml);;All files (*)",
+            )
+            if selected:
+                self._dataset_calibration_path.setText(selected)
+
+        def _browse_dataset_video(self) -> None:
+            current = self._dataset_video_path.text().strip()
+            start_path = current or str(self._current_project_root())
+            selected, _ = QtWidgets.QFileDialog.getOpenFileName(
+                self,
+                "Select dataset video",
+                start_path,
+                "Video files (*.mp4 *.mov *.avi *.mkv);;All files (*)",
+            )
+            if selected:
+                self._dataset_video_path.setText(selected)
+
+        def _browse_dataset_bag(self) -> None:
+            current = self._dataset_bag_path.text().strip()
+            start_path = current or str(self._current_project_root())
+            selected, _ = QtWidgets.QFileDialog.getOpenFileName(
+                self,
+                "Select RealSense bag",
+                start_path,
+                "RealSense bag files (*.bag);;All files (*)",
+            )
+            if selected:
+                self._dataset_bag_path.setText(selected)
 
         def _browse_capture_face_output_dir(self) -> None:
             current = self._capture_face_out_dir.text().strip()
@@ -5685,6 +6037,7 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._capture_face_card.setVisible(model.stage_id == 5)
             self._mesh_keypoints_card.setVisible(model.stage_id == 6)
             self._annotation_card.setVisible(model.stage_id == 7)
+            self._dataset_card.setVisible(model.stage_id == 8)
             if model.stage_id == 2:
                 self._sync_calibration_from_project_metadata()
                 self._update_calibration_flow()
@@ -5699,6 +6052,8 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                 self._update_mesh_keypoint_flow()
             if model.stage_id == 7:
                 self._update_annotation_flow()
+            if model.stage_id == 8:
+                self._update_dataset_collection_flow()
             self._render_side_panel_calibration_result()
             self._render_stage_rail_selection()
 
@@ -5803,6 +6158,7 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             self._capture_face_card.setVisible(False)
             self._mesh_keypoints_card.setVisible(False)
             self._annotation_card.setVisible(False)
+            self._dataset_card.setVisible(False)
             self._render_health()
 
         def _render_stage_rail_selection(self) -> None:
@@ -6201,6 +6557,60 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             )
             self._copy_feedback.setText(
                 _annotation_command_ready_message(
+                    readiness,
+                    stage_complete=model.status == "complete",
+                )
+            )
+
+        def _update_dataset_collection_flow(self) -> None:
+            if not hasattr(self, "_dataset_readiness"):
+                return
+
+            self._render_dataset_source_fields()
+            readiness = inspect_dataset_collection_readiness(
+                self._dataset_collection_config()
+            )
+            self._dataset_readiness.setText(
+                _format_dataset_collection_readiness(readiness)
+            )
+            self._dataset_outputs.setText(
+                _format_dataset_collection_outputs(readiness)
+            )
+            if (
+                self._dataset_process_state.state
+                == COLLECT_PROCESS_NOT_STARTED
+            ):
+                self._set_dataset_collection_process_state(
+                    collect_dataset_process_not_started(
+                        readiness.expected_session_dir,
+                    )
+                )
+            process_running = self._dataset_collection_process_is_running()
+            self._dataset_dry_run_button.setEnabled(
+                readiness.ready and not process_running
+            )
+            self._dataset_run_button.setEnabled(
+                readiness.ready and not process_running
+            )
+            self._dataset_run_button.setText(
+                _dataset_collection_run_button_label(
+                    self._dataset_process_state
+                )
+            )
+
+            model = self._model_by_stage_id(self._selected_stage_id)
+            if model is None or model.stage_id != 8:
+                return
+
+            command_preview = readiness.command_preview
+            self._command_preview.setText(command_preview)
+            self._command_preview.setCursorPosition(0)
+            self._copy_button.setEnabled(bool(command_preview))
+            self._command_note.setText(
+                _dataset_collection_command_card_note(readiness, model)
+            )
+            self._copy_feedback.setText(
+                _dataset_collection_command_ready_message(
                     readiness,
                     stage_complete=model.status == "complete",
                 )
@@ -7726,6 +8136,196 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                 return False
             return process.state() != QtCore.QProcess.ProcessState.NotRunning
 
+        def _run_dataset_collection(self, *, dry_run: bool = False) -> None:
+            if self._dataset_collection_process_is_running():
+                message = "Dataset collection is already running."
+                self.statusBar().showMessage(message, 3000)
+                return
+
+            config = self._dataset_collection_config()
+            readiness = inspect_dataset_collection_readiness(config)
+            if not readiness.ready:
+                message = (
+                    "Resolve dataset collection readiness messages before "
+                    "running."
+                )
+                self._copy_feedback.setText(message)
+                self.statusBar().showMessage(message, 5000)
+                self._update_dataset_collection_flow()
+                return
+
+            try:
+                launch = build_dataset_collection_launch(config, dry_run=dry_run)
+            except Exception as exc:
+                message = f"Could not prepare dataset collection launch: {exc}"
+                self._set_dataset_collection_process_state(
+                    collect_dataset_process_failed(
+                        message,
+                        expected_session_dir=readiness.expected_session_dir,
+                        dry_run=dry_run,
+                    )
+                )
+                self._append_dataset_collection_log(f"[gui] {message}")
+                self.statusBar().showMessage(message, 6000)
+                self._update_dataset_collection_flow()
+                return
+
+            process = QtCore.QProcess(self)
+            process.setProgram(launch.program)
+            process.setArguments(list(launch.arguments))
+            process.setProcessChannelMode(
+                QtCore.QProcess.ProcessChannelMode.SeparateChannels
+            )
+            if hasattr(QtCore, "QProcessEnvironment"):
+                env = QtCore.QProcessEnvironment.systemEnvironment()
+                env.insert("PYTHONUNBUFFERED", "1")
+                env.insert("POSETAG_PROJECT", str(launch.project_root))
+                process.setProcessEnvironment(env)
+            process.readyReadStandardOutput.connect(
+                self._read_dataset_collection_stdout
+            )
+            process.readyReadStandardError.connect(
+                self._read_dataset_collection_stderr
+            )
+            process.finished.connect(self._dataset_collection_process_finished)
+            process.errorOccurred.connect(self._dataset_collection_process_error)
+
+            self._dataset_process = process
+            self._dataset_running_expected_session_dir = (
+                launch.expected_session_dir
+            )
+            self._dataset_running_previous_session_yaml_mtime_ns = _path_mtime_ns(
+                launch.expected_session_dir / "session.yaml"
+            )
+            self._dataset_running_dry_run = bool(dry_run)
+            self._dataset_log.clear()
+            self._append_dataset_collection_log(f"$ {launch.display_command}")
+            self._append_dataset_collection_log(
+                "[gui] Launching with the current Python interpreter."
+            )
+            if dry_run:
+                self._append_dataset_collection_log(
+                    "[gui] Dry-run validates inputs and exits without opening "
+                    "a camera or writing dataset outputs."
+                )
+            else:
+                self._append_dataset_collection_log(
+                    "[gui] Use the GT Capture OpenCV window to review and "
+                    "accept frames. ENTER/y/s saves, q or ESC skips, Q exits."
+                )
+            self._set_dataset_collection_process_state(
+                collect_dataset_process_running(
+                    launch.expected_session_dir,
+                    dry_run=dry_run,
+                )
+            )
+            self._update_dataset_collection_flow()
+            process.start()
+            message = (
+                "Dataset collection dry-run started."
+                if dry_run
+                else "Dataset collection process started."
+            )
+            self.statusBar().showMessage(message, 4000)
+
+        def _read_dataset_collection_stdout(self) -> None:
+            process = self._dataset_process
+            if process is None:
+                return
+            self._append_dataset_collection_output(
+                process.readAllStandardOutput(),
+                "",
+            )
+
+        def _read_dataset_collection_stderr(self) -> None:
+            process = self._dataset_process
+            if process is None:
+                return
+            self._append_dataset_collection_output(
+                process.readAllStandardError(),
+                "stderr",
+            )
+
+        def _dataset_collection_process_finished(
+            self,
+            exit_code: int,
+            exit_status: Any,
+        ) -> None:
+            self._read_dataset_collection_stdout()
+            self._read_dataset_collection_stderr()
+            crashed = exit_status == QtCore.QProcess.ExitStatus.CrashExit
+            state = summarize_dataset_collection_process_result(
+                exit_code=int(exit_code),
+                crashed=crashed,
+                expected_session_dir=self._dataset_running_expected_session_dir,
+                previous_session_yaml_mtime_ns=(
+                    self._dataset_running_previous_session_yaml_mtime_ns
+                ),
+                require_output_update=not self._dataset_running_dry_run,
+                dry_run=self._dataset_running_dry_run,
+            )
+            self._dataset_process = None
+            self._set_dataset_collection_process_state(state)
+            self._append_dataset_collection_log(f"[gui] {state.message}")
+            self._refresh()
+            self.statusBar().showMessage(state.message, 7000)
+
+        def _dataset_collection_process_error(self, error: Any) -> None:
+            process = self._dataset_process
+            error_name = _qt_enum_name(error)
+            detail = process.errorString() if process is not None else error_name
+            self._append_dataset_collection_log(f"[gui] Process error: {detail}")
+            failed_to_start = QtCore.QProcess.ProcessError.FailedToStart
+            if error != failed_to_start:
+                return
+
+            state = collect_dataset_process_failed(
+                f"Dataset collection process failed to start: {detail}",
+                expected_session_dir=self._dataset_running_expected_session_dir,
+                dry_run=self._dataset_running_dry_run,
+            )
+            self._dataset_process = None
+            self._set_dataset_collection_process_state(state)
+            self._update_dataset_collection_flow()
+            self.statusBar().showMessage(state.message, 7000)
+
+        def _append_dataset_collection_output(self, data: Any, prefix: str) -> None:
+            text = bytes(data).decode("utf-8", errors="replace")
+            if not text:
+                return
+            if prefix:
+                for line in text.rstrip().splitlines():
+                    self._append_dataset_collection_log(f"[{prefix}] {line}")
+            else:
+                self._append_dataset_collection_log(text.rstrip())
+
+        def _append_dataset_collection_log(self, text: str) -> None:
+            if not text:
+                return
+            self._dataset_log.appendPlainText(text)
+            scrollbar = self._dataset_log.verticalScrollBar()
+            scrollbar.setValue(scrollbar.maximum())
+
+        def _set_dataset_collection_process_state(
+            self,
+            state: DatasetCollectionProcessState,
+        ) -> None:
+            self._dataset_process_state = state
+            if hasattr(self, "_dataset_process_state_label"):
+                self._dataset_process_state_label.setText(
+                    _format_dataset_collection_process_state(state)
+                )
+            if hasattr(self, "_dataset_run_button"):
+                self._dataset_run_button.setText(
+                    _dataset_collection_run_button_label(state)
+                )
+
+        def _dataset_collection_process_is_running(self) -> bool:
+            process = self._dataset_process
+            if process is None:
+                return False
+            return process.state() != QtCore.QProcess.ProcessState.NotRunning
+
         def _run_calibration(self) -> None:
             if self._calibration_process_is_running():
                 message = "Calibration is already running."
@@ -7959,6 +8559,19 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
             ):
                 field.setEnabled(uses_capture_size)
 
+        def _render_dataset_source_fields(self) -> None:
+            source = self._dataset_source_value()
+            is_webcam = source == DATASET_SOURCE_OPENCV
+            is_video = source == DATASET_SOURCE_VIDEO
+            is_bag = source == DATASET_SOURCE_BAG
+            self._dataset_camera_field.setVisible(is_webcam)
+            self._dataset_video_field.setVisible(is_video)
+            self._dataset_bag_field.setVisible(is_bag)
+            self._dataset_video_path.setEnabled(is_video)
+            self._dataset_video_browse_button.setEnabled(is_video)
+            self._dataset_bag_path.setEnabled(is_bag)
+            self._dataset_bag_browse_button.setEnabled(is_bag)
+
         def _render_board_save_shot_fields(self) -> None:
             save_shot = bool(self._board_save_shot.isChecked())
             self._board_shots_field.setVisible(save_shot)
@@ -8107,6 +8720,35 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                 exit_when_complete=capture_all or bool(queue_faces),
             )
 
+        def _dataset_collection_config(self) -> DatasetCollectionConfig:
+            calib_text = self._dataset_calibration_path.text().strip()
+            registry_text = self._dataset_registry_path.text().strip()
+            face_manifest_text = self._dataset_face_manifest_path.text().strip()
+            video_text = self._dataset_video_path.text().strip()
+            bag_text = self._dataset_bag_path.text().strip()
+            return DatasetCollectionConfig(
+                project_root=self._current_project_root(),
+                session=self._dataset_session.text().strip(),
+                mode=self._dataset_source_value(),
+                camera_index=int(self._dataset_camera_index.value()),
+                video_path=Path(video_text).expanduser() if video_text else None,
+                bag_path=Path(bag_text).expanduser() if bag_text else None,
+                calib_path=Path(calib_text).expanduser() if calib_text else None,
+                registry_path=Path(registry_text).expanduser()
+                if registry_text
+                else None,
+                face_manifest_path=Path(face_manifest_text).expanduser()
+                if face_manifest_text
+                else None,
+                family=self._dataset_family.text().strip() or DEFAULT_DATASET_FAMILY,
+                continuous=bool(self._dataset_continuous.isChecked()),
+                auto_capture=bool(self._dataset_smart_auto.isChecked()),
+                auto_stable_frames=int(self._dataset_auto_stable_frames.value()),
+                auto_cooldown_sec=float(self._dataset_auto_cooldown.value()),
+                max_frames=int(self._dataset_max_frames.value()),
+                save_depth=bool(self._dataset_save_depth.isChecked()),
+            )
+
         def _object_tag_id_mode_value(self) -> str:
             data = self._object_tags_id_mode.currentData()
             raw = str(data if data is not None else self._object_tags_id_mode.currentText())
@@ -8133,6 +8775,18 @@ def build_main_window(qt: Any, project_root: Path) -> Any:
                 return normalize_capture_source(raw)
             except Exception:
                 return CAPTURE_SOURCE_OPENCV
+
+        def _dataset_source_value(self) -> str:
+            data = self._dataset_source.currentData()
+            raw = str(
+                data
+                if data is not None
+                else self._dataset_source.currentText()
+            )
+            try:
+                return normalize_dataset_source(raw)
+            except Exception:
+                return DATASET_SOURCE_OPENCV
 
         def _model_by_stage_id(self, stage_id: int) -> Optional[StageViewModel]:
             for model in self._models:
@@ -8624,6 +9278,76 @@ def _format_annotation_process_state(
     return "\n".join(lines)
 
 
+def _format_dataset_collection_readiness(
+    readiness: DatasetCollectionReadiness,
+) -> str:
+    lines = [
+        (
+            "Ready to collect pose-labelled dataset frames."
+            if readiness.ready
+            else "Not ready yet."
+        )
+    ]
+    summary = readiness.input_summary
+    if summary is not None:
+        lines.extend(["", f"Annotation inputs: {len(summary.annotations)}"])
+        if summary.missing_keypoints:
+            lines.append(
+                f"Optional keypoints missing: {len(summary.missing_keypoints)}"
+            )
+    if readiness.errors:
+        lines.extend(["", "Errors", *_format_items(readiness.errors)])
+    if readiness.warnings:
+        lines.extend(["", "Warnings", *_format_items(readiness.warnings)])
+    return "\n".join(lines)
+
+
+def _format_dataset_collection_outputs(
+    readiness: DatasetCollectionReadiness,
+) -> str:
+    session = readiness.expected_session_dir
+    annotation_dir = session / "annotations"
+    lines = [
+        "Calibration YAML",
+        _display_path(readiness.calibration_path),
+        f"Status: {'present' if readiness.calibration_path.exists() else 'missing'}",
+        "",
+        "Tag registry",
+        _display_path(readiness.registry_path),
+        f"Status: {'present' if readiness.registry_path.exists() else 'missing'}",
+        "",
+        "Face manifest",
+        _display_path(readiness.face_manifest_path),
+        f"Status: {'present' if readiness.face_manifest_path.exists() else 'missing'}",
+        "",
+        "Expected session",
+        _display_path(session),
+        f"Session metadata: {'present' if (session / 'session.yaml').exists() else 'missing'}",
+    ]
+    if annotation_dir.exists():
+        count = len(tuple(annotation_dir.glob("*.json")))
+        lines.append(f"Pose annotation JSON files: {count}")
+    return "\n".join(lines)
+
+
+def _format_dataset_collection_process_state(
+    state: DatasetCollectionProcessState,
+) -> str:
+    lines = [state.label, "", state.message]
+    if state.expected_session_dir is not None:
+        lines.extend(
+            [
+                "",
+                f"Expected session: {_display_path(state.expected_session_dir)}",
+            ]
+        )
+    if state.dry_run:
+        lines.append("Mode: dry-run")
+    if state.exit_code is not None:
+        lines.append(f"Exit code: {state.exit_code}")
+    return "\n".join(lines)
+
+
 def _annotation_queue_item_label(label: str, *, annotated: bool) -> str:
     marker = "[x]" if annotated else "[ ]"
     status = "annotated" if annotated else "missing"
@@ -8894,6 +9618,16 @@ def _annotation_run_button_label(state: AnnotationProcessState) -> str:
     if state.success:
         return "Open Annotator Again"
     return "Open Annotator"
+
+
+def _dataset_collection_run_button_label(
+    state: DatasetCollectionProcessState,
+) -> str:
+    if state.running:
+        return "Collection Running..."
+    if state.success:
+        return "Start Collection Again"
+    return "Start Collection"
 
 
 def _qt_enum_name(value: Any) -> str:
@@ -9294,6 +10028,41 @@ def _annotation_command_ready_message(
     return "Ready to open the annotator, dry-run, run batch, or copy the command."
 
 
+def _dataset_collection_command_card_note(
+    readiness: DatasetCollectionReadiness,
+    model: StageViewModel,
+) -> str:
+    if not readiness.ready:
+        return (
+            "Resolve the dataset collection readiness messages above before "
+            "running posetag-collect."
+        )
+    if model.status == "complete":
+        return (
+            "Dataset session outputs already pass the current checks. Start "
+            "collection again only if you need another pose-labelled session."
+        )
+    return (
+        "Dry Run validates collection inputs without opening a camera. Start "
+        "Collection launches the existing posetag-collect workflow with the "
+        "selected review, smart auto-capture, or continuous policy and "
+        "POSETAG_PROJECT set for this project; Copy Command keeps the terminal "
+        "fallback."
+    )
+
+
+def _dataset_collection_command_ready_message(
+    readiness: DatasetCollectionReadiness,
+    *,
+    stage_complete: bool = False,
+) -> str:
+    if not readiness.ready:
+        return "No runnable dataset collection command is available yet."
+    if stage_complete:
+        return "Dataset outputs exist. Copy only if you need to run another session."
+    return "Ready to dry-run, start collection, or copy the command."
+
+
 def _project_root_hint(root: Path) -> str:
     if root.is_dir():
         return (
@@ -9302,7 +10071,8 @@ def _project_root_hint(root: Path) -> str:
             "3 object tag generation. Stage 4 can launch the existing "
             "board-building workflow, and Stage 5 can open guided face-shot "
             "capture. Stage 6 can stage OBJ mesh inputs and preview "
-            "mesh-keypoint generation before Stage 7 launches annotation."
+            "mesh-keypoint generation before Stage 7 launches annotation. "
+            "Stage 8 can launch dataset collection."
         )
     if root.exists():
         return "Selected path exists but is not a folder."

--- a/src/posetag/pipelines/collect_dataset.py
+++ b/src/posetag/pipelines/collect_dataset.py
@@ -1,0 +1,1296 @@
+"""Pure helpers for the PoseTag dataset-collection workflow.
+
+The interactive capture loop still lives in the legacy collector script for
+now.  This module holds the small pieces that need hardware-free tests:
+input preflight, source argument validation, session metadata, and pose-label
+serialization.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence, Union
+
+import numpy as np
+import yaml
+
+from utils.annotation_utils import load_board
+from utils.project_config import resolve_project_root
+
+
+DATASET_VERSION = "1.0"
+POSE_COMPOSITION = "T_cam_object = T_cam_board @ T_board_object"
+TRANSLATION_UNITS = "meters"
+ANGLE_UNITS = "degrees"
+QUATERNION_ORDER = "x, y, z, w"
+RPY_ORDER = "roll, pitch, yaw"
+
+
+class CollectDatasetError(RuntimeError):
+    """Raised when dataset collection cannot start safely."""
+
+
+@dataclass(frozen=True)
+class Intrinsics:
+    """Validated colour-camera intrinsics for collection."""
+
+    path: Path
+    fx: float
+    fy: float
+    cx: float
+    cy: float
+    width: int
+    height: int
+    dist: np.ndarray
+
+
+@dataclass(frozen=True)
+class AnnotationInput:
+    """Validated face annotation used by collection."""
+
+    object_name: str
+    face_key: str
+    yaml_path: Path
+    board_yaml: Path
+    tag_ids: tuple[int, ...]
+    tag_size_m: float
+    keypoints_path: Optional[Path]
+
+
+@dataclass(frozen=True)
+class CollectionInputSummary:
+    """Summary returned by collection preflight."""
+
+    project_root: Path
+    calibration_path: Path
+    registry_path: Path
+    face_manifest_path: Path
+    annotations: tuple[AnnotationInput, ...]
+    missing_keypoints: tuple[Path, ...]
+
+
+@dataclass(frozen=True)
+class AutoCaptureConfig:
+    """Quality gates for smart dataset auto-capture.
+
+    This policy is deliberately independent of camera/GUI code.  It consumes
+    already-estimated object poses and decides whether the current frame is
+    stable, good enough, and useful enough to save.
+    """
+
+    enabled: bool = False
+    stable_frames: int = 5
+    cooldown_sec: float = 1.0
+    min_tags_visible: int = 1
+    min_bbox_area_px: float = 12000.0
+    max_tag_scale_error: float = 0.08
+    min_translation_delta_m: float = 0.04
+    min_rotation_delta_deg: float = 8.0
+    grid_rows: int = 3
+    grid_cols: int = 3
+    distance_bin_m: float = 0.25
+    max_frames_per_object: int = 0
+
+
+@dataclass(frozen=True)
+class AutoCaptureCandidate:
+    """One detected object candidate considered for smart auto-capture."""
+
+    object_name: str
+    face_key: str
+    T_cam_object: Any
+    bbox_xywh_px: tuple[float, float, float, float]
+    num_tags_visible: int
+    score: float = 0.0
+    score_area_px: float = 0.0
+    tag_scale_ratio: float = 1.0
+    tag_scale_pairs: int = 0
+
+
+@dataclass
+class AutoCaptureTrack:
+    """Per-object stability state for smart auto-capture."""
+
+    last_face_key: str = ""
+    last_T_cam_object: Optional[np.ndarray] = None
+    stable_count: int = 0
+
+
+@dataclass
+class AutoCaptureState:
+    """Mutable smart auto-capture state accumulated during one session."""
+
+    tracks: dict[str, AutoCaptureTrack] = field(default_factory=dict)
+    accepted_cells: dict[str, set[tuple[int, int]]] = field(default_factory=dict)
+    accepted_distance_bins: dict[str, set[int]] = field(default_factory=dict)
+    accepted_poses: dict[str, list[np.ndarray]] = field(default_factory=dict)
+    accepted_counts: dict[str, int] = field(default_factory=dict)
+    last_save_timestamp: Optional[float] = None
+
+
+@dataclass(frozen=True)
+class AutoCaptureDecision:
+    """Decision returned by the smart auto-capture policy."""
+
+    should_save: bool
+    status: str
+    message: str
+    reason: str = ""
+    trigger_object: Optional[str] = None
+    trigger_face: Optional[str] = None
+    stable_count: int = 0
+    rejected_reasons: tuple[str, ...] = ()
+
+    def metadata(self) -> dict[str, Any]:
+        """Return a JSON-safe record for per-frame capture metadata."""
+
+        return {
+            "mode": "smart_auto",
+            "status": self.status,
+            "reason": self.reason,
+            "trigger_object": self.trigger_object,
+            "trigger_face": self.trigger_face,
+            "stable_count": int(self.stable_count),
+            "rejected_reasons": list(self.rejected_reasons),
+        }
+
+
+def preview_project_root(project_root: Optional[Union[Path, str]]) -> Path:
+    """Resolve the project root without creating directories when explicit."""
+
+    if project_root is not None:
+        return Path(project_root).expanduser().resolve()
+    return Path(resolve_project_root(None))
+
+
+def resolve_under_project(
+    project_root: Union[Path, str],
+    value: Optional[Union[Path, str]],
+    default: Union[Path, str],
+) -> Path:
+    """Resolve a project-relative path unless the provided path is absolute."""
+
+    root = Path(project_root).expanduser().resolve()
+    raw = Path(default if value is None else value).expanduser()
+    return raw if raw.is_absolute() else root / raw
+
+
+def resolve_calibration_path(
+    project_root: Union[Path, str],
+    calib: Optional[Union[Path, str]] = "calib_color.yaml",
+) -> Path:
+    """Resolve the required Step 1 colour calibration YAML.
+
+    The canonical location is ``<project_root>/calib/calib_color.yaml``.
+    Relative names are resolved there first, then under the project root, then
+    as a literal relative path for compatibility with older script usage.
+    """
+
+    root = Path(project_root).expanduser().resolve()
+    raw = Path(calib or "calib_color.yaml").expanduser()
+    if raw.is_absolute():
+        return raw
+
+    candidates: list[Path] = []
+    if len(raw.parts) > 1:
+        candidates.append(root / raw)
+    else:
+        candidates.append(root / "calib" / raw)
+        candidates.append(root / raw)
+    candidates.append(raw)
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return candidates[0]
+
+
+def resolve_registry_path(
+    project_root: Union[Path, str],
+    registry: Optional[Union[Path, str]] = None,
+) -> Path:
+    """Resolve the required board tag registry."""
+
+    return resolve_under_project(project_root, registry, "boards/tag_registry.yaml")
+
+
+def resolve_face_manifest_path(
+    project_root: Union[Path, str],
+    face_manifest: Optional[Union[Path, str]] = None,
+) -> Path:
+    """Resolve the required face annotation manifest."""
+
+    return resolve_under_project(project_root, face_manifest, "faces/face_manifest.csv")
+
+
+def resolve_dataset_root(
+    project_root: Union[Path, str],
+    dataset_root: Optional[Union[Path, str]] = None,
+) -> Path:
+    """Resolve the root containing dataset sessions."""
+
+    return resolve_under_project(project_root, dataset_root, "datasets")
+
+
+def load_intrinsics_from_calibration(calib_path: Union[Path, str]) -> Intrinsics:
+    """Load and validate the Step 1 colour-camera calibration YAML."""
+
+    target = Path(calib_path).expanduser()
+    if not target.exists():
+        raise CollectDatasetError(
+            f"Calibration YAML not found: {target}. Run Step 1 to create "
+            "calib/calib_color.yaml first."
+        )
+
+    data = _load_yaml_mapping(target, "calibration YAML")
+    camera_matrix = data.get("camera_matrix")
+    if not isinstance(camera_matrix, Mapping):
+        raise CollectDatasetError(
+            f"Malformed calibration YAML: {target} is missing camera_matrix fields."
+        )
+
+    missing = [name for name in ("fx", "fy", "cx", "cy") if name not in camera_matrix]
+    if missing:
+        joined = ", ".join(f"camera_matrix.{name}" for name in missing)
+        raise CollectDatasetError(f"Malformed calibration YAML: {target} is missing {joined}.")
+
+    try:
+        fx = float(camera_matrix["fx"])
+        fy = float(camera_matrix["fy"])
+        cx = float(camera_matrix["cx"])
+        cy = float(camera_matrix["cy"])
+    except (TypeError, ValueError) as exc:
+        raise CollectDatasetError(
+            f"Malformed calibration YAML: {target} camera_matrix values must be numeric."
+        ) from exc
+    if not all(np.isfinite(value) for value in (fx, fy, cx, cy)):
+        raise CollectDatasetError(
+            f"Malformed calibration YAML: {target} camera_matrix values must be finite."
+        )
+
+    width = _positive_int(data, "image_width", target)
+    height = _positive_int(data, "image_height", target)
+
+    distortion = data.get("distortion_coefficients") or {}
+    if not isinstance(distortion, Mapping):
+        raise CollectDatasetError(
+            f"Malformed calibration YAML: {target} distortion_coefficients must be a mapping."
+        )
+    distortion_values: list[float] = []
+    for name in ("k1", "k2", "p1", "p2", "k3"):
+        try:
+            distortion_values.append(float(distortion.get(name, 0.0)))
+        except (TypeError, ValueError) as exc:
+            raise CollectDatasetError(
+                f"Malformed calibration YAML: {target} distortion_coefficients.{name} "
+                "must be numeric."
+            ) from exc
+    dist = np.array([distortion_values], dtype=float)
+
+    return Intrinsics(
+        path=target,
+        fx=fx,
+        fy=fy,
+        cx=cx,
+        cy=cy,
+        width=width,
+        height=height,
+        dist=dist,
+    )
+
+
+def validate_source_args(
+    *,
+    mode: str,
+    video: Optional[Union[Path, str]],
+    bag: Optional[Union[Path, str]],
+    realsense_module: Any,
+    video_capture_factory: Optional[Callable[[str], Any]] = None,
+) -> None:
+    """Validate source-specific arguments before opening hardware or outputs."""
+
+    if mode == "video":
+        if not video:
+            raise CollectDatasetError("--video is required when --mode video")
+        video_path = Path(video).expanduser()
+        if not video_path.exists():
+            raise CollectDatasetError(f"Could not open video: {video_path}")
+        if video_capture_factory is not None:
+            cap = video_capture_factory(str(video_path))
+            try:
+                is_open = bool(cap.isOpened()) if hasattr(cap, "isOpened") else True
+            finally:
+                if hasattr(cap, "release"):
+                    cap.release()
+            if not is_open:
+                raise CollectDatasetError(f"Could not open video: {video_path}")
+
+    if mode == "bag":
+        if not bag:
+            raise CollectDatasetError("--bag is required when --mode bag")
+        bag_path = Path(bag).expanduser()
+        if not bag_path.exists():
+            raise CollectDatasetError(f"RealSense bag file not found: {bag_path}")
+
+    if mode in {"live", "bag"} and realsense_module is None:
+        raise CollectDatasetError(
+            "pyrealsense2 is not available; install PoseTag with the 'realsense' "
+            "extra or use --mode opencv|video."
+        )
+
+
+def validate_collection_inputs(
+    *,
+    project_root: Union[Path, str],
+    calib_path: Union[Path, str],
+    registry_path: Union[Path, str],
+    face_manifest_path: Union[Path, str],
+    allow_face_scan: bool = False,
+) -> CollectionInputSummary:
+    """Validate required collection inputs without opening cameras."""
+
+    root = Path(project_root).expanduser().resolve()
+    calibration = Path(calib_path).expanduser()
+    registry = Path(registry_path).expanduser()
+    manifest = Path(face_manifest_path).expanduser()
+
+    # Validate calibration for clearer preflight failures even when caller
+    # already loaded it.
+    load_intrinsics_from_calibration(calibration)
+
+    registry_index = load_tag_registry_index(registry, root)
+    rows = _read_face_manifest_rows(manifest, root, allow_face_scan=allow_face_scan)
+
+    annotations: list[AnnotationInput] = []
+    missing_keypoints: set[Path] = set()
+    errors: list[str] = []
+    for row_number, row in rows:
+        try:
+            annotation = _validate_annotation_row(row, row_number, root, registry_index)
+            annotations.append(annotation)
+            if annotation.keypoints_path is None:
+                missing_keypoints.add(root / "objects" / annotation.object_name / "keypoints.json")
+        except CollectDatasetError as exc:
+            errors.append(str(exc))
+
+    if errors:
+        raise CollectDatasetError("\n".join(errors))
+    if not annotations:
+        raise CollectDatasetError(f"No annotation YAMLs found from {manifest}.")
+
+    return CollectionInputSummary(
+        project_root=root,
+        calibration_path=calibration,
+        registry_path=registry,
+        face_manifest_path=manifest,
+        annotations=tuple(annotations),
+        missing_keypoints=tuple(sorted(missing_keypoints)),
+    )
+
+
+def load_tag_registry_index(registry_path: Union[Path, str], project_root: Union[Path, str]) -> dict[int, Path]:
+    """Load ``boards/tag_registry.yaml`` as ``tag_id -> board YAML``."""
+
+    target = Path(registry_path).expanduser()
+    if not target.exists():
+        raise CollectDatasetError(
+            f"Tag registry not found: {target}. Run Step 2 to create boards/tag_registry.yaml."
+        )
+
+    data = _load_yaml_mapping(target, "tag registry YAML")
+    tags = data.get("tags")
+    if not isinstance(tags, Mapping) or not tags:
+        raise CollectDatasetError(f"Malformed tag registry YAML: {target} tags must be a non-empty mapping.")
+
+    root = Path(project_root).expanduser().resolve()
+    index: dict[int, Path] = {}
+    for raw_tag_id, value in tags.items():
+        try:
+            tag_id = int(raw_tag_id)
+        except (TypeError, ValueError) as exc:
+            raise CollectDatasetError(
+                f"Malformed tag registry YAML: {target} tag id {raw_tag_id!r} must be an integer."
+            ) from exc
+        if not isinstance(value, Mapping):
+            raise CollectDatasetError(
+                f"Malformed tag registry YAML: {target} tags.{raw_tag_id} must be a mapping."
+            )
+        yaml_value = value.get("yaml")
+        if not yaml_value:
+            raise CollectDatasetError(
+                f"Malformed tag registry YAML: {target} tags.{raw_tag_id}.yaml is required."
+            )
+        board_path = Path(str(yaml_value)).expanduser()
+        if not board_path.is_absolute():
+            board_path = root / board_path
+        index[tag_id] = board_path.resolve()
+    return index
+
+
+def compose_T_cam_object(T_cam_board: np.ndarray, T_board_object: np.ndarray) -> np.ndarray:
+    """Compose PoseTag's runtime object pose convention."""
+
+    cam_board = _matrix4(T_cam_board, "T_cam_board")
+    board_object = _matrix4(T_board_object, "T_board_object")
+    return cam_board @ board_object
+
+
+def pose_convention_record() -> dict[str, str]:
+    """Return the explicit transform and rotation convention metadata."""
+
+    return {
+        "composition": POSE_COMPOSITION,
+        "matrix_shape": "4x4 homogeneous transform",
+        "matrix_storage": "row-major nested lists",
+        "point_convention": "column vectors",
+        "T_cam_board": "maps board-frame points into the camera frame",
+        "T_board_object": "maps object-frame points into the board frame",
+        "T_cam_object": "maps object-frame points into the camera frame",
+        "translation_units": TRANSLATION_UNITS,
+        "quaternion_order": QUATERNION_ORDER,
+        "rpy_order": RPY_ORDER,
+        "angle_units": ANGLE_UNITS,
+    }
+
+
+def rpy_deg_from_matrix(R: np.ndarray) -> tuple[float, float, float]:
+    """Return intrinsic roll, pitch, yaw angles in degrees."""
+
+    rot = np.asarray(R, dtype=float)
+    sy = math.sqrt(rot[0, 0] ** 2 + rot[1, 0] ** 2)
+    if sy >= 1e-6:
+        roll = math.atan2(rot[2, 1], rot[2, 2])
+        pitch = math.atan2(-rot[2, 0], sy)
+        yaw = math.atan2(rot[1, 0], rot[0, 0])
+    else:
+        roll = math.atan2(-rot[1, 2], rot[1, 1])
+        pitch = math.atan2(-rot[2, 0], sy)
+        yaw = 0.0
+    return tuple(float(v) for v in np.degrees([roll, pitch, yaw]).tolist())
+
+
+def quaternion_xyzw_from_matrix(R: np.ndarray) -> tuple[float, float, float, float]:
+    """Convert a rotation matrix to quaternion order ``[x, y, z, w]``."""
+
+    rot = np.asarray(R, dtype=float)
+    trace = float(np.trace(rot))
+    if trace > 0.0:
+        s = math.sqrt(trace + 1.0) * 2.0
+        w = 0.25 * s
+        x = (rot[2, 1] - rot[1, 2]) / s
+        y = (rot[0, 2] - rot[2, 0]) / s
+        z = (rot[1, 0] - rot[0, 1]) / s
+    else:
+        index = int(np.argmax([rot[0, 0], rot[1, 1], rot[2, 2]]))
+        if index == 0:
+            s = math.sqrt(1.0 + rot[0, 0] - rot[1, 1] - rot[2, 2]) * 2.0
+            w = (rot[2, 1] - rot[1, 2]) / s
+            x = 0.25 * s
+            y = (rot[0, 1] + rot[1, 0]) / s
+            z = (rot[0, 2] + rot[2, 0]) / s
+        elif index == 1:
+            s = math.sqrt(1.0 + rot[1, 1] - rot[0, 0] - rot[2, 2]) * 2.0
+            w = (rot[0, 2] - rot[2, 0]) / s
+            x = (rot[0, 1] + rot[1, 0]) / s
+            y = 0.25 * s
+            z = (rot[1, 2] + rot[2, 1]) / s
+        else:
+            s = math.sqrt(1.0 + rot[2, 2] - rot[0, 0] - rot[1, 1]) * 2.0
+            w = (rot[1, 0] - rot[0, 1]) / s
+            x = (rot[0, 2] + rot[2, 0]) / s
+            y = (rot[1, 2] + rot[2, 1]) / s
+            z = 0.25 * s
+    quat = np.array([x, y, z, w], dtype=float)
+    norm = float(np.linalg.norm(quat))
+    if norm > 0.0 and np.isfinite(norm):
+        quat /= norm
+    return tuple(float(v) for v in quat.tolist())
+
+
+def parse_auto_capture_grid(value: Union[str, tuple[int, int], list[int]]) -> tuple[int, int]:
+    """Parse a smart auto-capture coverage grid such as ``3x3``."""
+
+    if isinstance(value, str):
+        raw = value.strip().lower().replace(" ", "")
+        if "x" not in raw:
+            raise CollectDatasetError("--auto-grid must look like ROWSxCOLS, for example 3x3.")
+        row_s, col_s = raw.split("x", 1)
+        try:
+            rows, cols = int(row_s), int(col_s)
+        except ValueError as exc:
+            raise CollectDatasetError("--auto-grid rows and columns must be integers.") from exc
+    else:
+        try:
+            rows, cols = int(value[0]), int(value[1])
+        except (TypeError, ValueError, IndexError) as exc:
+            raise CollectDatasetError("--auto-grid must provide rows and columns.") from exc
+    if rows <= 0 or cols <= 0:
+        raise CollectDatasetError("--auto-grid rows and columns must be positive.")
+    return rows, cols
+
+
+def auto_capture_candidates_from_results(
+    results: Mapping[str, Mapping[str, Any]],
+) -> tuple[AutoCaptureCandidate, ...]:
+    """Convert collector pose results into smart auto-capture candidates."""
+
+    candidates: list[AutoCaptureCandidate] = []
+    for result in results.values():
+        bbox = result.get("bbox_xywh") or result.get("bbox_xywh_px")
+        transform = result.get("T_cam_object")
+        if isinstance(transform, Mapping):
+            transform = transform.get("matrix")
+        diagnostics = dict(result.get("diagnostics", {}))
+        try:
+            bbox_xywh = tuple(float(v) for v in bbox)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            bbox_xywh = (0.0, 0.0, 0.0, 0.0)
+        if len(bbox_xywh) != 4:
+            bbox_xywh = (0.0, 0.0, 0.0, 0.0)
+        candidates.append(
+            AutoCaptureCandidate(
+                object_name=str(result.get("object", "")),
+                face_key=str(result.get("face_key", "")),
+                T_cam_object=transform,
+                bbox_xywh_px=bbox_xywh,  # type: ignore[arg-type]
+                num_tags_visible=int(result.get("num_tags_visible", 0)),
+                score=float(result.get("score", 0.0)),
+                score_area_px=float(result.get("score_area_px", 0.0)),
+                tag_scale_ratio=float(diagnostics.get("tag_scale_ratio", 1.0)),
+                tag_scale_pairs=int(diagnostics.get("tag_scale_pairs", 0)),
+            )
+        )
+    return tuple(sorted(candidates, key=lambda c: c.score, reverse=True))
+
+
+def evaluate_auto_capture(
+    candidates: Sequence[AutoCaptureCandidate],
+    state: AutoCaptureState,
+    config: AutoCaptureConfig,
+    *,
+    frame_width: int,
+    frame_height: int,
+    timestamp: float,
+) -> AutoCaptureDecision:
+    """Evaluate smart auto-capture gates for one frame.
+
+    The function mutates ``state`` by updating per-object stability tracks.  It
+    does not mark frames as accepted; call ``record_auto_capture_save`` after a
+    successful write.
+    """
+
+    if not config.enabled:
+        return AutoCaptureDecision(False, "disabled", "Smart auto-capture is disabled.")
+    if not candidates:
+        return AutoCaptureDecision(
+            False,
+            "waiting_for_detection",
+            "Auto: waiting for a registered board face.",
+        )
+
+    rows, cols = _coverage_grid(config)
+    width = max(1, int(frame_width))
+    height = max(1, int(frame_height))
+    quality_candidates: list[tuple[AutoCaptureCandidate, np.ndarray, int]] = []
+    rejected: list[str] = []
+
+    for candidate in candidates:
+        matrix, reasons = _auto_candidate_quality_rejections(candidate, config)
+        if reasons or matrix is None:
+            rejected.extend(f"{candidate.object_name or '?'}: {reason}" for reason in reasons)
+            _reset_auto_capture_track(state, candidate)
+            continue
+        stable_count = _update_auto_capture_track(state, candidate, matrix, config)
+        quality_candidates.append((candidate, matrix, stable_count))
+
+    if not quality_candidates:
+        msg = "Auto: waiting for quality"
+        if rejected:
+            msg = f"{msg} ({rejected[0]})"
+        return AutoCaptureDecision(
+            False,
+            "waiting_for_quality",
+            msg,
+            rejected_reasons=tuple(rejected[:6]),
+        )
+
+    stable_candidates = [
+        (candidate, matrix, stable_count)
+        for candidate, matrix, stable_count in quality_candidates
+        if stable_count >= max(1, int(config.stable_frames))
+    ]
+    if not stable_candidates:
+        best_count = max(stable_count for _, _, stable_count in quality_candidates)
+        needed = max(1, int(config.stable_frames))
+        return AutoCaptureDecision(
+            False,
+            "waiting_for_stability",
+            f"Auto: stabilizing pose {best_count}/{needed}",
+            stable_count=best_count,
+            rejected_reasons=tuple(rejected[:6]),
+        )
+
+    if _auto_capture_cooling_down(state, config, timestamp):
+        remaining = max(0.0, float(config.cooldown_sec) - (float(timestamp) - float(state.last_save_timestamp)))
+        best = stable_candidates[0]
+        return AutoCaptureDecision(
+            False,
+            "cooldown",
+            f"Auto: cooldown {remaining:.1f}s",
+            trigger_object=best[0].object_name,
+            trigger_face=best[0].face_key,
+            stable_count=best[2],
+            rejected_reasons=tuple(rejected[:6]),
+        )
+
+    duplicate_reasons: list[str] = []
+    for candidate, matrix, stable_count in stable_candidates:
+        useful_reason, duplicate_reason = _auto_capture_usefulness(
+            state,
+            candidate,
+            matrix,
+            config,
+            frame_width=width,
+            frame_height=height,
+            grid_rows=rows,
+            grid_cols=cols,
+        )
+        if useful_reason:
+            return AutoCaptureDecision(
+                True,
+                "ready",
+                f"Auto: save {candidate.object_name} ({useful_reason})",
+                reason=useful_reason,
+                trigger_object=candidate.object_name,
+                trigger_face=candidate.face_key,
+                stable_count=stable_count,
+                rejected_reasons=tuple(rejected[:6]),
+            )
+        duplicate_reasons.append(f"{candidate.object_name}: {duplicate_reason}")
+
+    return AutoCaptureDecision(
+        False,
+        "waiting_for_new_view",
+        "Auto: waiting for a new view",
+        stable_count=max(stable_count for _, _, stable_count in stable_candidates),
+        rejected_reasons=tuple((duplicate_reasons or rejected)[:6]),
+    )
+
+
+def record_auto_capture_save(
+    state: AutoCaptureState,
+    candidate: AutoCaptureCandidate,
+    config: AutoCaptureConfig,
+    *,
+    frame_width: int,
+    frame_height: int,
+    timestamp: float,
+) -> None:
+    """Record that a smart auto-capture candidate was written to disk."""
+
+    matrix = _matrix4(candidate.T_cam_object, "auto-capture T_cam_object")
+    rows, cols = _coverage_grid(config)
+    obj = candidate.object_name
+    state.accepted_counts[obj] = int(state.accepted_counts.get(obj, 0)) + 1
+    state.accepted_cells.setdefault(obj, set()).add(
+        _bbox_grid_cell(candidate.bbox_xywh_px, frame_width, frame_height, rows, cols)
+    )
+    state.accepted_distance_bins.setdefault(obj, set()).add(
+        _distance_bin(matrix, config)
+    )
+    state.accepted_poses.setdefault(obj, []).append(matrix.copy())
+    state.last_save_timestamp = float(timestamp)
+
+
+def _coverage_grid(config: AutoCaptureConfig) -> tuple[int, int]:
+    rows = max(1, int(config.grid_rows))
+    cols = max(1, int(config.grid_cols))
+    return rows, cols
+
+
+def _auto_candidate_quality_rejections(
+    candidate: AutoCaptureCandidate,
+    config: AutoCaptureConfig,
+) -> tuple[Optional[np.ndarray], list[str]]:
+    reasons: list[str] = []
+    matrix: Optional[np.ndarray] = None
+    if not candidate.object_name:
+        reasons.append("missing object name")
+    if not candidate.face_key:
+        reasons.append("missing face key")
+    try:
+        matrix = _matrix4(candidate.T_cam_object, "auto-capture T_cam_object")
+    except CollectDatasetError as exc:
+        reasons.append(str(exc))
+    x0, y0, w_px, h_px = candidate.bbox_xywh_px
+    if not all(np.isfinite([x0, y0, w_px, h_px])):
+        reasons.append("bbox is not finite")
+    if w_px <= 0.0 or h_px <= 0.0:
+        reasons.append("bbox is empty")
+    if (w_px * h_px) < float(config.min_bbox_area_px):
+        reasons.append(f"bbox area < {float(config.min_bbox_area_px):g}px^2")
+    if int(candidate.num_tags_visible) < int(config.min_tags_visible):
+        reasons.append(f"visible tags < {int(config.min_tags_visible)}")
+    if int(candidate.tag_scale_pairs) > 0:
+        scale_error = abs(float(candidate.tag_scale_ratio) - 1.0)
+        if scale_error > float(config.max_tag_scale_error):
+            reasons.append(
+                f"tag scale error {scale_error:.3f} > {float(config.max_tag_scale_error):.3f}"
+            )
+    return matrix, reasons
+
+
+def _reset_auto_capture_track(
+    state: AutoCaptureState,
+    candidate: AutoCaptureCandidate,
+) -> None:
+    if not candidate.object_name:
+        return
+    state.tracks[candidate.object_name] = AutoCaptureTrack(
+        last_face_key=candidate.face_key,
+        last_T_cam_object=None,
+        stable_count=0,
+    )
+
+
+def _update_auto_capture_track(
+    state: AutoCaptureState,
+    candidate: AutoCaptureCandidate,
+    matrix: np.ndarray,
+    config: AutoCaptureConfig,
+) -> int:
+    track = state.tracks.get(candidate.object_name)
+    stable_count = 1
+    if (
+        track is not None
+        and track.last_T_cam_object is not None
+        and track.last_face_key == candidate.face_key
+    ):
+        translation_delta, rotation_delta = pose_delta(
+            track.last_T_cam_object,
+            matrix,
+        )
+        if (
+            translation_delta <= float(config.min_translation_delta_m)
+            and rotation_delta <= float(config.min_rotation_delta_deg)
+        ):
+            stable_count = int(track.stable_count) + 1
+    state.tracks[candidate.object_name] = AutoCaptureTrack(
+        last_face_key=candidate.face_key,
+        last_T_cam_object=matrix.copy(),
+        stable_count=stable_count,
+    )
+    return stable_count
+
+
+def _auto_capture_cooling_down(
+    state: AutoCaptureState,
+    config: AutoCaptureConfig,
+    timestamp: float,
+) -> bool:
+    return (
+        state.last_save_timestamp is not None
+        and float(config.cooldown_sec) > 0.0
+        and (float(timestamp) - float(state.last_save_timestamp)) < float(config.cooldown_sec)
+    )
+
+
+def _auto_capture_usefulness(
+    state: AutoCaptureState,
+    candidate: AutoCaptureCandidate,
+    matrix: np.ndarray,
+    config: AutoCaptureConfig,
+    *,
+    frame_width: int,
+    frame_height: int,
+    grid_rows: int,
+    grid_cols: int,
+) -> tuple[Optional[str], str]:
+    obj = candidate.object_name
+    count = int(state.accepted_counts.get(obj, 0))
+    if int(config.max_frames_per_object) > 0 and count >= int(config.max_frames_per_object):
+        return None, "per-object limit reached"
+    if count == 0:
+        return "first_sample", ""
+
+    cell = _bbox_grid_cell(
+        candidate.bbox_xywh_px,
+        frame_width,
+        frame_height,
+        grid_rows,
+        grid_cols,
+    )
+    if cell not in state.accepted_cells.get(obj, set()):
+        return "coverage_cell", ""
+
+    distance_bin = _distance_bin(matrix, config)
+    if distance_bin not in state.accepted_distance_bins.get(obj, set()):
+        return "distance_bin", ""
+
+    previous_poses = state.accepted_poses.get(obj, [])
+    if previous_poses:
+        translation_delta, rotation_delta = pose_delta(previous_poses[-1], matrix)
+        if (
+            translation_delta >= float(config.min_translation_delta_m)
+            or rotation_delta >= float(config.min_rotation_delta_deg)
+        ):
+            return "pose_delta", ""
+    return None, "duplicate view"
+
+
+def _bbox_grid_cell(
+    bbox_xywh_px: tuple[float, float, float, float],
+    frame_width: int,
+    frame_height: int,
+    rows: int,
+    cols: int,
+) -> tuple[int, int]:
+    x0, y0, w_px, h_px = [float(v) for v in bbox_xywh_px]
+    cx = min(max((x0 + 0.5 * w_px) / max(1.0, float(frame_width)), 0.0), 0.999999)
+    cy = min(max((y0 + 0.5 * h_px) / max(1.0, float(frame_height)), 0.0), 0.999999)
+    return int(cy * max(1, rows)), int(cx * max(1, cols))
+
+
+def _distance_bin(matrix: np.ndarray, config: AutoCaptureConfig) -> int:
+    bin_size = max(1e-9, float(config.distance_bin_m))
+    distance = float(np.linalg.norm(matrix[:3, 3]))
+    return int(math.floor(distance / bin_size))
+
+
+def pose_delta(T_a: np.ndarray, T_b: np.ndarray) -> tuple[float, float]:
+    """Return translation distance in meters and rotation angle in degrees."""
+
+    a = _matrix4(T_a, "T_a")
+    b = _matrix4(T_b, "T_b")
+    translation_delta = float(np.linalg.norm(a[:3, 3] - b[:3, 3]))
+    rel = a[:3, :3].T @ b[:3, :3]
+    cos_theta = max(-1.0, min(1.0, (float(np.trace(rel)) - 1.0) * 0.5))
+    rotation_delta = float(math.degrees(math.acos(cos_theta)))
+    return translation_delta, rotation_delta
+
+
+def build_session_metadata(
+    *,
+    session_name: str,
+    project_root: Union[Path, str],
+    dataset_root: Union[Path, str],
+    session_dir: Union[Path, str],
+    intrinsics: Intrinsics,
+    tag_family: str,
+    camera_kind: str,
+    mode: str,
+    tag_scale_controls: Mapping[str, Any],
+    faces_index: Mapping[str, Mapping[str, Any]],
+    missing_keypoints: tuple[Path, ...] = (),
+) -> dict[str, Any]:
+    """Build session-wide metadata for a dataset collection run."""
+
+    objects = sorted(
+        {
+            str(value.get("object"))
+            for value in faces_index.values()
+            if value.get("object")
+        }
+    )
+    return {
+        "version": DATASET_VERSION,
+        "name": session_name,
+        "project_root": str(Path(project_root).expanduser().resolve()),
+        "paths": {
+            "root": str(Path(dataset_root).expanduser()),
+            "session_dir": str(Path(session_dir).expanduser()),
+        },
+        "source": {
+            "mode": mode,
+            "camera_kind": camera_kind,
+        },
+        "camera": {
+            "kind": camera_kind,
+            "fx": float(intrinsics.fx),
+            "fy": float(intrinsics.fy),
+            "cx": float(intrinsics.cx),
+            "cy": float(intrinsics.cy),
+            "width": int(intrinsics.width),
+            "height": int(intrinsics.height),
+            "distortion_coefficients": intrinsics.dist.reshape(-1).astype(float).tolist(),
+            "calibration_yaml": str(intrinsics.path),
+        },
+        "tag_family": tag_family,
+        "pose_convention": pose_convention_record(),
+        "tag_scale_controls": dict(tag_scale_controls),
+        "faces_index": dict(faces_index),
+        "objects_available": objects,
+        "optional_keypoints_missing": [str(path) for path in missing_keypoints],
+        "objects_seen_counts": {},
+        "frames_captured": 0,
+    }
+
+
+def build_frame_annotation_record(
+    *,
+    dataset_name: str,
+    frame_index: int,
+    timestamp: float,
+    tag_family: str,
+    image_filename: str,
+    annotated_image: Optional[str],
+    reproj_image: Optional[str],
+    depth: Optional[str],
+    intrinsics: Intrinsics,
+    results: Mapping[str, Mapping[str, Any]],
+    pts3d_by_object: Optional[Mapping[str, np.ndarray]] = None,
+    capture_metadata: Optional[Mapping[str, Any]] = None,
+) -> dict[str, Any]:
+    """Serialize one accepted dataset frame using PoseTag's pose schema."""
+
+    camera_extrinsics = _camera_extrinsics_from_results(results)
+    objects_out = [
+        build_pose_object_record(result, intrinsics, pts3d_by_object=pts3d_by_object)
+        for result in results.values()
+    ]
+
+    record = {
+        "version": DATASET_VERSION,
+        "metadata": {
+            "dataset_name": dataset_name,
+            "frame_index": int(frame_index),
+            "timestamp": float(timestamp),
+            "tag_family": tag_family,
+        },
+        "pose_convention": pose_convention_record(),
+        "image_filename": image_filename,
+        "objects": objects_out,
+        "annotated_image": annotated_image,
+        "reproj_image": reproj_image,
+        "depth": depth,
+        "camera_intrinsics": {
+            "fx": float(intrinsics.fx),
+            "fy": float(intrinsics.fy),
+            "cx": float(intrinsics.cx),
+            "cy": float(intrinsics.cy),
+            "width": int(intrinsics.width),
+            "height": int(intrinsics.height),
+        },
+        "camera_extrinsics": camera_extrinsics,
+    }
+    if capture_metadata:
+        record["capture"] = _json_safe(capture_metadata)
+    return record
+
+
+def build_pose_object_record(
+    result: Mapping[str, Any],
+    intrinsics: Intrinsics,
+    *,
+    pts3d_by_object: Optional[Mapping[str, np.ndarray]] = None,
+) -> dict[str, Any]:
+    """Serialize one selected object/face pose from an estimated result."""
+
+    obj_name = str(result["object"])
+    cls_id, cls_name = _map_class_id_and_name(obj_name)
+    x0, y0, w_px, h_px = [float(v) for v in result["bbox_xywh"]]
+    width = float(intrinsics.width)
+    height = float(intrinsics.height)
+    cx = (x0 + 0.5 * w_px) / width
+    cy = (y0 + 0.5 * h_px) / height
+
+    T_cam_board = _matrix4(result["T_cam_board"]["matrix"], "T_cam_board")
+    T_board_object = _matrix4(result["T_board_object"]["matrix"], "T_board_object")
+    T_cam_object = _matrix4(result["T_cam_object"]["matrix"], "T_cam_object")
+
+    composed = compose_T_cam_object(T_cam_board, T_board_object)
+    if not np.allclose(composed, T_cam_object, rtol=1e-9, atol=1e-9):
+        raise CollectDatasetError(
+            f"Pose composition mismatch for {obj_name}/{result.get('face_key')}: "
+            f"{POSE_COMPOSITION} was not preserved."
+        )
+
+    R = T_cam_object[:3, :3]
+    t = T_cam_object[:3, 3]
+    roll, pitch, yaw = rpy_deg_from_matrix(R)
+    q_xyzw = quaternion_xyzw_from_matrix(R)
+
+    dimensions = None
+    obb_corners_cam = None
+    obb_corners_img = None
+    keypoints_source = None
+    if pts3d_by_object and obj_name in pts3d_by_object:
+        points = np.asarray(pts3d_by_object[obj_name], dtype=float)
+        if points.size > 0:
+            keypoints_source = f"objects/{obj_name}/keypoints.json"
+            mins = points.min(axis=0)
+            maxs = points.max(axis=0)
+            dims = maxs - mins
+            dimensions = [float(dims[0]), float(dims[1]), float(dims[2])]
+            corners_obj = np.array(
+                [[x, y, z] for x in (mins[0], maxs[0]) for y in (mins[1], maxs[1]) for z in (mins[2], maxs[2])],
+                dtype=float,
+            )
+            corners_cam = (R @ corners_obj.T + t.reshape(3, 1)).T
+            obb_corners_cam = corners_cam.tolist()
+            obb_corners_img = _project_points(corners_obj.astype(np.float32), T_cam_object, intrinsics).tolist()
+
+    diagnostics = dict(result.get("diagnostics", {}))
+    quality = {
+        "tag_used": int(result["tag_used"]),
+        "num_tags_visible": int(result["num_tags_visible"]),
+        "score": float(result["score"]),
+        "score_tags": int(result.get("score_tags", result["num_tags_visible"])),
+        "score_area_px": int(result.get("score_area_px", 0)),
+        "bbox_source": result.get("bbox_source"),
+        "tag_scale_ratio": float(diagnostics.get("tag_scale_ratio", 1.0)),
+        "tag_scale_pairs": int(diagnostics.get("tag_scale_pairs", 0)),
+        "tag_scale_mad": float(diagnostics.get("tag_scale_mad", 0.0)),
+        "tag_scale_auto_corrected": bool(diagnostics.get("tag_scale_auto_corrected", False)),
+    }
+
+    pose = {
+        "position": [float(t[0]), float(t[1]), float(t[2])],
+        "orientation": [float(roll), float(pitch), float(yaw)],
+        "rotation": [float(q_xyzw[0]), float(q_xyzw[1]), float(q_xyzw[2]), float(q_xyzw[3])],
+        "translation_units": TRANSLATION_UNITS,
+        "orientation_order": RPY_ORDER,
+        "orientation_units": ANGLE_UNITS,
+        "rotation_quaternion_order": QUATERNION_ORDER,
+        **({"dimensions": dimensions} if dimensions is not None else {}),
+        **({"obb_corners_cam": obb_corners_cam, "obb_corners_img": obb_corners_img}
+           if obb_corners_cam is not None else {}),
+    }
+
+    return {
+        "object_name": obj_name,
+        "selected_face": str(result["face_key"]),
+        "selected_board": str(result["board_yaml"]),
+        "class_id": int(cls_id),
+        "class_name": cls_name,
+        "2D_center": [float(cx), float(cy)],
+        "width": float(w_px / width),
+        "height": float(h_px / height),
+        "bbox_xywh_px": [float(x0), float(y0), float(w_px), float(h_px)],
+        "bbox_source": result.get("bbox_source"),
+        "keypoints_source": keypoints_source,
+        "transforms": {
+            "T_cam_board": {"matrix": T_cam_board.tolist()},
+            "T_board_object": {"matrix": T_board_object.tolist()},
+            "T_cam_object": {"matrix": T_cam_object.tolist()},
+        },
+        "quality": quality,
+        "6DOF_pose": pose,
+    }
+
+
+def _camera_extrinsics_from_results(results: Mapping[str, Mapping[str, Any]]) -> dict[str, Any]:
+    camera_pos = [0.0, 0.0, 0.0]
+    cam_quat = [0.0, 0.0, 0.0, 1.0]
+    cam_rpy = None
+    reference: dict[str, Any] = {}
+
+    if results:
+        ref = max(results.values(), key=lambda r: (r.get("num_tags_visible", 0), r.get("score", 0.0)))
+        T_cam_board = _matrix4(ref["T_cam_board"]["matrix"], "T_cam_board")
+        T_board_cam = np.linalg.inv(T_cam_board)
+        Rbc = T_board_cam[:3, :3]
+        tbc = T_board_cam[:3, 3]
+        camera_pos = [float(tbc[0]), float(tbc[1]), float(tbc[2])]
+        cam_quat = [float(v) for v in quaternion_xyzw_from_matrix(Rbc)]
+        cam_rpy = [float(v) for v in rpy_deg_from_matrix(Rbc)]
+        reference = {
+            "reference_face": str(ref.get("face_key", "")),
+            "reference_board": str(ref.get("board_yaml", "")),
+        }
+
+    return {
+        "position": camera_pos,
+        "orientation": cam_quat,
+        "rotation": cam_quat,
+        **({"rpy_deg": cam_rpy} if cam_rpy is not None else {}),
+        **reference,
+        "position_units": TRANSLATION_UNITS,
+        "rotation_quaternion_order": QUATERNION_ORDER,
+        "rpy_order": RPY_ORDER,
+        "rpy_units": ANGLE_UNITS,
+    }
+
+
+def _read_face_manifest_rows(
+    manifest_path: Path,
+    project_root: Path,
+    *,
+    allow_face_scan: bool,
+) -> list[tuple[int, Mapping[str, str]]]:
+    if not manifest_path.exists():
+        if not allow_face_scan:
+            raise CollectDatasetError(
+                f"Face manifest not found: {manifest_path}. Run Step 5 annotation "
+                "so faces/face_manifest.csv lists T_board_object YAMLs."
+            )
+        scanned: list[tuple[int, Mapping[str, str]]] = []
+        for index, yaml_path in enumerate(sorted((project_root / "faces").glob("*/*/*_T_board_object.yaml")), start=1):
+            scanned.append(
+                (
+                    index,
+                    {
+                        "yaml_path": str(yaml_path),
+                        "board_yaml": "",
+                        "object": "",
+                        "face_key": "",
+                    },
+                )
+            )
+        return scanned
+
+    try:
+        with manifest_path.open("r", newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            return [(index, row) for index, row in enumerate(reader, start=2)]
+    except OSError as exc:
+        raise CollectDatasetError(f"Could not read face manifest: {manifest_path}: {exc}") from exc
+
+
+def _validate_annotation_row(
+    row: Mapping[str, str],
+    row_number: int,
+    project_root: Path,
+    registry_index: Mapping[int, Path],
+) -> AnnotationInput:
+    yaml_value = str(row.get("yaml_path") or "").strip()
+    if not yaml_value:
+        raise CollectDatasetError(f"faces/face_manifest.csv row {row_number} is missing yaml_path.")
+    yaml_path = _resolve_manifest_path(project_root, yaml_value)
+    if not yaml_path.exists():
+        raise CollectDatasetError(f"Annotation YAML not found: {yaml_path}")
+
+    data = _load_yaml_mapping(yaml_path, "annotation YAML")
+    object_name = str(data.get("object") or row.get("object") or "").strip()
+    if not object_name:
+        raise CollectDatasetError(f"Malformed annotation YAML: {yaml_path} is missing object.")
+    face_key = str(data.get("face_key") or row.get("face_key") or yaml_path.stem.replace("_T_board_object", "")).strip()
+    if not face_key:
+        raise CollectDatasetError(f"Malformed annotation YAML: {yaml_path} is missing face_key.")
+
+    t_board_object = data.get("T_board_object")
+    if not isinstance(t_board_object, Mapping) or "matrix" not in t_board_object:
+        raise CollectDatasetError(f"Malformed annotation YAML: {yaml_path} is missing T_board_object.matrix.")
+    _matrix4(t_board_object["matrix"], f"{yaml_path} T_board_object.matrix")
+
+    board_value = data.get("board_yaml") or row.get("board_yaml")
+    if not board_value:
+        raise CollectDatasetError(f"Malformed annotation YAML: {yaml_path} is missing board_yaml.")
+    board_path = _resolve_manifest_path(project_root, str(board_value))
+    if not board_path.exists():
+        raise CollectDatasetError(f"Board YAML not found for annotation {yaml_path}: {board_path}")
+
+    try:
+        _origin_id, tag_size_m, t_board_tag = load_board(board_path)
+    except Exception as exc:
+        raise CollectDatasetError(f"Malformed board YAML for annotation {yaml_path}: {board_path}: {exc}") from exc
+
+    resolved_board = board_path.resolve()
+    for tag_id in t_board_tag:
+        registered_board = registry_index.get(int(tag_id))
+        if registered_board is None:
+            raise CollectDatasetError(
+                f"Tag registry is missing tag id {tag_id} from board YAML {board_path}."
+            )
+        if registered_board != resolved_board:
+            raise CollectDatasetError(
+                f"Tag registry maps tag id {tag_id} to {registered_board}, "
+                f"but annotation {yaml_path} uses board {resolved_board}."
+            )
+
+    keypoints_path = project_root / "objects" / object_name / "keypoints.json"
+    return AnnotationInput(
+        object_name=object_name,
+        face_key=face_key,
+        yaml_path=yaml_path,
+        board_yaml=resolved_board,
+        tag_ids=tuple(sorted(int(tag_id) for tag_id in t_board_tag)),
+        tag_size_m=float(tag_size_m),
+        keypoints_path=keypoints_path if keypoints_path.exists() else None,
+    )
+
+
+def _resolve_manifest_path(project_root: Path, value: str) -> Path:
+    raw = Path(value).expanduser()
+    return raw.resolve() if raw.is_absolute() else (project_root / raw).resolve()
+
+
+def _load_yaml_mapping(path: Path, label: str) -> Mapping[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        raise CollectDatasetError(f"Malformed {label}: {path}: {exc}") from exc
+    except OSError as exc:
+        raise CollectDatasetError(f"Could not read {label}: {path}: {exc}") from exc
+    if not isinstance(data, Mapping):
+        raise CollectDatasetError(f"Malformed {label}: {path} must contain a mapping.")
+    return data
+
+
+def _positive_int(data: Mapping[str, Any], field: str, path: Path) -> int:
+    if field not in data:
+        raise CollectDatasetError(f"Malformed calibration YAML: {path} is missing {field}.")
+    try:
+        value = int(data[field])
+    except (TypeError, ValueError) as exc:
+        raise CollectDatasetError(f"Malformed calibration YAML: {path} {field} must be an integer.") from exc
+    if value <= 0:
+        raise CollectDatasetError(f"Malformed calibration YAML: {path} {field} must be positive.")
+    return value
+
+
+def _matrix4(value: Any, name: str) -> np.ndarray:
+    try:
+        matrix = np.asarray(value, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise CollectDatasetError(f"Malformed transform: {name} must be numeric.") from exc
+    if matrix.shape != (4, 4):
+        raise CollectDatasetError(f"Malformed transform: {name} must be a 4x4 matrix.")
+    if not np.all(np.isfinite(matrix)):
+        raise CollectDatasetError(f"Malformed transform: {name} values must be finite.")
+    return matrix
+
+
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(v) for v in value]
+    if isinstance(value, (np.integer,)):
+        return int(value)
+    if isinstance(value, (np.floating,)):
+        return float(value)
+    if isinstance(value, (np.bool_,)):
+        return bool(value)
+    return value
+
+
+def _project_points(pts3d: np.ndarray, T_cam_obj: np.ndarray, intrinsics: Intrinsics) -> np.ndarray:
+    import cv2
+
+    R = T_cam_obj[:3, :3]
+    t = T_cam_obj[:3, 3].reshape(3, 1)
+    K = np.array(
+        [[intrinsics.fx, 0.0, intrinsics.cx], [0.0, intrinsics.fy, intrinsics.cy], [0.0, 0.0, 1.0]],
+        dtype=float,
+    )
+    rvec, _ = cv2.Rodrigues(R)
+    uv, _ = cv2.projectPoints(pts3d.astype(np.float32), rvec, t, K, intrinsics.dist)
+    return uv.reshape(-1, 2)
+
+
+def _map_class_id_and_name(object_name: str) -> tuple[int, str]:
+    name = object_name.lower()
+    if "connection_plate" in name or ("connection" in name and "plate" in name):
+        return 2, "connection_plate"
+    if "full_assembly" in name or ("full" in name and "assembly" in name):
+        return 3, "full_assembly"
+    if "column" in name:
+        return 1, "column"
+    return 0, object_name

--- a/src/posetag/workflows/collect_dataset.py
+++ b/src/posetag/workflows/collect_dataset.py
@@ -1,0 +1,556 @@
+"""GUI-independent helpers for launching dataset collection.
+
+The interactive capture, AprilTag detection, pose estimation, review UI, and
+dataset writing remain in ``posetag-collect``.  This module only validates the
+dashboard-facing launch values, builds shell-free process arguments, and
+summarizes child-process state.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shlex
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
+
+from posetag.pipelines.collect_dataset import (
+    CollectDatasetError,
+    CollectionInputSummary,
+    preview_project_root,
+    resolve_calibration_path,
+    resolve_dataset_root,
+    resolve_face_manifest_path,
+    resolve_registry_path,
+    validate_collection_inputs,
+    validate_source_args,
+)
+
+
+SOURCE_OPENCV = "opencv"
+SOURCE_LIVE = "live"
+SOURCE_VIDEO = "video"
+SOURCE_BAG = "bag"
+COLLECT_SOURCE_CHOICES = (SOURCE_OPENCV, SOURCE_LIVE, SOURCE_VIDEO, SOURCE_BAG)
+COLLECT_SOURCE_LABELS = {
+    SOURCE_OPENCV: "webcam/OpenCV",
+    SOURCE_LIVE: "RealSense live",
+    SOURCE_VIDEO: "video",
+    SOURCE_BAG: "RealSense bag",
+}
+
+DEFAULT_SESSION_NAME = "run01"
+DEFAULT_FAMILY = "tag36h11"
+DEFAULT_CAMERA_INDEX = 0
+DEFAULT_FPS = 30
+COLLECT_PROCESS_NOT_STARTED = "not_started"
+COLLECT_PROCESS_RUNNING = "running"
+COLLECT_PROCESS_FINISHED = "finished"
+COLLECT_PROCESS_FAILED_CANCELLED = "failed_cancelled"
+
+
+@dataclass(frozen=True)
+class DatasetCollectionConfig:
+    """User-facing ``posetag-collect`` launch state."""
+
+    project_root: Union[Path, str]
+    session: str = DEFAULT_SESSION_NAME
+    mode: str = SOURCE_OPENCV
+    camera_index: int = DEFAULT_CAMERA_INDEX
+    video_path: Optional[Union[Path, str]] = None
+    bag_path: Optional[Union[Path, str]] = None
+    calib_path: Optional[Union[Path, str]] = None
+    registry_path: Optional[Union[Path, str]] = None
+    face_manifest_path: Optional[Union[Path, str]] = None
+    dataset_root: Optional[Union[Path, str]] = None
+    family: str = DEFAULT_FAMILY
+    continuous: bool = False
+    auto_capture: bool = False
+    auto_stable_frames: int = 5
+    auto_cooldown_sec: float = 1.0
+    max_frames: int = 0
+    width: int = 0
+    height: int = 0
+    fps: int = DEFAULT_FPS
+    rs_width: int = 0
+    rs_height: int = 0
+    rs_fps: int = DEFAULT_FPS
+    save_depth: bool = False
+    allow_face_scan: bool = False
+    check_tag_scale: bool = False
+    auto_correct_scale: bool = False
+    scale_tol: float = 0.02
+    axes: str = "both"
+    bbox_mode: str = "auto"
+
+
+@dataclass(frozen=True)
+class DatasetCollectionReadiness:
+    """Display-ready preflight state for dataset collection."""
+
+    ready: bool
+    command_preview: str
+    dry_run_command_preview: str
+    project_root: Path
+    calibration_path: Path
+    registry_path: Path
+    face_manifest_path: Path
+    dataset_root: Path
+    expected_session_dir: Path
+    input_summary: CollectionInputSummary | None
+    checked_paths: tuple[Path, ...]
+    warnings: tuple[str, ...] = ()
+    errors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class DatasetCollectionLaunch:
+    """Editable-install-safe launch details for ``posetag-collect``."""
+
+    program: str
+    arguments: tuple[str, ...]
+    display_command: str
+    project_root: Path
+    expected_session_dir: Path
+    dry_run: bool
+
+
+@dataclass(frozen=True)
+class DatasetCollectionProcessState:
+    """GUI-independent dataset-collection child-process state."""
+
+    state: str
+    label: str
+    message: str
+    running: bool = False
+    success: bool = False
+    expected_session_dir: Path | None = None
+    exit_code: int | None = None
+    dry_run: bool = False
+
+
+def inspect_dataset_collection_readiness(
+    config: DatasetCollectionConfig,
+) -> DatasetCollectionReadiness:
+    """Validate collection inputs and return display-ready launch state."""
+
+    root = preview_project_root(config.project_root)
+    calibration_path = resolve_calibration_path(root, config.calib_path)
+    registry_path = resolve_registry_path(root, config.registry_path)
+    face_manifest_path = resolve_face_manifest_path(root, config.face_manifest_path)
+    dataset_root = resolve_dataset_root(root, config.dataset_root)
+    errors: list[str] = []
+    try:
+        session = normalize_session_name(config.session)
+    except ValueError as exc:
+        session = DEFAULT_SESSION_NAME
+        errors.append(str(exc))
+    expected_session_dir = dataset_root / session
+
+    checked_paths: list[Path] = [
+        calibration_path,
+        registry_path,
+        face_manifest_path,
+        dataset_root,
+        expected_session_dir,
+    ]
+    warnings: list[str] = []
+    input_summary: CollectionInputSummary | None = None
+    try:
+        mode = normalize_source(config.mode)
+    except ValueError as exc:
+        mode = SOURCE_OPENCV
+        errors.append(str(exc))
+
+    try:
+        validate_source_args(
+            mode=mode,
+            video=config.video_path,
+            bag=config.bag_path,
+            realsense_module=_realsense_module_marker(),
+            video_capture_factory=None,
+        )
+    except CollectDatasetError as exc:
+        errors.append(str(exc))
+
+    try:
+        input_summary = validate_collection_inputs(
+            project_root=root,
+            calib_path=calibration_path,
+            registry_path=registry_path,
+            face_manifest_path=face_manifest_path,
+            allow_face_scan=config.allow_face_scan,
+        )
+    except CollectDatasetError as exc:
+        errors.append(str(exc))
+    else:
+        checked_paths.extend(annotation.yaml_path for annotation in input_summary.annotations)
+        checked_paths.extend(annotation.board_yaml for annotation in input_summary.annotations)
+        checked_paths.extend(
+            path for path in input_summary.missing_keypoints if path is not None
+        )
+        if input_summary.missing_keypoints:
+            warnings.append(
+                "Optional object keypoints are missing for bbox/review behavior; "
+                "collection can still use tag-based fallback boxes."
+            )
+
+    command_preview = ""
+    dry_run_command_preview = ""
+    if not errors:
+        try:
+            command_preview = build_dataset_collection_command(config, dry_run=False)
+            dry_run_command_preview = build_dataset_collection_command(
+                config,
+                dry_run=True,
+            )
+        except ValueError as exc:
+            errors.append(str(exc))
+
+    return DatasetCollectionReadiness(
+        ready=not errors,
+        command_preview=command_preview,
+        dry_run_command_preview=dry_run_command_preview,
+        project_root=root,
+        calibration_path=calibration_path,
+        registry_path=registry_path,
+        face_manifest_path=face_manifest_path,
+        dataset_root=dataset_root,
+        expected_session_dir=expected_session_dir,
+        input_summary=input_summary,
+        checked_paths=tuple(dict.fromkeys(checked_paths)),
+        warnings=tuple(dict.fromkeys(warnings)),
+        errors=tuple(dict.fromkeys(errors)),
+    )
+
+
+def build_dataset_collection_launch(
+    config: DatasetCollectionConfig,
+    *,
+    dry_run: bool = False,
+    python_executable: Optional[Union[Path, str]] = None,
+) -> DatasetCollectionLaunch:
+    """Build process launch details for the existing collection workflow."""
+
+    executable = str(python_executable) if python_executable else sys.executable
+    arguments = build_dataset_collection_arguments(config, dry_run=dry_run)
+    root = preview_project_root(config.project_root)
+    dataset_root = resolve_dataset_root(root, config.dataset_root)
+    expected_session_dir = dataset_root / normalize_session_name(config.session)
+    return DatasetCollectionLaunch(
+        program=executable,
+        arguments=("-m", "posetag.cli.collect", *arguments),
+        display_command=build_dataset_collection_command(config, dry_run=dry_run),
+        project_root=root,
+        expected_session_dir=expected_session_dir,
+        dry_run=bool(dry_run),
+    )
+
+
+def build_dataset_collection_command(
+    config: DatasetCollectionConfig,
+    *,
+    dry_run: bool = False,
+) -> str:
+    """Build a copyable ``posetag-collect`` command from GUI state."""
+
+    root = preview_project_root(config.project_root)
+    parts = (
+        "env",
+        f"POSETAG_PROJECT={root}",
+        "posetag-collect",
+        *build_dataset_collection_arguments(config, dry_run=dry_run),
+    )
+    return shlex.join(parts)
+
+
+def build_dataset_collection_arguments(
+    config: DatasetCollectionConfig,
+    *,
+    dry_run: bool = False,
+) -> tuple[str, ...]:
+    """Build argv items for ``posetag-collect`` without a shell."""
+
+    root = preview_project_root(config.project_root)
+    mode = normalize_source(config.mode)
+    session = normalize_session_name(config.session)
+    family = str(config.family or DEFAULT_FAMILY).strip() or DEFAULT_FAMILY
+    if bool(config.continuous) and bool(config.auto_capture):
+        raise ValueError("Continuous capture and smart auto-capture cannot both be enabled.")
+    if family != DEFAULT_FAMILY:
+        family_arg = family
+    else:
+        family_arg = DEFAULT_FAMILY
+
+    parts: list[str] = [
+        "--project_root",
+        str(root),
+        "--mode",
+        mode,
+        "--session",
+        session,
+        "--calib",
+        str(config.calib_path or "calib_color.yaml"),
+    ]
+    if config.registry_path:
+        parts.extend(["--registry", str(Path(config.registry_path).expanduser())])
+    if config.face_manifest_path:
+        parts.extend(
+            ["--face_manifest", str(Path(config.face_manifest_path).expanduser())]
+        )
+    if config.dataset_root:
+        parts.extend(["--dataset_root", str(Path(config.dataset_root).expanduser())])
+
+    if mode == SOURCE_OPENCV:
+        parts.extend(["--cam", str(int(config.camera_index))])
+        if int(config.width) > 0:
+            parts.extend(["--width", str(int(config.width))])
+        if int(config.height) > 0:
+            parts.extend(["--height", str(int(config.height))])
+        if int(config.fps) != DEFAULT_FPS:
+            parts.extend(["--fps", str(int(config.fps))])
+    elif mode == SOURCE_VIDEO:
+        if not config.video_path:
+            raise ValueError("--video is required when dataset source is video.")
+        parts.extend(["--video", str(Path(config.video_path).expanduser())])
+    elif mode == SOURCE_BAG:
+        if not config.bag_path:
+            raise ValueError("--bag is required when dataset source is bag.")
+        parts.extend(["--bag", str(Path(config.bag_path).expanduser())])
+    elif mode == SOURCE_LIVE:
+        if int(config.rs_width) > 0:
+            parts.extend(["--rs_w", str(int(config.rs_width))])
+        if int(config.rs_height) > 0:
+            parts.extend(["--rs_h", str(int(config.rs_height))])
+        if int(config.rs_fps) != DEFAULT_FPS:
+            parts.extend(["--rs_fps", str(int(config.rs_fps))])
+
+    if family_arg:
+        parts.extend(["--family", family_arg])
+    if bool(config.continuous):
+        parts.append("--continuous")
+    if bool(config.auto_capture):
+        parts.append("--auto-capture")
+        if int(config.auto_stable_frames) != 5:
+            parts.extend(["--auto-stable-frames", str(int(config.auto_stable_frames))])
+        if float(config.auto_cooldown_sec) != 1.0:
+            parts.extend(["--auto-cooldown-sec", f"{float(config.auto_cooldown_sec):g}"])
+    if int(config.max_frames) > 0:
+        parts.extend(["--max_frames", str(int(config.max_frames))])
+    if bool(config.save_depth):
+        parts.append("--save_depth")
+    if bool(config.allow_face_scan):
+        parts.append("--allow-face-scan")
+    if bool(config.check_tag_scale):
+        parts.append("--check-tag-scale")
+    if bool(config.auto_correct_scale):
+        parts.append("--auto-correct-scale")
+    if float(config.scale_tol) != 0.02:
+        parts.extend(["--scale-tol", f"{float(config.scale_tol):g}"])
+    if str(config.axes) != "both":
+        parts.extend(["--axes", str(config.axes)])
+    if str(config.bbox_mode) != "auto":
+        parts.extend(["--bbox-mode", str(config.bbox_mode)])
+    if dry_run:
+        parts.append("--dry-run")
+    return tuple(parts)
+
+
+def collect_dataset_process_not_started(
+    expected_session_dir: Optional[Union[Path, str]] = None,
+) -> DatasetCollectionProcessState:
+    """Return the initial dataset-collection process state."""
+
+    path = _optional_path(expected_session_dir)
+    return DatasetCollectionProcessState(
+        state=COLLECT_PROCESS_NOT_STARTED,
+        label="not started",
+        message=(
+            "Dataset collection has not been launched from this dashboard "
+            "session."
+        ),
+        expected_session_dir=path,
+    )
+
+
+def collect_dataset_process_running(
+    expected_session_dir: Union[Path, str],
+    *,
+    dry_run: bool = False,
+) -> DatasetCollectionProcessState:
+    """Return the active dataset-collection process state."""
+
+    if dry_run:
+        message = (
+            "Dataset collection dry-run is validating inputs without opening "
+            "a camera or writing dataset outputs."
+        )
+    else:
+        message = (
+            "Dataset collection is running in the existing OpenCV/RealSense "
+            "workflow. Use the review window to accept or force-save frames; "
+            "q, Q, ESC, x, or the window close button exits cleanly."
+        )
+    return DatasetCollectionProcessState(
+        state=COLLECT_PROCESS_RUNNING,
+        label="running",
+        message=message,
+        running=True,
+        expected_session_dir=Path(expected_session_dir).expanduser(),
+        dry_run=bool(dry_run),
+    )
+
+
+def collect_dataset_process_failed(
+    message: str,
+    *,
+    expected_session_dir: Optional[Union[Path, str]] = None,
+    exit_code: Optional[int] = None,
+    dry_run: bool = False,
+) -> DatasetCollectionProcessState:
+    """Return a failed/cancelled collection process state."""
+
+    return DatasetCollectionProcessState(
+        state=COLLECT_PROCESS_FAILED_CANCELLED,
+        label="failed/cancelled",
+        message=message,
+        expected_session_dir=_optional_path(expected_session_dir),
+        exit_code=exit_code,
+        dry_run=bool(dry_run),
+    )
+
+
+def summarize_dataset_collection_process_result(
+    *,
+    exit_code: int,
+    crashed: bool = False,
+    expected_session_dir: Optional[Union[Path, str]] = None,
+    previous_session_yaml_mtime_ns: Optional[int] = None,
+    require_output_update: bool = False,
+    dry_run: bool = False,
+) -> DatasetCollectionProcessState:
+    """Summarize process completion from dry-run or expected session output."""
+
+    session_dir = _optional_path(expected_session_dir)
+    session_yaml = session_dir / "session.yaml" if session_dir is not None else None
+    session_yaml_exists = bool(session_yaml and session_yaml.exists())
+    session_yaml_updated = (
+        not require_output_update
+        or (
+            session_yaml is not None
+            and _path_mtime_ns(session_yaml) != previous_session_yaml_mtime_ns
+        )
+    )
+
+    if crashed:
+        return collect_dataset_process_failed(
+            "Dataset collection process crashed or was cancelled.",
+            expected_session_dir=session_dir,
+            exit_code=exit_code,
+            dry_run=dry_run,
+        )
+    if exit_code != 0:
+        return collect_dataset_process_failed(
+            f"Dataset collection process exited with code {exit_code}.",
+            expected_session_dir=session_dir,
+            exit_code=exit_code,
+            dry_run=dry_run,
+        )
+    if dry_run:
+        return DatasetCollectionProcessState(
+            state=COLLECT_PROCESS_FINISHED,
+            label="finished",
+            message=(
+                "Dataset collection dry-run completed. Inputs passed preflight; "
+                "run collection to create a pose-labelled session."
+            ),
+            success=True,
+            expected_session_dir=session_dir,
+            exit_code=exit_code,
+            dry_run=True,
+        )
+    if session_yaml_exists and session_yaml_updated:
+        return DatasetCollectionProcessState(
+            state=COLLECT_PROCESS_FINISHED,
+            label="finished",
+            message=(
+                "Dataset collection exited cleanly. Stage 8 status was "
+                "refreshed from the saved session outputs."
+            ),
+            success=True,
+            expected_session_dir=session_dir,
+            exit_code=exit_code,
+        )
+
+    if not session_yaml_exists:
+        message = (
+            "Dataset collection exited cleanly without writing session.yaml. "
+            "This usually means collection stopped before outputs were saved."
+        )
+    else:
+        message = (
+            "Dataset collection exited cleanly, but the expected session "
+            "metadata was not updated during this launch."
+        )
+    return collect_dataset_process_failed(
+        message,
+        expected_session_dir=session_dir,
+        exit_code=exit_code,
+    )
+
+
+def normalize_source(source: str) -> str:
+    """Normalize a user-facing dataset source value."""
+
+    normalized = str(source or "").strip().lower().replace("_", "-")
+    aliases = {
+        "opencv": SOURCE_OPENCV,
+        "webcam": SOURCE_OPENCV,
+        "webcam/opencv": SOURCE_OPENCV,
+        "camera": SOURCE_OPENCV,
+        "live": SOURCE_LIVE,
+        "realsense": SOURCE_LIVE,
+        "realsense live": SOURCE_LIVE,
+        "video": SOURCE_VIDEO,
+        "file": SOURCE_VIDEO,
+        "bag": SOURCE_BAG,
+        "realsense bag": SOURCE_BAG,
+    }
+    try:
+        return aliases[normalized]
+    except KeyError as exc:
+        supported = ", ".join(COLLECT_SOURCE_CHOICES)
+        raise ValueError(f"Unsupported dataset source {source!r}. Use {supported}.") from exc
+
+
+def normalize_session_name(session: str) -> str:
+    """Validate and normalize a dataset session folder name."""
+
+    value = str(session or "").strip()
+    if not value:
+        raise ValueError("Dataset session name is required.")
+    path = Path(value)
+    if path.is_absolute() or len(path.parts) != 1 or value in {".", ".."}:
+        raise ValueError("Dataset session must be a simple folder name.")
+    return value
+
+
+def _realsense_module_marker() -> object | None:
+    try:
+        return object() if importlib.util.find_spec("pyrealsense2") else None
+    except (ImportError, ValueError):
+        return None
+
+
+def _optional_path(value: Optional[Union[Path, str]]) -> Path | None:
+    if value is None:
+        return None
+    return Path(value).expanduser()
+
+
+def _path_mtime_ns(path: Path) -> int | None:
+    try:
+        return path.stat().st_mtime_ns
+    except OSError:
+        return None

--- a/src/posetag/workflows/commands.py
+++ b/src/posetag/workflows/commands.py
@@ -130,11 +130,13 @@ _COMMAND_TEMPLATES = {
         "POSETAG_PROJECT={project_root}",
         "posetag-collect",
         "--mode",
-        "live",
+        "opencv",
         "--session",
         "SESSION",
         "--calib",
         "calib_color.yaml",
+        "--auto-capture",
+        "--dry-run",
     ),
 }
 

--- a/src/posetag/workflows/status.py
+++ b/src/posetag/workflows/status.py
@@ -17,7 +17,17 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Union
 
 import yaml
+import numpy as np
 
+from posetag.pipelines.collect_dataset import (
+    CollectDatasetError,
+    POSE_COMPOSITION,
+    resolve_calibration_path as resolve_collection_calibration_path,
+    resolve_dataset_root,
+    resolve_face_manifest_path,
+    resolve_registry_path as resolve_collection_registry_path,
+    validate_collection_inputs,
+)
 from posetag.pipelines.make_board import (
     MakeBoardError,
     load_calibration_yaml,
@@ -130,6 +140,14 @@ def inspect_project(project_root: Union[Path, str]) -> list[StageSummary]:
         root,
         face_shots_complete=face_shots.status == WorkflowStatus.COMPLETE,
     )
+    face_annotations = inspect_face_annotations(
+        root,
+        mesh_keypoints_complete=mesh_keypoints.status == WorkflowStatus.COMPLETE,
+    )
+    dataset_collection = inspect_dataset_collection(
+        root,
+        annotations_complete=face_annotations.status == WorkflowStatus.COMPLETE,
+    )
     summaries = [
         project_setup,
         charuco_board,
@@ -138,15 +156,14 @@ def inspect_project(project_root: Union[Path, str]) -> list[StageSummary]:
         board_definitions,
         face_shots,
         mesh_keypoints,
-        inspect_face_annotations(
+        face_annotations,
+        dataset_collection,
+        inspect_review_export(
             root,
-            mesh_keypoints_complete=mesh_keypoints.status == WorkflowStatus.COMPLETE,
+            dataset_collection_complete=dataset_collection.status
+            == WorkflowStatus.COMPLETE,
         ),
     ]
-    summaries.extend(
-        _placeholder_summaries(
-        )
-    )
     return summaries
 
 
@@ -818,26 +835,388 @@ def inspect_face_annotations(
     )
 
 
-def _placeholder_summaries() -> list[StageSummary]:
-    return [
-        _stage(
+def inspect_dataset_collection(
+    project_root: Union[Path, str],
+    *,
+    annotations_complete: bool = False,
+) -> StageSummary:
+    """Inspect Stage 8 dataset sessions and pose-label outputs."""
+
+    root = Path(project_root).expanduser()
+    calib_path = resolve_collection_calibration_path(root, "calib_color.yaml")
+    registry_path = resolve_collection_registry_path(root)
+    manifest_path = resolve_face_manifest_path(root)
+    datasets_root = resolve_dataset_root(root)
+    checked_paths: list[Path] = [
+        calib_path,
+        registry_path,
+        manifest_path,
+        datasets_root,
+    ]
+
+    if not annotations_complete:
+        return _stage(
             stage_id=8,
             status=WorkflowStatus.NOT_APPLICABLE,
             message=(
                 "Dataset collection depends on calibration, boards, and "
                 "annotations."
             ),
-            checked_paths=(),
+            checked_paths=checked_paths,
             next_action="Complete Stages 2-7 before checking Stage 8.",
+        )
+
+    try:
+        input_summary = validate_collection_inputs(
+            project_root=root,
+            calib_path=calib_path,
+            registry_path=registry_path,
+            face_manifest_path=manifest_path,
+        )
+    except CollectDatasetError as exc:
+        return _stage(
+            stage_id=8,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="Dataset collection inputs need attention.",
+            checked_paths=checked_paths,
+            errors=tuple(str(exc).splitlines()),
+            next_action=(
+                "Repair the collection inputs, then run "
+                "posetag-collect --dry-run."
+            ),
+        )
+
+    for annotation in input_summary.annotations:
+        checked_paths.extend([annotation.yaml_path, annotation.board_yaml])
+        if annotation.keypoints_path is not None:
+            checked_paths.append(annotation.keypoints_path)
+
+    session_dirs = _dataset_session_dirs(datasets_root)
+    checked_paths.extend(session_dirs)
+    if not session_dirs:
+        warnings = tuple(
+            f"Optional keypoints are missing: {path}"
+            for path in input_summary.missing_keypoints
+        )
+        return _stage(
+            stage_id=8,
+            status=WorkflowStatus.MISSING,
+            message=(
+                "Dataset collection inputs are ready, but no dataset sessions "
+                "were found."
+            ),
+            checked_paths=_path_tuple(checked_paths),
+            warnings=warnings,
+            next_action=(
+                "Run posetag-collect --dry-run, then collect a dataset session "
+                "with OpenCV, RealSense, bag, or video input."
+            ),
+        )
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    valid_sessions = 0
+    valid_frames = 0
+    for session_dir in session_dirs:
+        session_valid, session_frames, session_checked, session_warnings, session_errors = (
+            _validate_dataset_session(session_dir, root)
+        )
+        checked_paths.extend(session_checked)
+        warnings.extend(session_warnings)
+        if session_valid:
+            valid_sessions += 1
+            valid_frames += session_frames
+        errors.extend(session_errors)
+
+    if errors:
+        return _stage(
+            stage_id=8,
+            status=WorkflowStatus.NEEDS_ATTENTION,
+            message="Dataset session outputs exist but need attention.",
+            checked_paths=_path_tuple(checked_paths),
+            warnings=tuple(warnings),
+            errors=tuple(errors),
+            next_action=(
+                "Repair malformed dataset annotations or rerun "
+                "posetag-collect for the affected session."
+            ),
+        )
+
+    if valid_sessions == 0:
+        return _stage(
+            stage_id=8,
+            status=WorkflowStatus.MISSING,
+            message="No valid dataset pose-label frames were found.",
+            checked_paths=_path_tuple(checked_paths),
+            warnings=tuple(warnings),
+            next_action="Collect at least one valid pose-labelled dataset frame.",
+        )
+
+    return _stage(
+        stage_id=8,
+        status=WorkflowStatus.COMPLETE,
+        message=(
+            f"Found {valid_frames} valid pose-labelled frame"
+            f"{'s' if valid_frames != 1 else ''} across {valid_sessions} "
+            f"dataset session{'s' if valid_sessions != 1 else ''}."
         ),
-        _stage(
+        checked_paths=_path_tuple(checked_paths),
+        warnings=tuple(warnings),
+        next_action="Proceed to Stage 9 review and export.",
+    )
+
+
+def inspect_review_export(
+    project_root: Union[Path, str],
+    *,
+    dataset_collection_complete: bool = False,
+) -> StageSummary:
+    """Inspect Stage 9 review/export readiness placeholder."""
+
+    root = Path(project_root).expanduser()
+    datasets_root = resolve_dataset_root(root)
+    if not dataset_collection_complete:
+        return _stage(
             stage_id=9,
             status=WorkflowStatus.NOT_APPLICABLE,
             message="Review and export depends on generated dataset outputs.",
-            checked_paths=(),
+            checked_paths=[datasets_root],
             next_action="Complete Stage 8 before checking Stage 9.",
+        )
+
+    return _stage(
+        stage_id=9,
+        status=WorkflowStatus.MISSING,
+        message="Dataset outputs are ready for manual review/export tooling.",
+        checked_paths=[datasets_root],
+        next_action=(
+            "Review annotated images, reprojection views, session metadata, "
+            "and pose-label JSON before export."
         ),
+    )
+
+
+def _dataset_session_dirs(datasets_root: Path) -> tuple[Path, ...]:
+    if not datasets_root.is_dir():
+        return ()
+    return tuple(
+        sorted(path for path in datasets_root.iterdir() if path.is_dir() and not path.name.startswith("."))
+    )
+
+
+def _validate_dataset_session(
+    session_dir: Path,
+    project_root: Path,
+) -> tuple[bool, int, list[Path], list[str], list[str]]:
+    checked_paths = [
+        session_dir / "session.yaml",
+        session_dir / f"{session_dir.name}.jsonl",
+        session_dir / "annotations",
+        session_dir / "images",
+        session_dir / "annotated",
+        session_dir / "reproj",
     ]
+    warnings: list[str] = []
+    errors: list[str] = []
+
+    session_yaml = session_dir / "session.yaml"
+    if not session_yaml.exists():
+        errors.append(f"{session_dir.name}: session.yaml was not found.")
+    else:
+        session_errors = _validate_dataset_session_yaml(session_yaml)
+        errors.extend(f"{session_dir.name}: {error}" for error in session_errors)
+
+    jsonl_path = session_dir / f"{session_dir.name}.jsonl"
+    if not jsonl_path.exists():
+        errors.append(f"{session_dir.name}: rolling JSONL log was not found.")
+    elif jsonl_path.stat().st_size == 0:
+        warnings.append(f"{session_dir.name}: rolling JSONL log is empty.")
+
+    annotations_dir = session_dir / "annotations"
+    annotation_paths = tuple(sorted(annotations_dir.glob("*.json"))) if annotations_dir.is_dir() else ()
+    checked_paths.extend(annotation_paths)
+    if not annotation_paths:
+        errors.append(f"{session_dir.name}: no per-frame annotation JSON files were found.")
+        return False, 0, checked_paths, warnings, errors
+
+    valid_frames = 0
+    for annotation_path in annotation_paths:
+        frame_errors = _validate_dataset_annotation_json(annotation_path, session_dir, project_root)
+        if frame_errors:
+            errors.extend(f"{session_dir.name}/{annotation_path.name}: {error}" for error in frame_errors)
+        else:
+            valid_frames += 1
+
+    return valid_frames > 0 and not errors, valid_frames, checked_paths, warnings, errors
+
+
+def _validate_dataset_session_yaml(path: Path) -> tuple[str, ...]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle)
+    except yaml.YAMLError as exc:
+        return (f"Malformed session.yaml: {exc}",)
+    except OSError as exc:
+        return (f"Could not read session.yaml: {exc}",)
+
+    if not isinstance(data, Mapping):
+        return ("session.yaml must contain a mapping.",)
+
+    errors: list[str] = []
+    if str(data.get("version", "")).strip() != "1.0":
+        errors.append("session.yaml version must be '1.0'.")
+    if not str(data.get("name", "")).strip():
+        errors.append("session.yaml is missing name.")
+    if "camera" not in data or not isinstance(data["camera"], Mapping):
+        errors.append("session.yaml is missing camera metadata.")
+    if "pose_convention" not in data or not isinstance(data["pose_convention"], Mapping):
+        errors.append("session.yaml is missing pose_convention metadata.")
+    else:
+        composition = str(data["pose_convention"].get("composition", "")).strip()
+        if composition != POSE_COMPOSITION:
+            errors.append(f"session.yaml pose convention must be {POSE_COMPOSITION}.")
+    frames = _parse_int(data.get("frames_captured"))
+    if frames is None:
+        errors.append("session.yaml frames_captured must be an integer.")
+    elif frames <= 0:
+        errors.append("session.yaml frames_captured must be positive.")
+    return tuple(errors)
+
+
+def _validate_dataset_annotation_json(
+    path: Path,
+    session_dir: Path,
+    project_root: Path,
+) -> tuple[str, ...]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return (f"Malformed annotation JSON: {exc}",)
+    except OSError as exc:
+        return (f"Could not read annotation JSON: {exc}",)
+
+    if not isinstance(data, Mapping):
+        return ("Annotation JSON must contain a mapping.",)
+
+    errors: list[str] = []
+    if str(data.get("version", "")).strip() != "1.0":
+        errors.append("Annotation JSON version must be '1.0'.")
+    metadata = data.get("metadata")
+    if not isinstance(metadata, Mapping):
+        errors.append("Annotation JSON is missing metadata.")
+    else:
+        for field in ("dataset_name", "frame_index", "timestamp", "tag_family"):
+            if field not in metadata:
+                errors.append(f"Annotation metadata is missing field {field!r}.")
+
+    pose_convention = data.get("pose_convention")
+    if not isinstance(pose_convention, Mapping):
+        errors.append("Annotation JSON is missing pose_convention.")
+    elif str(pose_convention.get("composition", "")).strip() != POSE_COMPOSITION:
+        errors.append(f"Annotation pose convention must be {POSE_COMPOSITION}.")
+
+    image_filename = str(data.get("image_filename", "")).strip()
+    if not image_filename:
+        errors.append("Annotation JSON is missing image_filename.")
+    elif not (session_dir / "images" / image_filename).exists():
+        errors.append(f"Raw image was not found: {session_dir / 'images' / image_filename}")
+
+    for field, folder in (("annotated_image", "annotated"), ("reproj_image", "reproj")):
+        filename = data.get(field)
+        if filename:
+            candidate = session_dir / folder / str(filename)
+            if not candidate.exists():
+                errors.append(f"{field} was not found: {candidate}")
+
+    depth_filename = data.get("depth")
+    if depth_filename:
+        candidate = session_dir / "depth" / str(depth_filename)
+        if not candidate.exists():
+            errors.append(f"Depth file was not found: {candidate}")
+
+    intrinsics = data.get("camera_intrinsics")
+    if not isinstance(intrinsics, Mapping):
+        errors.append("Annotation JSON is missing camera_intrinsics.")
+    else:
+        for field in ("fx", "fy", "cx", "cy"):
+            _require_number(intrinsics, field, errors, prefix="camera_intrinsics")
+        _require_positive_int(intrinsics, "width", errors, prefix="camera_intrinsics")
+        _require_positive_int(intrinsics, "height", errors, prefix="camera_intrinsics")
+
+    objects = data.get("objects")
+    if not isinstance(objects, list) or not objects:
+        errors.append("Annotation JSON objects must be a non-empty list.")
+    else:
+        for index, obj in enumerate(objects):
+            if not isinstance(obj, Mapping):
+                errors.append(f"objects[{index}] must be a mapping.")
+                continue
+            errors.extend(_validate_dataset_object(obj, index, project_root))
+
+    return tuple(errors)
+
+
+def _validate_dataset_object(
+    obj: Mapping[str, Any],
+    index: int,
+    project_root: Path,
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    label = f"objects[{index}]"
+    for field in ("object_name", "selected_face", "selected_board", "transforms", "quality", "6DOF_pose"):
+        if field not in obj:
+            errors.append(f"{label} is missing field {field!r}.")
+
+    selected_board = obj.get("selected_board")
+    if isinstance(selected_board, str) and selected_board.strip():
+        board_path = _resolve_artifact_path(project_root, selected_board)
+        if not board_path.exists():
+            errors.append(f"{label} selected_board was not found: {board_path}")
+
+    transforms = obj.get("transforms")
+    if isinstance(transforms, Mapping):
+        matrices: dict[str, np.ndarray] = {}
+        for name in ("T_cam_board", "T_board_object", "T_cam_object"):
+            item = transforms.get(name)
+            if not isinstance(item, Mapping) or "matrix" not in item:
+                errors.append(f"{label}.transforms.{name}.matrix is required.")
+                continue
+            matrix_errors = _matrix_errors(item["matrix"], f"{label}.transforms.{name}.matrix")
+            errors.extend(matrix_errors)
+            if not matrix_errors:
+                matrices[name] = np.asarray(item["matrix"], dtype=float)
+        if set(matrices) == {"T_cam_board", "T_board_object", "T_cam_object"}:
+            composed = matrices["T_cam_board"] @ matrices["T_board_object"]
+            if not np.allclose(composed, matrices["T_cam_object"], rtol=1e-9, atol=1e-9):
+                errors.append(f"{label} does not preserve {POSE_COMPOSITION}.")
+    elif "transforms" in obj:
+        errors.append(f"{label}.transforms must be a mapping.")
+
+    pose = obj.get("6DOF_pose")
+    if isinstance(pose, Mapping):
+        _require_vector(pose.get("position"), 3, f"{label}.6DOF_pose.position", errors)
+        _require_vector(pose.get("orientation"), 3, f"{label}.6DOF_pose.orientation", errors)
+        _require_vector(pose.get("rotation"), 4, f"{label}.6DOF_pose.rotation", errors)
+        if pose.get("translation_units") != "meters":
+            errors.append(f"{label}.6DOF_pose.translation_units must be 'meters'.")
+        if pose.get("orientation_order") != "roll, pitch, yaw":
+            errors.append(f"{label}.6DOF_pose.orientation_order must be 'roll, pitch, yaw'.")
+        if pose.get("orientation_units") != "degrees":
+            errors.append(f"{label}.6DOF_pose.orientation_units must be 'degrees'.")
+        if pose.get("rotation_quaternion_order") != "x, y, z, w":
+            errors.append(f"{label}.6DOF_pose.rotation_quaternion_order must be 'x, y, z, w'.")
+    elif "6DOF_pose" in obj:
+        errors.append(f"{label}.6DOF_pose must be a mapping.")
+
+    quality = obj.get("quality")
+    if isinstance(quality, Mapping):
+        for field in ("tag_used", "num_tags_visible", "score"):
+            if field not in quality:
+                errors.append(f"{label}.quality is missing field {field!r}.")
+    elif "quality" in obj:
+        errors.append(f"{label}.quality must be a mapping.")
+
+    return tuple(errors)
 
 
 def _expected_annotation_yaml_paths(project_root: Path) -> tuple[Path, ...]:
@@ -1174,6 +1553,37 @@ def _sorted_registry_entries(tags: Mapping[Any, Any]) -> Iterable[tuple[str, Any
         ((str(tag_id), entry) for tag_id, entry in tags.items()),
         key=lambda item: item[0],
     )
+
+
+def _matrix_errors(value: Any, label: str) -> tuple[str, ...]:
+    errors: list[str] = []
+    _require_numeric_matrix(value, label, rows=4, cols=4, errors=errors)
+    if not errors and _is_numeric_matrix(value, rows=4, cols=4):
+        last_row = [float(item) for item in value[3]]
+        if any(
+            abs(actual - expected) > 1e-9
+            for actual, expected in zip(last_row, (0.0, 0.0, 0.0, 1.0))
+        ):
+            errors.append(f"{label} must have last row [0, 0, 0, 1].")
+    return tuple(errors)
+
+
+def _require_vector(value: Any, length: int, label: str, errors: list[str]) -> None:
+    if not isinstance(value, list) or len(value) != length:
+        errors.append(f"{label} must be a length-{length} numeric list.")
+        return
+    for item in value:
+        if isinstance(item, bool):
+            errors.append(f"{label} must contain only numeric values.")
+            return
+        try:
+            numeric = float(item)
+        except (TypeError, ValueError):
+            errors.append(f"{label} must contain only numeric values.")
+            return
+        if not math.isfinite(numeric):
+            errors.append(f"{label} must contain only finite values.")
+            return
 
 
 def _stage(

--- a/tests/test_step6_collect_dataset.py
+++ b/tests/test_step6_collect_dataset.py
@@ -35,6 +35,7 @@ from posetag.pipelines.collect_dataset import (
     validate_collection_inputs,
     validate_source_args,
 )
+from collect_gt_dataset import save_frame
 from utils.collect_gt_utils import (
     _capture_key_requests_quit,
     _capture_status_panel,
@@ -637,6 +638,28 @@ class CollectDatasetStep6Tests(unittest.TestCase):
             )
 
         self.assertIn("Pose composition mismatch", str(ctx.exception))
+
+    def test_save_frame_rejects_empty_pose_results_without_outputs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "datasets" / "run01"
+
+            with self.assertRaises(CollectDatasetError) as ctx:
+                save_frame(
+                    out_dir=out_dir,
+                    idx=0,
+                    ts=123.456,
+                    bgr_raw=np.zeros((16, 16, 3), dtype=np.uint8),
+                    depth=None,
+                    intr=_intrinsics(),
+                    family="tag36h11",
+                    results={},
+                    reproj_img=None,
+                    save_depth=False,
+                    dataset_name="run01",
+                )
+
+            self.assertIn("without at least one pose-labelled object", str(ctx.exception))
+            self.assertFalse(out_dir.exists())
 
     def test_capture_review_dashboard_renders_structured_status_panel(self) -> None:
         left = np.full((240, 320, 3), 180, dtype=np.uint8)

--- a/tests/test_step6_collect_dataset.py
+++ b/tests/test_step6_collect_dataset.py
@@ -1,0 +1,711 @@
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+import sys
+import unittest
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import yaml
+
+from posetag.cli import collect as collect_cli
+from posetag.pipelines.collect_dataset import (
+    AutoCaptureConfig,
+    AutoCaptureState,
+    CollectDatasetError,
+    Intrinsics,
+    auto_capture_candidates_from_results,
+    build_frame_annotation_record,
+    build_session_metadata,
+    compose_T_cam_object,
+    evaluate_auto_capture,
+    load_intrinsics_from_calibration,
+    parse_auto_capture_grid,
+    pose_delta,
+    record_auto_capture_save,
+    resolve_calibration_path,
+    resolve_dataset_root,
+    resolve_face_manifest_path,
+    resolve_registry_path,
+    validate_collection_inputs,
+    validate_source_args,
+)
+from utils.collect_gt_utils import (
+    _capture_key_requests_quit,
+    _capture_status_panel,
+    _dashboard_strip,
+    _normalize_capture_key,
+)
+
+
+OBJECT = "connection_plate_white"
+SIDE = "sideA"
+FACE_KEY = f"{OBJECT}_{SIDE}"
+
+
+def _write_calibration(project_root: Path) -> Path:
+    calib_path = project_root / "calib" / "calib_color.yaml"
+    calib_path.parent.mkdir(parents=True, exist_ok=True)
+    calib_path.write_text(
+        yaml.safe_dump(
+            {
+                "image_width": 640,
+                "image_height": 480,
+                "camera_matrix": {
+                    "fx": 600.0,
+                    "fy": 610.0,
+                    "cx": 320.0,
+                    "cy": 240.0,
+                },
+                "distortion_coefficients": {
+                    "k1": 0.0,
+                    "k2": 0.0,
+                    "p1": 0.0,
+                    "p2": 0.0,
+                    "k3": 0.0,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return calib_path
+
+
+def _write_board(project_root: Path) -> Path:
+    board_path = project_root / "boards" / f"{FACE_KEY}.yaml"
+    board_path.parent.mkdir(parents=True, exist_ok=True)
+    board_path.write_text(
+        yaml.safe_dump(
+            {
+                "object": FACE_KEY,
+                "family": "tag36h11",
+                "tag_size_m": 0.08,
+                "origin_id": 52,
+                "tags": [
+                    {"id": 52, "cx": 0.0, "cy": 0.0, "yaw_deg": 0.0},
+                    {"id": 53, "cx": 0.12, "cy": 0.0, "yaw_deg": 0.0},
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return board_path
+
+
+def _relative_to_project(project_root: Path, path: Path) -> str:
+    return path.relative_to(project_root).as_posix()
+
+
+def _write_registry(project_root: Path, board_path: Path) -> Path:
+    registry_path = project_root / "boards" / "tag_registry.yaml"
+    board_rel = _relative_to_project(project_root, board_path)
+    registry_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "updated": "2026-06-07T12:00:00Z",
+                "tags": {
+                    "52": {"object": FACE_KEY, "yaml": board_rel},
+                    "53": {"object": FACE_KEY, "yaml": board_rel},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def _write_annotation(project_root: Path, board_path: Path, *, include_transform: bool = True) -> Path:
+    annotation_path = project_root / "faces" / OBJECT / SIDE / f"{FACE_KEY}_T_board_object.yaml"
+    annotation_path.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "object": OBJECT,
+        "face_key": FACE_KEY,
+        "board_yaml": _relative_to_project(project_root, board_path),
+        "shot_raw": "shots/example_raw.png",
+        "rms_px": 0.42,
+    }
+    if include_transform:
+        T_board_object = np.eye(4)
+        T_board_object[:3, 3] = [0.02, 0.03, 0.04]
+        record["T_board_object"] = {"matrix": T_board_object.tolist()}
+    annotation_path.write_text(yaml.safe_dump(record), encoding="utf-8")
+    return annotation_path
+
+
+def _write_face_manifest(project_root: Path, annotation_path: Path, board_path: Path) -> Path:
+    manifest_path = project_root / "faces" / "face_manifest.csv"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    with manifest_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "timestamp",
+                "object",
+                "side",
+                "face_key",
+                "yaml_path",
+                "board_yaml",
+                "image",
+                "rms_px",
+                "tag_size_m",
+            ],
+        )
+        writer.writeheader()
+        writer.writerow(
+            {
+                "timestamp": "20260607_120000",
+                "object": OBJECT,
+                "side": SIDE,
+                "face_key": FACE_KEY,
+                "yaml_path": _relative_to_project(project_root, annotation_path),
+                "board_yaml": _relative_to_project(project_root, board_path),
+                "image": "shots/example_raw.png",
+                "rms_px": "0.42",
+                "tag_size_m": "0.08",
+            }
+        )
+    return manifest_path
+
+
+def _write_keypoints(project_root: Path) -> Path:
+    keypoints_path = project_root / "objects" / OBJECT / "keypoints.json"
+    keypoints_path.parent.mkdir(parents=True, exist_ok=True)
+    keypoints_path.write_text(
+        json.dumps(
+            {
+                "object": OBJECT,
+                "units_to_m": 1.0,
+                "points": {
+                    "p0": [0.0, 0.0, 0.0],
+                    "p1": [0.1, 0.0, 0.0],
+                    "p2": [0.1, 0.1, 0.0],
+                    "p3": [0.0, 0.1, 0.0],
+                },
+                "faces": {FACE_KEY: ["p0", "p1", "p2", "p3"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return keypoints_path
+
+
+def _write_project_fixture(project_root: Path, *, keypoints: bool = False) -> tuple[Path, Path, Path, Path]:
+    calib_path = _write_calibration(project_root)
+    board_path = _write_board(project_root)
+    registry_path = _write_registry(project_root, board_path)
+    annotation_path = _write_annotation(project_root, board_path)
+    manifest_path = _write_face_manifest(project_root, annotation_path, board_path)
+    if keypoints:
+        _write_keypoints(project_root)
+    return calib_path, registry_path, manifest_path, annotation_path
+
+
+def _intrinsics() -> Intrinsics:
+    return Intrinsics(
+        path=Path("calib/calib_color.yaml"),
+        fx=600.0,
+        fy=610.0,
+        cx=320.0,
+        cy=240.0,
+        width=640,
+        height=480,
+        dist=np.zeros((1, 5), dtype=float),
+    )
+
+
+def _pose_result() -> dict[str, object]:
+    T_cam_board = np.eye(4)
+    T_cam_board[:3, 3] = [0.25, -0.1, 1.5]
+    T_board_object = np.eye(4)
+    T_board_object[:3, 3] = [0.02, 0.03, 0.04]
+    T_cam_object = compose_T_cam_object(T_cam_board, T_board_object)
+    return {
+        "object": OBJECT,
+        "face_key": FACE_KEY,
+        "board_yaml": f"boards/{FACE_KEY}.yaml",
+        "tag_used": 52,
+        "num_tags_visible": 2,
+        "score": 2500.0,
+        "score_tags": 2,
+        "score_area_px": 500,
+        "bbox_xywh": [64.0, 48.0, 128.0, 96.0],
+        "bbox_source": "face_kps",
+        "T_cam_board": {"matrix": T_cam_board.tolist()},
+        "T_board_object": {"matrix": T_board_object.tolist()},
+        "T_cam_object": {"matrix": T_cam_object.tolist()},
+        "diagnostics": {
+            "tag_scale_ratio": 1.0,
+            "tag_scale_pairs": 1,
+            "tag_scale_mad": 0.0,
+            "tag_scale_auto_corrected": False,
+        },
+    }
+
+
+class ClosedCapture:
+    def __init__(self, _path: str) -> None:
+        pass
+
+    def isOpened(self) -> bool:
+        return False
+
+    def release(self) -> None:
+        pass
+
+
+class CollectDatasetStep6Tests(unittest.TestCase):
+    def test_cli_help_resolves(self) -> None:
+        stdout = StringIO()
+        with self.assertRaises(SystemExit) as ctx:
+            with redirect_stdout(stdout):
+                collect_cli.main(["--help"])
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.assertIn("Collect multi-object/multi-face GT dataset", stdout.getvalue())
+        self.assertIn("--dry-run", stdout.getvalue())
+        self.assertIn("opencv", stdout.getvalue())
+
+        result = subprocess.run(
+            [sys.executable, "-m", "posetag.cli.collect", "--help"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("posetag-collect", result.stdout)
+
+    def test_input_preflight_validates_required_collection_files(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib_path, registry_path, manifest_path, _annotation_path = _write_project_fixture(project_root)
+
+            summary = validate_collection_inputs(
+                project_root=project_root,
+                calib_path=calib_path,
+                registry_path=registry_path,
+                face_manifest_path=manifest_path,
+            )
+
+        self.assertEqual(summary.calibration_path, calib_path)
+        self.assertEqual(summary.registry_path, registry_path)
+        self.assertEqual(summary.face_manifest_path, manifest_path)
+        self.assertEqual(len(summary.annotations), 1)
+        self.assertEqual(summary.annotations[0].object_name, OBJECT)
+        self.assertEqual(summary.annotations[0].face_key, FACE_KEY)
+        self.assertEqual(summary.annotations[0].tag_ids, (52, 53))
+        self.assertEqual(len(summary.missing_keypoints), 1)
+
+    def test_dry_run_succeeds_without_creating_dataset_session(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_project_fixture(project_root, keypoints=True)
+
+            stdout = StringIO()
+            with redirect_stdout(stdout):
+                exit_code = collect_cli.main(
+                    [
+                        "--project_root",
+                        str(project_root),
+                        "--mode",
+                        "opencv",
+                        "--session",
+                        "run01",
+                        "--dry-run",
+                    ]
+                )
+
+            self.assertEqual(exit_code, 0)
+            self.assertIn("Dataset collection dry run OK", stdout.getvalue())
+            self.assertFalse((project_root / "datasets" / "run01").exists())
+
+    def test_path_helpers_resolve_canonical_inputs(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            _write_project_fixture(project_root)
+
+            self.assertEqual(
+                resolve_calibration_path(project_root, "calib_color.yaml"),
+                project_root.resolve() / "calib" / "calib_color.yaml",
+            )
+            self.assertEqual(resolve_registry_path(project_root), project_root.resolve() / "boards" / "tag_registry.yaml")
+            self.assertEqual(
+                resolve_face_manifest_path(project_root),
+                project_root.resolve() / "faces" / "face_manifest.csv",
+            )
+            self.assertEqual(resolve_dataset_root(project_root), project_root.resolve() / "datasets")
+
+    def test_missing_inputs_fail_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib_path, registry_path, manifest_path, annotation_path = _write_project_fixture(project_root)
+
+            calib_path.unlink()
+            with self.assertRaises(CollectDatasetError) as missing_calib:
+                load_intrinsics_from_calibration(calib_path)
+            self.assertIn("Calibration YAML not found", str(missing_calib.exception))
+
+            calib_path.parent.mkdir(parents=True, exist_ok=True)
+            calib_path.write_text("not_camera_matrix: true\n", encoding="utf-8")
+            with self.assertRaises(CollectDatasetError) as malformed_calib:
+                load_intrinsics_from_calibration(calib_path)
+            self.assertIn("Malformed calibration YAML", str(malformed_calib.exception))
+
+            _write_calibration(project_root)
+            registry_path.unlink()
+            with self.assertRaises(CollectDatasetError) as missing_registry:
+                validate_collection_inputs(
+                    project_root=project_root,
+                    calib_path=calib_path,
+                    registry_path=registry_path,
+                    face_manifest_path=manifest_path,
+                )
+            self.assertIn("Tag registry not found", str(missing_registry.exception))
+
+            registry_path = _write_registry(project_root, project_root / "boards" / f"{FACE_KEY}.yaml")
+            manifest_path.unlink()
+            with self.assertRaises(CollectDatasetError) as missing_manifest:
+                validate_collection_inputs(
+                    project_root=project_root,
+                    calib_path=calib_path,
+                    registry_path=registry_path,
+                    face_manifest_path=manifest_path,
+                )
+            self.assertIn("Face manifest not found", str(missing_manifest.exception))
+
+            board_path = project_root / "boards" / f"{FACE_KEY}.yaml"
+            board_path.unlink()
+            manifest_path = _write_face_manifest(project_root, annotation_path, board_path)
+            with self.assertRaises(CollectDatasetError) as missing_board:
+                validate_collection_inputs(
+                    project_root=project_root,
+                    calib_path=calib_path,
+                    registry_path=registry_path,
+                    face_manifest_path=manifest_path,
+                )
+            self.assertIn("Board YAML not found", str(missing_board.exception))
+
+    def test_missing_annotation_transform_fails_clearly(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            calib_path = _write_calibration(project_root)
+            board_path = _write_board(project_root)
+            registry_path = _write_registry(project_root, board_path)
+            annotation_path = _write_annotation(project_root, board_path, include_transform=False)
+            manifest_path = _write_face_manifest(project_root, annotation_path, board_path)
+
+            with self.assertRaises(CollectDatasetError) as ctx:
+                validate_collection_inputs(
+                    project_root=project_root,
+                    calib_path=calib_path,
+                    registry_path=registry_path,
+                    face_manifest_path=manifest_path,
+                )
+
+        self.assertIn("T_board_object.matrix", str(ctx.exception))
+
+    def test_source_argument_failures_are_clear(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            video_path = Path(tmpdir) / "empty.mp4"
+            video_path.touch()
+
+            with self.assertRaises(CollectDatasetError) as missing_video:
+                validate_source_args(mode="video", video=None, bag=None, realsense_module=object())
+            self.assertIn("--video is required", str(missing_video.exception))
+
+            with self.assertRaises(CollectDatasetError) as unreadable_video:
+                validate_source_args(
+                    mode="video",
+                    video=video_path,
+                    bag=None,
+                    realsense_module=object(),
+                    video_capture_factory=ClosedCapture,
+                )
+            self.assertIn("Could not open video", str(unreadable_video.exception))
+
+            with self.assertRaises(CollectDatasetError) as missing_bag:
+                validate_source_args(mode="bag", video=None, bag=None, realsense_module=object())
+            self.assertIn("--bag is required", str(missing_bag.exception))
+
+            with self.assertRaises(CollectDatasetError) as missing_realsense:
+                validate_source_args(mode="live", video=None, bag=None, realsense_module=None)
+            self.assertIn("pyrealsense2 is not available", str(missing_realsense.exception))
+
+    def test_pose_schema_serializes_explicit_transform_convention(self) -> None:
+        result = _pose_result()
+        record = build_frame_annotation_record(
+            dataset_name="run01",
+            frame_index=7,
+            timestamp=123.456,
+            tag_family="tag36h11",
+            image_filename="Run_20260607-120000_rgb_frame_000007.png",
+            annotated_image="Run_20260607-120000_annotated_frame_000007.png",
+            reproj_image="Run_20260607-120000_reproj_frame_000007.png",
+            depth=None,
+            intrinsics=_intrinsics(),
+            results={FACE_KEY: result},
+            capture_metadata={
+                "mode": "smart_auto",
+                "reason": "first_sample",
+                "trigger_object": OBJECT,
+            },
+        )
+
+        obj = record["objects"][0]
+        T_cam_board = np.array(obj["transforms"]["T_cam_board"]["matrix"], dtype=float)
+        T_board_object = np.array(obj["transforms"]["T_board_object"]["matrix"], dtype=float)
+        T_cam_object = np.array(obj["transforms"]["T_cam_object"]["matrix"], dtype=float)
+
+        self.assertEqual(record["pose_convention"]["composition"], "T_cam_object = T_cam_board @ T_board_object")
+        self.assertTrue(np.allclose(T_cam_board @ T_board_object, T_cam_object))
+        self.assertEqual(obj["object_name"], OBJECT)
+        self.assertEqual(obj["selected_face"], FACE_KEY)
+        self.assertEqual(obj["6DOF_pose"]["translation_units"], "meters")
+        self.assertEqual(obj["6DOF_pose"]["rotation_quaternion_order"], "x, y, z, w")
+        self.assertEqual(obj["6DOF_pose"]["orientation_order"], "roll, pitch, yaw")
+        self.assertEqual(obj["6DOF_pose"]["orientation_units"], "degrees")
+        self.assertEqual(obj["quality"]["num_tags_visible"], 2)
+        self.assertEqual(record["camera_extrinsics"]["rotation"], [0.0, 0.0, 0.0, 1.0])
+        self.assertEqual(record["capture"]["mode"], "smart_auto")
+        self.assertEqual(record["capture"]["reason"], "first_sample")
+
+    def test_pose_delta_reports_translation_and_rotation_thresholds(self) -> None:
+        T_a = np.eye(4)
+        T_b = np.eye(4)
+        T_b[:3, 3] = [0.1, 0.0, 0.0]
+        theta = np.deg2rad(90.0)
+        T_b[:3, :3] = [
+            [np.cos(theta), -np.sin(theta), 0.0],
+            [np.sin(theta), np.cos(theta), 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+
+        translation_delta, rotation_delta = pose_delta(T_a, T_b)
+
+        self.assertAlmostEqual(translation_delta, 0.1)
+        self.assertAlmostEqual(rotation_delta, 90.0)
+
+    def test_smart_auto_capture_waits_for_stability_and_useful_views(self) -> None:
+        config = AutoCaptureConfig(
+            enabled=True,
+            stable_frames=3,
+            cooldown_sec=1.0,
+            min_tags_visible=1,
+            min_bbox_area_px=1000.0,
+            min_translation_delta_m=0.02,
+            min_rotation_delta_deg=5.0,
+            grid_rows=2,
+            grid_cols=2,
+            distance_bin_m=0.25,
+        )
+        state = AutoCaptureState()
+        result = _pose_result()
+        candidates = auto_capture_candidates_from_results({FACE_KEY: result})
+
+        first = evaluate_auto_capture(
+            candidates,
+            state,
+            config,
+            frame_width=640,
+            frame_height=480,
+            timestamp=1.0,
+        )
+        second = evaluate_auto_capture(
+            candidates,
+            state,
+            config,
+            frame_width=640,
+            frame_height=480,
+            timestamp=1.1,
+        )
+        third = evaluate_auto_capture(
+            candidates,
+            state,
+            config,
+            frame_width=640,
+            frame_height=480,
+            timestamp=1.2,
+        )
+
+        self.assertFalse(first.should_save)
+        self.assertEqual(first.status, "waiting_for_stability")
+        self.assertFalse(second.should_save)
+        self.assertTrue(third.should_save)
+        self.assertEqual(third.reason, "first_sample")
+
+        record_auto_capture_save(
+            state,
+            candidates[0],
+            config,
+            frame_width=640,
+            frame_height=480,
+            timestamp=1.2,
+        )
+        cooldown = evaluate_auto_capture(
+            candidates,
+            state,
+            config,
+            frame_width=640,
+            frame_height=480,
+            timestamp=1.5,
+        )
+        duplicate = evaluate_auto_capture(
+            candidates,
+            state,
+            config,
+            frame_width=640,
+            frame_height=480,
+            timestamp=3.0,
+        )
+
+        self.assertFalse(cooldown.should_save)
+        self.assertEqual(cooldown.status, "cooldown")
+        self.assertFalse(duplicate.should_save)
+        self.assertEqual(duplicate.status, "waiting_for_new_view")
+
+        moved_result = _pose_result()
+        moved_result["bbox_xywh"] = [450.0, 320.0, 128.0, 96.0]
+        moved_candidates = auto_capture_candidates_from_results({FACE_KEY: moved_result})
+        coverage = evaluate_auto_capture(
+            moved_candidates,
+            state,
+            config,
+            frame_width=640,
+            frame_height=480,
+            timestamp=3.1,
+        )
+
+        self.assertTrue(coverage.should_save)
+        self.assertEqual(coverage.reason, "coverage_cell")
+
+    def test_smart_auto_capture_rejects_low_quality_candidates(self) -> None:
+        config = AutoCaptureConfig(
+            enabled=True,
+            stable_frames=1,
+            min_tags_visible=2,
+            min_bbox_area_px=2000.0,
+            max_tag_scale_error=0.05,
+        )
+        result = _pose_result()
+        result["num_tags_visible"] = 1
+        result["bbox_xywh"] = [10.0, 20.0, 10.0, 10.0]
+        result["diagnostics"]["tag_scale_ratio"] = 1.20
+        result["diagnostics"]["tag_scale_pairs"] = 1
+        decision = evaluate_auto_capture(
+            auto_capture_candidates_from_results({FACE_KEY: result}),
+            AutoCaptureState(),
+            config,
+            frame_width=640,
+            frame_height=480,
+            timestamp=1.0,
+        )
+
+        self.assertFalse(decision.should_save)
+        self.assertEqual(decision.status, "waiting_for_quality")
+        self.assertTrue(any("visible tags" in reason for reason in decision.rejected_reasons))
+        self.assertTrue(any("tag scale error" in reason for reason in decision.rejected_reasons))
+
+    def test_auto_capture_grid_parser_validates_rows_and_columns(self) -> None:
+        self.assertEqual(parse_auto_capture_grid("4x5"), (4, 5))
+        with self.assertRaises(CollectDatasetError):
+            parse_auto_capture_grid("4")
+
+    def test_pose_schema_rejects_transform_composition_drift(self) -> None:
+        result = _pose_result()
+        bad_T = np.array(result["T_cam_object"]["matrix"], dtype=float)
+        bad_T[0, 3] += 1.0
+        result["T_cam_object"] = {"matrix": bad_T.tolist()}
+
+        with self.assertRaises(CollectDatasetError) as ctx:
+            build_frame_annotation_record(
+                dataset_name="run01",
+                frame_index=0,
+                timestamp=1.0,
+                tag_family="tag36h11",
+                image_filename="frame.png",
+                annotated_image=None,
+                reproj_image=None,
+                depth=None,
+                intrinsics=_intrinsics(),
+                results={FACE_KEY: result},
+            )
+
+        self.assertIn("Pose composition mismatch", str(ctx.exception))
+
+    def test_capture_review_dashboard_renders_structured_status_panel(self) -> None:
+        left = np.full((240, 320, 3), 180, dtype=np.uint8)
+        mid = np.full((240, 320, 3), 96, dtype=np.uint8)
+        panel = _capture_status_panel(
+            session="run01",
+            faces_visible=1,
+            saved_count=2,
+            object_summaries=[
+                {
+                    "object": OBJECT,
+                    "face_key": FACE_KEY,
+                    "translation_m": (0.25, -0.10, 1.50),
+                    "distance_m": 1.53,
+                    "rpy_deg": (1.0, 2.0, 3.0),
+                    "tag_used": 52,
+                    "bbox_source": "face_kps",
+                    "tag_scale_ratio": 1.0,
+                    "tag_scale_pairs": 1,
+                }
+            ],
+            capture_message="Frame #002 captured [OK]",
+            width=420,
+            height=320,
+        )
+        strip = _dashboard_strip(
+            left,
+            mid,
+            panel,
+            tile_h=320,
+            tile_w=360,
+            right_w=420,
+        )
+
+        self.assertEqual(panel.shape, (320, 420, 3))
+        self.assertEqual(strip.shape, (320, 1160, 3))
+        self.assertGreater(np.count_nonzero(panel != panel[0, 0]), 1000)
+        self.assertGreater(np.count_nonzero(strip != strip[0, 0]), 1000)
+
+    def test_capture_review_quit_keys_close_cleanly(self) -> None:
+        for key in (27, ord("q"), ord("Q"), ord("x"), ord("X")):
+            with self.subTest(key=key):
+                self.assertTrue(_capture_key_requests_quit(key))
+                self.assertTrue(_capture_key_requests_quit(key | 0x100000))
+
+        self.assertFalse(_capture_key_requests_quit(ord("p")))
+        self.assertFalse(_capture_key_requests_quit(ord("h")))
+        self.assertFalse(_capture_key_requests_quit(-1))
+        self.assertEqual(_normalize_capture_key(27 | 0x100000), 27)
+
+    def test_session_metadata_records_source_and_pose_convention(self) -> None:
+        meta = build_session_metadata(
+            session_name="run01",
+            project_root=Path("/tmp/project"),
+            dataset_root=Path("/tmp/project/datasets"),
+            session_dir=Path("/tmp/project/datasets/run01"),
+            intrinsics=_intrinsics(),
+            tag_family="tag36h11",
+            camera_kind="opencv_webcam",
+            mode="opencv",
+            tag_scale_controls={"check_tag_scale": False, "auto_correct_scale": False, "scale_tol": 0.02},
+            faces_index={FACE_KEY: {"object": OBJECT, "board_yaml": f"boards/{FACE_KEY}.yaml"}},
+        )
+
+        self.assertEqual(meta["source"]["mode"], "opencv")
+        self.assertEqual(meta["camera"]["kind"], "opencv_webcam")
+        self.assertEqual(meta["pose_convention"]["translation_units"], "meters")
+        self.assertEqual(meta["objects_available"], [OBJECT])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workflow_gui.py
+++ b/tests/test_workflow_gui.py
@@ -50,6 +50,9 @@ from posetag.gui.main_window import (
     _format_capture_face_readiness,
     _format_capture_face_saved_shot_group_details,
     _format_capture_face_saved_shot_details,
+    _format_dataset_collection_outputs,
+    _format_dataset_collection_process_state,
+    _format_dataset_collection_readiness,
     _format_annotation_outputs,
     _format_annotation_process_state,
     _format_annotation_readiness,
@@ -68,6 +71,9 @@ from posetag.gui.main_window import (
     _annotation_command_ready_message,
     _annotation_queue_item_label,
     _annotation_run_button_label,
+    _dataset_collection_command_card_note,
+    _dataset_collection_command_ready_message,
+    _dataset_collection_run_button_label,
     _project_root_hint,
     _stage_list_label,
     _stage_rail_dot_style,
@@ -111,6 +117,17 @@ from posetag.workflows.annotation import (
     annotation_process_running,
     build_annotation_launch,
     remove_annotation_output,
+)
+from posetag.workflows.collect_dataset import (
+    SOURCE_VIDEO as DATASET_SOURCE_VIDEO,
+    DatasetCollectionConfig,
+    DatasetCollectionProcessState,
+    DatasetCollectionReadiness,
+    build_dataset_collection_launch,
+    collect_dataset_process_not_started,
+    collect_dataset_process_running,
+    inspect_dataset_collection_readiness,
+    summarize_dataset_collection_process_result,
 )
 from posetag.workflows.object_tags import (
     ObjectTagGenerationReadiness,
@@ -310,7 +327,8 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertIn("env 'POSETAG_PROJECT=/tmp/PoseTag project'", annotate_preview)
         self.assertIn("posetag-annotate --browse", annotate_preview)
         self.assertIn("env 'POSETAG_PROJECT=/tmp/PoseTag project'", collect_preview)
-        self.assertIn("posetag-collect --mode live", collect_preview)
+        self.assertIn("posetag-collect --mode opencv", collect_preview)
+        self.assertIn("--dry-run", collect_preview)
 
     def test_annotation_launch_uses_project_environment(self) -> None:
         project_root = Path("/tmp/PoseTag project")
@@ -365,6 +383,88 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertIn("--check-tag-scale", launch.display_command)
         self.assertIn("--auto-correct-scale", launch.display_command)
         self.assertIn("--force", launch.display_command)
+
+    def test_dataset_collection_launch_uses_project_environment(self) -> None:
+        project_root = Path("/tmp/PoseTag project")
+        resolved_root = project_root.expanduser().resolve()
+        config = DatasetCollectionConfig(
+            project_root=project_root,
+            session="run01",
+        )
+
+        launch = build_dataset_collection_launch(config, dry_run=True)
+
+        self.assertIn("python", Path(launch.program).name)
+        self.assertEqual(
+            launch.arguments[:4],
+            ("-m", "posetag.cli.collect", "--project_root", str(resolved_root)),
+        )
+        self.assertIn("--mode", launch.arguments)
+        self.assertIn("opencv", launch.arguments)
+        self.assertIn("--dry-run", launch.arguments)
+        self.assertIn(
+            f"env 'POSETAG_PROJECT={resolved_root}'",
+            launch.display_command,
+        )
+        self.assertIn("posetag-collect --project_root", launch.display_command)
+        self.assertEqual(
+            launch.expected_session_dir,
+            resolved_root / "datasets" / "run01",
+        )
+        self.assertTrue(launch.dry_run)
+
+    def test_dataset_collection_video_launch_requires_video_path(self) -> None:
+        config = DatasetCollectionConfig(
+            project_root=Path("/tmp/project"),
+            session="run01",
+            mode=DATASET_SOURCE_VIDEO,
+        )
+
+        with self.assertRaisesRegex(ValueError, "--video is required"):
+            build_dataset_collection_launch(config, dry_run=True)
+
+    def test_dataset_collection_launch_can_enable_smart_auto_capture(self) -> None:
+        config = DatasetCollectionConfig(
+            project_root=Path("/tmp/project"),
+            session="run01",
+            auto_capture=True,
+            auto_stable_frames=4,
+            auto_cooldown_sec=0.5,
+        )
+
+        launch = build_dataset_collection_launch(config, dry_run=False)
+
+        self.assertIn("--auto-capture", launch.arguments)
+        self.assertIn("--auto-stable-frames", launch.arguments)
+        self.assertIn("4", launch.arguments)
+        self.assertIn("--auto-cooldown-sec", launch.arguments)
+        self.assertIn("0.5", launch.arguments)
+        self.assertIn("--auto-capture", launch.display_command)
+
+    def test_dataset_collection_launch_rejects_continuous_smart_mix(self) -> None:
+        config = DatasetCollectionConfig(
+            project_root=Path("/tmp/project"),
+            session="run01",
+            continuous=True,
+            auto_capture=True,
+        )
+
+        with self.assertRaisesRegex(ValueError, "cannot both be enabled"):
+            build_dataset_collection_launch(config, dry_run=False)
+
+    def test_dataset_collection_readiness_reports_invalid_source(self) -> None:
+        readiness = inspect_dataset_collection_readiness(
+            DatasetCollectionConfig(
+                project_root=Path("/tmp/project"),
+                session="run01",
+                mode="invalid-source",
+            )
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertTrue(
+            any("Unsupported dataset source" in error for error in readiness.errors)
+        )
 
     def test_remove_annotation_output_refreshes_face_manifest(self) -> None:
         with TemporaryDirectory() as tmpdir:
@@ -1171,6 +1271,102 @@ class WorkflowGuiTests(unittest.TestCase):
         self.assertIn("not started", _format_annotation_process_state(idle))
         self.assertIn("Expected manifest:", _format_annotation_process_state(idle))
         self.assertIn("OpenCV browser", _format_annotation_process_state(running))
+
+    def test_dataset_collection_command_note_and_process_state(self) -> None:
+        project_root = Path("/tmp/project")
+        readiness = DatasetCollectionReadiness(
+            ready=True,
+            command_preview=(
+                "env POSETAG_PROJECT=/tmp/project posetag-collect "
+                "--mode opencv --session run01"
+            ),
+            dry_run_command_preview=(
+                "env POSETAG_PROJECT=/tmp/project posetag-collect "
+                "--mode opencv --session run01 --dry-run"
+            ),
+            project_root=project_root,
+            calibration_path=project_root / "calib" / "calib_color.yaml",
+            registry_path=project_root / "boards" / "tag_registry.yaml",
+            face_manifest_path=project_root / "faces" / "face_manifest.csv",
+            dataset_root=project_root / "datasets",
+            expected_session_dir=project_root / "datasets" / "run01",
+            input_summary=None,
+            checked_paths=(),
+        )
+        active = SimpleNamespace(status="missing")
+        complete = SimpleNamespace(status="complete")
+        idle = collect_dataset_process_not_started(readiness.expected_session_dir)
+        running = collect_dataset_process_running(readiness.expected_session_dir)
+        success = DatasetCollectionProcessState(
+            state="finished",
+            label="finished",
+            message="Dataset collection exited cleanly.",
+            success=True,
+            expected_session_dir=readiness.expected_session_dir,
+            exit_code=0,
+        )
+
+        note = _dataset_collection_command_card_note(readiness, active)
+        complete_note = _dataset_collection_command_card_note(readiness, complete)
+        outputs = _format_dataset_collection_outputs(readiness)
+
+        self.assertIn("Dry Run", note)
+        self.assertIn("Start Collection", note)
+        self.assertIn("POSETAG_PROJECT", note)
+        self.assertIn("another pose-labelled session", complete_note)
+        self.assertEqual(
+            _dataset_collection_command_ready_message(readiness),
+            "Ready to dry-run, start collection, or copy the command.",
+        )
+        self.assertIn(
+            "Ready to collect pose-labelled",
+            _format_dataset_collection_readiness(readiness),
+        )
+        self.assertIn("Expected session", outputs)
+        self.assertEqual(
+            _dataset_collection_run_button_label(idle),
+            "Start Collection",
+        )
+        self.assertEqual(
+            _dataset_collection_run_button_label(running),
+            "Collection Running...",
+        )
+        self.assertEqual(
+            _dataset_collection_run_button_label(success),
+            "Start Collection Again",
+        )
+        self.assertIn("not started", _format_dataset_collection_process_state(idle))
+        self.assertIn("Expected session:", _format_dataset_collection_process_state(idle))
+        self.assertIn("review window", _format_dataset_collection_process_state(running))
+
+    def test_dataset_collection_process_summary_checks_session_outputs(self) -> None:
+        dry_run = summarize_dataset_collection_process_result(
+            exit_code=0,
+            dry_run=True,
+        )
+        self.assertTrue(dry_run.success)
+        self.assertIn("dry-run completed", dry_run.message)
+
+        with TemporaryDirectory() as tmpdir:
+            session_dir = Path(tmpdir) / "datasets" / "run01"
+            missing_output = summarize_dataset_collection_process_result(
+                exit_code=0,
+                expected_session_dir=session_dir,
+            )
+            self.assertFalse(missing_output.success)
+            self.assertIn("without writing session.yaml", missing_output.message)
+
+            session_dir.mkdir(parents=True)
+            (session_dir / "session.yaml").write_text(
+                "session_name: run01\n",
+                encoding="utf-8",
+            )
+            real_run = summarize_dataset_collection_process_result(
+                exit_code=0,
+                expected_session_dir=session_dir,
+            )
+            self.assertTrue(real_run.success)
+            self.assertIn("exited cleanly", real_run.message)
 
     def test_capture_face_process_state_text_and_run_button_labels(self) -> None:
         manifest = Path("/tmp/project/shots/manifest.csv")

--- a/tests/test_workflow_status.py
+++ b/tests/test_workflow_status.py
@@ -21,6 +21,11 @@ from posetag.pipelines.capture_face import (
     build_shot_paths,
 )
 from posetag.pipelines.make_board import build_board_yaml, write_board_yaml
+from posetag.pipelines.collect_dataset import (
+    Intrinsics,
+    build_frame_annotation_record,
+    compose_T_cam_object,
+)
 from posetag.workflows.status import WorkflowStatus, inspect_project
 
 
@@ -269,6 +274,171 @@ def _write_face_manifest(project_root: Path, annotation_paths: list[Path]) -> Pa
                 }
             )
     return path
+
+
+def _write_object_tag_pattern(project_root: Path) -> Path:
+    pattern_path = project_root / "boards" / "patterns" / "apriltag_sheet.png"
+    pattern_path.parent.mkdir(parents=True, exist_ok=True)
+    pattern_path.write_bytes(b"synthetic pattern")
+    return pattern_path
+
+
+def _write_collection_ready_project(project_root: Path) -> dict[str, Path]:
+    _write_valid_calibration(project_root / "calib" / "calib_color.yaml")
+    _write_object_tag_pattern(project_root)
+    board_paths, registry_path = _write_two_face_board_and_registry(project_root)
+    _write_face_capture(
+        project_root,
+        board_paths["sideA"],
+        timestamp="20260530_120000",
+    )
+    _write_face_capture(
+        project_root,
+        board_paths["sideB"],
+        timestamp="20260530_120100",
+    )
+    _write_valid_keypoints(project_root, "connection_plate_white")
+    side_a_image = (
+        project_root
+        / "shots"
+        / "connection_plate_white"
+        / "sideA"
+        / "connection_plate_white_sideA_20260530_120000_raw.png"
+    )
+    side_b_image = (
+        project_root
+        / "shots"
+        / "connection_plate_white"
+        / "sideB"
+        / "connection_plate_white_sideB_20260530_120100_raw.png"
+    )
+    annotation_paths = [
+        _write_face_annotation(
+            project_root,
+            object_name="connection_plate_white",
+            side="sideA",
+            board_path=board_paths["sideA"],
+            image_path=side_a_image,
+        ),
+        _write_face_annotation(
+            project_root,
+            object_name="connection_plate_white",
+            side="sideB",
+            board_path=board_paths["sideB"],
+            image_path=side_b_image,
+        ),
+    ]
+    manifest_path = _write_face_manifest(project_root, annotation_paths)
+    return {
+        "manifest": manifest_path,
+        "registry": registry_path,
+        "sideA_board": board_paths["sideA"],
+        "sideB_board": board_paths["sideB"],
+    }
+
+
+def _write_dataset_session(
+    project_root: Path,
+    board_path: Path,
+    *,
+    break_composition: bool = False,
+) -> Path:
+    session_dir = project_root / "datasets" / "run01"
+    for folder in ("images", "annotated", "reproj", "annotations"):
+        (session_dir / folder).mkdir(parents=True, exist_ok=True)
+
+    image_name = "Run_20260607-120000_rgb_frame_000000.png"
+    annotated_name = "Run_20260607-120000_annotated_frame_000000.png"
+    reproj_name = "Run_20260607-120000_reproj_frame_000000.png"
+    (session_dir / "images" / image_name).write_bytes(b"raw")
+    (session_dir / "annotated" / annotated_name).write_bytes(b"annotated")
+    (session_dir / "reproj" / reproj_name).write_bytes(b"reproj")
+
+    intrinsics = Intrinsics(
+        path=project_root / "calib" / "calib_color.yaml",
+        fx=600.0,
+        fy=610.0,
+        cx=320.0,
+        cy=240.0,
+        width=640,
+        height=480,
+        dist=np.zeros((1, 5), dtype=float),
+    )
+    T_cam_board = np.eye(4)
+    T_cam_board[:3, 3] = [0.2, -0.1, 1.5]
+    T_board_object = np.eye(4)
+    T_board_object[:3, 3] = [0.03, 0.02, 0.01]
+    T_cam_object = compose_T_cam_object(T_cam_board, T_board_object)
+    result = {
+        "object": "connection_plate_white",
+        "face_key": "connection_plate_white_sideA",
+        "board_yaml": str(board_path),
+        "tag_used": 52,
+        "num_tags_visible": 2,
+        "score": 2500.0,
+        "score_tags": 2,
+        "score_area_px": 500,
+        "bbox_xywh": [64.0, 48.0, 128.0, 96.0],
+        "bbox_source": "face_kps",
+        "T_cam_board": {"matrix": T_cam_board.tolist()},
+        "T_board_object": {"matrix": T_board_object.tolist()},
+        "T_cam_object": {"matrix": T_cam_object.tolist()},
+        "diagnostics": {
+            "tag_scale_ratio": 1.0,
+            "tag_scale_pairs": 1,
+            "tag_scale_mad": 0.0,
+            "tag_scale_auto_corrected": False,
+        },
+    }
+    record = build_frame_annotation_record(
+        dataset_name="run01",
+        frame_index=0,
+        timestamp=123.456,
+        tag_family="tag36h11",
+        image_filename=image_name,
+        annotated_image=annotated_name,
+        reproj_image=reproj_name,
+        depth=None,
+        intrinsics=intrinsics,
+        results={"connection_plate_white_sideA": result},
+    )
+    if break_composition:
+        record["objects"][0]["transforms"]["T_cam_object"]["matrix"][0][3] += 1.0
+    (session_dir / "annotations" / "Run_20260607-120000_frame_000000.json").write_text(
+        json.dumps(record),
+        encoding="utf-8",
+    )
+    (session_dir / "run01.jsonl").write_text(
+        json.dumps({"idx": 0, "image": image_name, "objects": ["connection_plate_white"]}) + "\n",
+        encoding="utf-8",
+    )
+    (session_dir / "session.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "version": "1.0",
+                "name": "run01",
+                "camera": {
+                    "kind": "opencv_webcam",
+                    "fx": 600.0,
+                    "fy": 610.0,
+                    "cx": 320.0,
+                    "cy": 240.0,
+                    "width": 640,
+                    "height": 480,
+                },
+                "pose_convention": {
+                    "composition": "T_cam_object = T_cam_board @ T_board_object",
+                    "translation_units": "meters",
+                    "quaternion_order": "x, y, z, w",
+                    "rpy_order": "roll, pitch, yaw",
+                    "angle_units": "degrees",
+                },
+                "frames_captured": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return session_dir
 
 
 class WorkflowStatusTests(unittest.TestCase):
@@ -649,6 +819,56 @@ class WorkflowStatusTests(unittest.TestCase):
             self.assertEqual(stage7.status, WorkflowStatus.COMPLETE)
             self.assertIn("valid board-to-object annotations for 2 faces", stage7.message)
             self.assertIn(str(manifest_path), stage7.checked_paths)
+
+    def test_collection_ready_project_marks_stage8_missing_not_not_applicable(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            paths = _write_collection_ready_project(project_root)
+
+            stage8 = _stage_by_id(project_root, 8)
+
+            self.assertEqual(stage8.status, WorkflowStatus.MISSING)
+            self.assertIn("inputs are ready", stage8.message)
+            self.assertIn(str(paths["manifest"].resolve()), stage8.checked_paths)
+            self.assertIn(str(paths["registry"].resolve()), stage8.checked_paths)
+            self.assertIn("posetag-collect --dry-run", stage8.next_action)
+
+    def test_valid_dataset_session_marks_stage8_complete(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            paths = _write_collection_ready_project(project_root)
+            session_dir = _write_dataset_session(project_root, paths["sideA_board"])
+
+            stage8 = _stage_by_id(project_root, 8)
+            stage9 = _stage_by_id(project_root, 9)
+
+            self.assertEqual(stage8.status, WorkflowStatus.COMPLETE)
+            self.assertIn("valid pose-labelled frame", stage8.message)
+            self.assertIn(str((session_dir / "session.yaml").resolve()), stage8.checked_paths)
+            self.assertIn(
+                str((session_dir / "annotations" / "Run_20260607-120000_frame_000000.json").resolve()),
+                stage8.checked_paths,
+            )
+            self.assertEqual(stage9.status, WorkflowStatus.MISSING)
+            self.assertIn("manual review/export", stage9.message)
+
+    def test_dataset_session_with_bad_pose_composition_needs_attention(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            project_root = Path(tmpdir) / "project"
+            paths = _write_collection_ready_project(project_root)
+            _write_dataset_session(
+                project_root,
+                paths["sideA_board"],
+                break_composition=True,
+            )
+
+            stage8 = _stage_by_id(project_root, 8)
+
+            self.assertEqual(stage8.status, WorkflowStatus.NEEDS_ATTENTION)
+            self.assertTrue(
+                any("T_cam_object = T_cam_board @ T_board_object" in error for error in stage8.errors),
+                stage8.errors,
+            )
 
     def test_stale_face_manifest_row_needs_attention(self) -> None:
         with TemporaryDirectory() as tmpdir:

--- a/utils/collect_gt_utils.py
+++ b/utils/collect_gt_utils.py
@@ -1,9 +1,30 @@
-from typing import Dict, List
+from typing import Any, Dict, List, Sequence
 
 import math
 import numpy as np
 import cv2, sys, os
 import time
+
+
+def _rgb(r: int, g: int, b: int) -> tuple[int, int, int]:
+    """Convert RGB literals to OpenCV's BGR order."""
+
+    return (int(b), int(g), int(r))
+
+
+def _normalize_capture_key(raw_key: int | None) -> int:
+    """Normalize an OpenCV waitKey/waitKeyEx result to an ASCII key code."""
+
+    if raw_key is None or int(raw_key) < 0:
+        return -1
+    return int(raw_key) & 0xFF
+
+
+def _capture_key_requests_quit(raw_key: int | None) -> bool:
+    """Return true when a GT Capture key should close the capture loop."""
+
+    key = _normalize_capture_key(raw_key)
+    return key in (27, ord("q"), ord("Q"), ord("x"), ord("X"))
 
 
 def _dominant_color_near_polygon(bgr: np.ndarray, uv: np.ndarray) -> tuple[int,int,int]:
@@ -103,21 +124,348 @@ def _resize_to(img: np.ndarray | None, h: int, w: int) -> np.ndarray:
     interp = cv2.INTER_AREA if (H > h or W > w) else cv2.INTER_LINEAR
     return cv2.resize(img, (w, h), interpolation=interp)
 
-def _label_strip(img: np.ndarray, text: str, bar_h: int = 26, bg=(0, 0, 0), fg=(0, 255, 255)) -> np.ndarray:
+def _label_strip(
+    img: np.ndarray,
+    text: str,
+    bar_h: int = 30,
+    bg=_rgb(20, 28, 36),
+    fg=_rgb(245, 248, 250),
+) -> np.ndarray:
     vis = img.copy()
     cv2.rectangle(vis, (0, 0), (vis.shape[1], bar_h), bg, -1)
-    cv2.putText(vis, text, (8, int(bar_h*0.75)), cv2.FONT_HERSHEY_SIMPLEX, 0.6, fg, 2, cv2.LINE_AA)
+    cv2.rectangle(vis, (0, bar_h - 2), (vis.shape[1], bar_h), _rgb(22, 119, 150), -1)
+    cv2.putText(
+        vis,
+        text,
+        (10, int(bar_h * 0.72)),
+        cv2.FONT_HERSHEY_SIMPLEX,
+        0.55,
+        fg,
+        1,
+        cv2.LINE_AA,
+    )
     return vis
 
 def _text_panel(lines: List[str], width: int = 640, height: int = 480) -> np.ndarray:
-    img = np.zeros((height, width, 3), np.uint8)
+    img = np.full((height, width, 3), _rgb(31, 39, 49), np.uint8)
     img = _label_strip(img, "Status / Legend")
-    y = 40
+    y = 48
     for ln in lines:
-        cv2.putText(img, ln, (10, y), cv2.FONT_HERSHEY_SIMPLEX, 0.52, (0,255,255), 1, cv2.LINE_AA)
-        y += 22
+        cv2.putText(
+            img,
+            ln,
+            (14, y),
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.48,
+            _rgb(224, 232, 240),
+            1,
+            cv2.LINE_AA,
+        )
+        y += 21
         if y > height - 8: break
     return img
+
+
+def _capture_status_panel(
+    *,
+    session: str,
+    faces_visible: int,
+    saved_count: int,
+    object_summaries: Sequence[Dict[str, Any]],
+    paused: bool = False,
+    continuous: bool = False,
+    auto_capture_enabled: bool = False,
+    auto_capture_status: str = "",
+    show_help: bool = True,
+    capture_message: str = "",
+    width: int = 520,
+    height: int = 480,
+) -> np.ndarray:
+    """Render the right-side GT capture status panel."""
+
+    img = np.full((height, width, 3), _rgb(235, 241, 246), np.uint8)
+    _draw_header(
+        img,
+        title="PoseTag GT Capture",
+        subtitle=f"session {session}",
+        state=("PAUSED" if paused else "LIVE"),
+        state_color=_rgb(52, 103, 190) if paused else _rgb(29, 126, 70),
+    )
+
+    y = 78
+    stat_w = (width - 44) // 3
+    for idx, (label, value, accent) in enumerate(
+        (
+            ("visible faces", str(faces_visible), _rgb(22, 119, 150)),
+            ("saved frames", str(saved_count), _rgb(29, 126, 70)),
+            (
+                "capture mode",
+                "smart auto" if auto_capture_enabled else ("continuous" if continuous else "review"),
+                _rgb(132, 94, 16),
+            ),
+        )
+    ):
+        _draw_metric_card(
+            img,
+            x=14 + idx * (stat_w + 8),
+            y=y,
+            w=stat_w,
+            h=62,
+            label=label,
+            value=value,
+            accent=accent,
+        )
+
+    y += 78
+    if capture_message:
+        _draw_message_card(img, 14, y, width - 28, 44, capture_message)
+        y += 58
+    if auto_capture_enabled and auto_capture_status:
+        _draw_auto_capture_card(img, 14, y, width - 28, 50, auto_capture_status)
+        y += 64
+
+    footer_h = 90 if show_help else 42
+    footer_y = height - footer_h - 12
+    _draw_section_title(img, "Selected object poses", 14, y)
+    y += 22
+    if object_summaries:
+        shown = 0
+        for summary in object_summaries[:4]:
+            if y + 82 > footer_y - 10:
+                break
+            y = _draw_object_summary(img, 14, y, width - 28, summary)
+            shown += 1
+            y += 8
+        remaining = len(object_summaries) - shown
+        if remaining > 0 and y < height - 96:
+            _put_text(
+                img,
+                f"+ {remaining} more object{'s' if remaining != 1 else ''}",
+                (22, y + 18),
+                scale=0.45,
+                color=_rgb(76, 88, 100),
+            )
+            y += 28
+    else:
+        _draw_empty_state(
+            img,
+            14,
+            y,
+            width - 28,
+            82,
+            "No registered board face is visible.",
+            "Move a tagged object face into view before saving.",
+        )
+        y += 96
+
+    if y < footer_y - 8:
+        _draw_divider(img, 14, footer_y - 8, width - 28)
+    if show_help:
+        _draw_controls_footer(img, 14, footer_y, width - 28, footer_h)
+    else:
+        _draw_empty_state(
+            img,
+            14,
+            footer_y,
+            width - 28,
+            footer_h,
+            "Controls hidden",
+            "Press h to show keys.",
+        )
+    return img
+
+
+def _draw_header(
+    img: np.ndarray,
+    *,
+    title: str,
+    subtitle: str,
+    state: str,
+    state_color: tuple[int, int, int],
+) -> None:
+    h, w = img.shape[:2]
+    cv2.rectangle(img, (0, 0), (w, 62), _rgb(16, 28, 42), -1)
+    cv2.rectangle(img, (0, 60), (w, 62), _rgb(22, 119, 150), -1)
+    _put_text(img, title, (16, 25), scale=0.62, color=_rgb(248, 251, 253), thickness=2)
+    _put_text(img, subtitle, (17, 49), scale=0.42, color=_rgb(190, 204, 216))
+    pill_w = max(74, 18 + len(state) * 10)
+    x0 = w - pill_w - 14
+    _rounded_rect(img, x0, 16, pill_w, 30, state_color, radius=8)
+    _put_text(
+        img,
+        state,
+        (x0 + 12, 36),
+        scale=0.43,
+        color=_rgb(255, 255, 255),
+        thickness=1,
+    )
+
+
+def _draw_metric_card(
+    img: np.ndarray,
+    *,
+    x: int,
+    y: int,
+    w: int,
+    h: int,
+    label: str,
+    value: str,
+    accent: tuple[int, int, int],
+) -> None:
+    _rounded_rect(img, x, y, w, h, _rgb(250, 252, 253), radius=8)
+    cv2.rectangle(img, (x, y), (x + 4, y + h), accent, -1)
+    _put_text(img, label, (x + 12, y + 20), scale=0.34, color=_rgb(82, 96, 110))
+    value_scale = 0.62 if len(value) <= 8 else 0.45
+    _put_text(img, value, (x + 12, y + 47), scale=value_scale, color=_rgb(26, 39, 52), thickness=2)
+
+
+def _draw_message_card(
+    img: np.ndarray,
+    x: int,
+    y: int,
+    w: int,
+    h: int,
+    message: str,
+) -> None:
+    _rounded_rect(img, x, y, w, h, _rgb(220, 246, 232), radius=8)
+    cv2.rectangle(img, (x, y), (x + 4, y + h), _rgb(29, 126, 70), -1)
+    _put_text(img, message, (x + 14, y + 28), scale=0.46, color=_rgb(20, 94, 55), thickness=1)
+
+
+def _draw_auto_capture_card(
+    img: np.ndarray,
+    x: int,
+    y: int,
+    w: int,
+    h: int,
+    message: str,
+) -> None:
+    _rounded_rect(img, x, y, w, h, _rgb(243, 248, 252), radius=8)
+    cv2.rectangle(img, (x, y), (x + 4, y + h), _rgb(22, 119, 150), -1)
+    _put_text(img, "Smart auto-capture", (x + 14, y + 19), scale=0.36, color=_rgb(72, 86, 100))
+    _put_text(img, message, (x + 14, y + 39), scale=0.42, color=_rgb(20, 52, 70), thickness=1)
+
+
+def _draw_section_title(img: np.ndarray, text: str, x: int, y: int) -> None:
+    _put_text(img, text, (x, y + 16), scale=0.46, color=_rgb(30, 43, 56), thickness=2)
+
+
+def _draw_object_summary(
+    img: np.ndarray,
+    x: int,
+    y: int,
+    w: int,
+    summary: Dict[str, Any],
+) -> int:
+    h = 82
+    _rounded_rect(img, x, y, w, h, _rgb(250, 252, 253), radius=8)
+    object_name = str(summary.get("object", "(unknown object)"))
+    face_key = str(summary.get("face_key", "(unknown face)"))
+    _put_text(img, object_name, (x + 12, y + 21), scale=0.47, color=_rgb(18, 31, 44), thickness=2)
+    _put_text(img, face_key, (x + 12, y + 42), scale=0.38, color=_rgb(91, 105, 119))
+
+    t = summary.get("translation_m", (0.0, 0.0, 0.0))
+    rpy = summary.get("rpy_deg", (0.0, 0.0, 0.0))
+    dist = float(summary.get("distance_m", 0.0))
+    tag_scale = float(summary.get("tag_scale_ratio", 1.0))
+    pairs = int(summary.get("tag_scale_pairs", 0))
+    auto = bool(summary.get("tag_scale_auto_corrected", False))
+    row1 = f"t m [{float(t[0]):+.2f}, {float(t[1]):+.2f}, {float(t[2]):+.2f}]  d={dist:.2f}"
+    row2 = f"rpy [{float(rpy[0]):+.0f}, {float(rpy[1]):+.0f}, {float(rpy[2]):+.0f}] deg"
+    row3 = (
+        f"tag {summary.get('tag_used', '?')}  bbox {summary.get('bbox_source', '?')}  "
+        f"scale {tag_scale:.3f}/{pairs}{' auto' if auto else ''}"
+    )
+    x2 = x + max(210, int(w * 0.44))
+    _put_text(img, row1, (x2, y + 20), scale=0.36, color=_rgb(35, 49, 64))
+    _put_text(img, row2, (x2, y + 41), scale=0.36, color=_rgb(35, 49, 64))
+    _put_text(img, row3, (x2, y + 62), scale=0.34, color=_rgb(83, 96, 109))
+    return y + h
+
+
+def _draw_empty_state(
+    img: np.ndarray,
+    x: int,
+    y: int,
+    w: int,
+    h: int,
+    title: str,
+    detail: str,
+) -> None:
+    _rounded_rect(img, x, y, w, h, _rgb(250, 252, 253), radius=8)
+    _put_text(img, title, (x + 14, y + 26), scale=0.45, color=_rgb(42, 55, 70), thickness=2)
+    _put_text(img, detail, (x + 14, y + 52), scale=0.38, color=_rgb(92, 106, 120))
+
+
+def _draw_controls_footer(img: np.ndarray, x: int, y: int, w: int, h: int) -> None:
+    _rounded_rect(img, x, y, w, h, _rgb(16, 28, 42), radius=8)
+    _put_text(img, "Controls", (x + 14, y + 22), scale=0.43, color=_rgb(242, 246, 249), thickness=2)
+    controls = (
+        "ENTER / y / s  save / force",
+        "r / n / backspace  reject",
+        "space / p  pause",
+        "h  hide controls",
+        "ESC / q / Q  close",
+        "x / X  close",
+    )
+    col_w = (w - 28) // 2
+    for idx, text in enumerate(controls):
+        col = idx % 2
+        row = idx // 2
+        _put_text(
+            img,
+            text,
+            (x + 14 + col * col_w, y + 46 + row * 17),
+            scale=0.36,
+            color=_rgb(200, 214, 226),
+        )
+
+
+def _draw_divider(img: np.ndarray, x: int, y: int, w: int) -> None:
+    cv2.line(img, (x, y), (x + w, y), _rgb(205, 216, 226), 1, cv2.LINE_AA)
+
+
+def _put_text(
+    img: np.ndarray,
+    text: str,
+    org: tuple[int, int],
+    *,
+    scale: float = 0.45,
+    color: tuple[int, int, int] = (0, 0, 0),
+    thickness: int = 1,
+) -> None:
+    cv2.putText(
+        img,
+        str(text),
+        org,
+        cv2.FONT_HERSHEY_SIMPLEX,
+        scale,
+        color,
+        thickness,
+        cv2.LINE_AA,
+    )
+
+
+def _rounded_rect(
+    img: np.ndarray,
+    x: int,
+    y: int,
+    w: int,
+    h: int,
+    color: tuple[int, int, int],
+    *,
+    radius: int = 8,
+) -> None:
+    radius = max(1, min(radius, w // 2, h // 2))
+    cv2.rectangle(img, (x + radius, y), (x + w - radius, y + h), color, -1)
+    cv2.rectangle(img, (x, y + radius), (x + w, y + h - radius), color, -1)
+    for cx, cy in (
+        (x + radius, y + radius),
+        (x + w - radius, y + radius),
+        (x + radius, y + h - radius),
+        (x + w - radius, y + h - radius),
+    ):
+        cv2.circle(img, (cx, cy), radius, color, -1, cv2.LINE_AA)
 
 def _hstack(left: np.ndarray, mid: np.ndarray | None, right: np.ndarray | None) -> np.ndarray:
     H = max(left.shape[0], 0 if mid is None else mid.shape[0], 0 if right is None else right.shape[0])
@@ -126,13 +474,34 @@ def _hstack(left: np.ndarray, mid: np.ndarray | None, right: np.ndarray | None) 
     Wr = right.shape[1] if right is not None else 380
     return np.hstack([_pad_to(left, H, Wl), _pad_to(mid, H, Wm), _pad_to(right, H, Wr)])
 
-def _show_dash(left: np.ndarray | None, mid: np.ndarray | None, right: np.ndarray | None,
-               win: str = "GT Capture", tile_h: int = 480, tile_w: int = 640):
+def _dashboard_strip(
+    left: np.ndarray | None,
+    mid: np.ndarray | None,
+    right: np.ndarray | None,
+    *,
+    tile_h: int = 480,
+    tile_w: int = 560,
+    right_w: int = 520,
+) -> np.ndarray:
     L = _resize_to(left, tile_h, tile_w)
     M = _resize_to(mid,  tile_h, tile_w)
-    R = _resize_to(right, tile_h, tile_w)
-    L = _label_strip(L, "Annotation")
-    M = _label_strip(M, "Reprojection / Tag debug")
-    strip = np.hstack([L, M, R])
-    cv2.imshow(win, strip)
+    R = _resize_to(right, tile_h, right_w)
+    L = _label_strip(L, "Annotation review")
+    M = _label_strip(M, "Reprojection / tag debug")
+    gutter = np.full((tile_h, 10, 3), _rgb(224, 232, 238), np.uint8)
+    return np.hstack([L, gutter, M, gutter, R])
 
+
+def _show_dash(left: np.ndarray | None, mid: np.ndarray | None, right: np.ndarray | None,
+               win: str = "GT Capture", tile_h: int = 480, tile_w: int = 560,
+               right_w: int = 520):
+    strip = _dashboard_strip(
+        left,
+        mid,
+        right,
+        tile_h=tile_h,
+        tile_w=tile_w,
+        right_w=right_w,
+    )
+    cv2.imshow(win, strip)
+    return strip


### PR DESCRIPTION
Closes #39.

## Summary

This validates and hardens the dataset collection workflow around `posetag-collect` after calibration, board definitions, face shots, mesh keypoints, and annotation are complete.

- Adds package-first collection helpers for input preflight, source validation, path resolution, session metadata, pose-label serialization, and transform composition checks.
- Preserves the runtime pose contract: `T_cam_object = T_cam_board @ T_board_object`.
- Documents and tests the per-frame pose schema, transform fields, units, quaternion ordering, RPY ordering, timestamps/frame indices, and quality fields.
- Hardens missing/malformed input failures for calibration, tag registry, board YAMLs, face manifest, annotation YAMLs / `T_board_object`, invalid source args, videos, bags, and missing RealSense dependency.
- Adds `--mode opencv`, `--dry-run`, project-relative input resolution, and a clearer runtime GT Capture status/review panel with clean quit handling.
- Adds quality-gated `--auto-capture` with pose stability, cooldown, tag/bbox quality, coverage, distance-bin, and pose-diversity gates while keeping manual force-save and legacy `--continuous` mode.
- Wires GUI Stage 8 readiness, dry-run, process launch, logs, and smart auto-capture controls over the existing `posetag-collect` process.
- Updates README, adds `docs/workflows/step6_collect_dataset.md`, and adds `STEP6_COLLECT_DATASET_REPORT.md`.

## Validation

- `python3 -m unittest tests.test_step6_collect_dataset -v` -> 16 tests OK
- `python3 -m unittest tests.test_workflow_gui tests.test_workflow_status tests.test_step6_collect_dataset -v` -> 90 tests OK
- `python3 -m unittest discover -s tests -v` -> 307 tests OK
- `python3 -m compileall -q src utils tests` -> OK
- `git diff --check` -> OK
- `python3 -m posetag.cli.collect --help` -> OK
- `/Users/samueladebayo/Library/Python/3.11/bin/posetag-collect --help` -> OK
- `python3 -m posetag.cli.collect --project_root my_project --mode opencv --session run01 --dry-run --auto-capture` -> OK
- `python3 -m posetag.cli.collect --project_root my_project --mode opencv --session run01 --dry-run --auto-capture --continuous` -> expected clear failure: `--continuous and --auto-capture are mutually exclusive.`

## Residual Risk / Technical Debt

- The interactive collection loop still mostly lives in `src/collect_gt_dataset.py`; this PR extracts testable helpers but does not do a broad architecture migration.
- Smart auto-capture thresholds are conservative defaults validated with hardware-free policy tests; real-camera sessions should tune stability, cooldown, coverage, and pose-diversity thresholds.
- Optional object keypoints still improve bbox/review quality; missing keypoints fall back to tag-derived boxes.

## Manual Hardware Checks Still Needed

- Run OpenCV webcam collection at the calibration resolution.
- Run RealSense live collection with optional depth.
- Run RealSense `.bag` playback.
- Run video mode on a representative experiment clip.
- Confirm smart auto-capture saves stable, diverse views without flooding near-duplicates.
- Review saved annotated/reprojection panels for plausible selected faces, axes, and bounding boxes.
